### PR TITLE
feat: add diff/patch, batch edit, and usage tracking tools

### DIFF
--- a/docs/articles/tools-reference.md
+++ b/docs/articles/tools-reference.md
@@ -305,14 +305,60 @@ Cross-platform support: uses PowerShell/clip on Windows, pbcopy/pbpaste on macOS
 ⚡ Tool: ask_questions(questionsJson: "{\"title\":\"Project Setup\",\"questions\":[{\"key\":\"name\",\"prompt\":\"Project name?\",\"type\":\"text\",\"required\":true}]}")
 ```
 
+## Diff and patch tools
+
+Create and apply structured text patches across files. The `create_patch` tool generates unified diff output for review, while `apply_patch` performs atomic multi-file text replacements — if any edit fails validation, no files are modified.
+
+### Functions
+
+- **`create_patch`** — `editsJson` (string, JSON array of `{path, oldText, newText}`). Returns a unified diff showing proposed changes without modifying files.
+- **`apply_patch`** — `editsJson` (string, JSON array of `{path, oldText, newText}`). Validates all edits first, then applies atomically. Returns an error if any `oldText` is not found (no files are modified).
+
+### Example
+
+```text
+⚡ Tool: create_patch(editsJson: "[{\"path\":\"src/Config.cs\",\"oldText\":\"Timeout = 30\",\"newText\":\"Timeout = 60\"}]")
+→ --- a/src/Config.cs
+  +++ b/src/Config.cs
+  @@ -12,1 +12,1 @@
+  -Timeout = 30
+  +Timeout = 60
+```
+
+## Batch edit tools
+
+Apply multiple text replacements across one or more files in a single atomic operation. All edits are validated before any files are written — if any `oldText` is not found, no files are modified. Multiple edits to the same file are applied sequentially in order.
+
+### Functions
+
+- **`batch_edit_files`** — `editsJson` (string, JSON array of `{path, oldText, newText}`). Groups edits by file, validates all, then writes atomically.
+
+### Example
+
+```text
+⚡ Tool: batch_edit_files(editsJson: "[{\"path\":\"src/App.cs\",\"oldText\":\"v1\",\"newText\":\"v2\"},{\"path\":\"src/Config.cs\",\"oldText\":\"old\",\"newText\":\"new\"}]")
+→ Applied 2 edit(s) across 2 file(s):
+    src/App.cs: 1 edit(s)
+    src/Config.cs: 1 edit(s)
+```
+
+## Usage tracking tools
+
+Track token usage and estimated costs for the current session. The agent loop can record usage after each turn, and the `get_usage` tool provides a summary with cost estimates across common model pricing tiers.
+
+### Functions
+
+- **`get_usage`** — No parameters. Returns session token counts (prompt, completion, total), tool call count, turn count, and estimated costs for several model pricing tiers.
+- **`reset_usage`** — No parameters. Resets all session usage counters to zero.
+
 ## Tool safety tiers
 
 Every tool belongs to a safety tier that controls how confirmation is handled:
 
 | Tier | Behavior | Tools |
 |------|----------|-------|
-| **Auto-approve** | Runs without confirmation | `read_file`, `grep`, `glob`, `list_directory`, `git_status`, `git_diff`, `git_log`, `git_branch`, `memory_search`, `web_fetch`, `ask_questions`, `think`, `get_environment`, `list_tasks`, `export_tasks`, `read_clipboard` |
-| **Confirm once** | Asks once per session | `write_file`, `edit_file`, `git_commit`, `git_push`, `git_pull`, `git_checkout`, `git_stash`, `memory_store`, `memory_forget`, `create_task`, `update_task`, `complete_task`, `write_clipboard`, `spawn_agent`, `spawn_team` |
+| **Auto-approve** | Runs without confirmation | `read_file`, `grep`, `glob`, `list_directory`, `git_status`, `git_diff`, `git_log`, `git_branch`, `memory_search`, `web_fetch`, `ask_questions`, `think`, `get_environment`, `list_tasks`, `export_tasks`, `read_clipboard`, `get_usage`, `create_patch` |
+| **Confirm once** | Asks once per session | `write_file`, `edit_file`, `git_commit`, `git_push`, `git_pull`, `git_checkout`, `git_stash`, `memory_store`, `memory_forget`, `create_task`, `update_task`, `complete_task`, `write_clipboard`, `spawn_agent`, `spawn_team`, `apply_patch`, `batch_edit_files`, `reset_usage` |
 | **Always confirm** | Asks every invocation | `run_command`, `web_search`, `execute_code` |
 
 ## Controlling tool permissions

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ JD.AI auto-detects available providers. No manual configuration needed.
 |---------|-------------|
 | **Multi-provider** | [Claude Code, GitHub Copilot, Ollama, OpenAI Codex, Local Models](articles/providers.md) — auto-detected on startup |
 | **25+ slash commands** | [Model switching, sessions, context management](articles/commands-reference.md) |
-| **13 tool categories** | [Files, search, shell, git, web, memory, subagents, think, environment, tasks, code execution, clipboard, questions](articles/tools-reference.md) |
+| **16 tool categories** | [Files, search, shell, git, web, memory, subagents, think, environment, tasks, code execution, clipboard, questions, diff/patch, batch edit, usage tracking](articles/tools-reference.md) |
 | **5 subagent types** | [Explore, task, plan, review, general-purpose](articles/subagents.md) |
 | **Team orchestration** | [Sequential, fan-out, supervisor, debate](articles/orchestration.md) strategies |
 | **Session persistence** | [Save, load, export conversations](articles/persistence.md) across sessions |

--- a/src/JD.AI.Core/Tools/BatchEditTools.cs
+++ b/src/JD.AI.Core/Tools/BatchEditTools.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Text;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// Tool for applying multiple edits to one or more files in a single atomic operation.
+/// If any edit fails validation, no files are modified.
+/// </summary>
+public sealed class BatchEditTools
+{
+    [KernelFunction("batch_edit_files")]
+    [Description(
+        "Apply multiple text replacements across one or more files atomically. " +
+        "All edits are validated first — if any oldText is not found, no files are modified. " +
+        "Use this instead of multiple edit_file calls when you need to make coordinated changes.")]
+    public static string BatchEditFiles(
+        [Description(
+            "JSON array of edits: [{\"path\":\"file.cs\",\"oldText\":\"before\",\"newText\":\"after\"}]. " +
+            "Multiple edits to the same file are applied sequentially in order.")]
+        string editsJson)
+    {
+        var edits = System.Text.Json.JsonSerializer.Deserialize<EditEntry[]>(editsJson, JsonOptions);
+        if (edits is null || edits.Length == 0)
+        {
+            return "No edits provided.";
+        }
+
+        // Group edits by file path (preserve order within each file)
+        var byFile = new Dictionary<string, List<EditEntry>>(StringComparer.Ordinal);
+        foreach (var edit in edits)
+        {
+            if (string.IsNullOrEmpty(edit.Path))
+            {
+                return "Error: edit missing 'path' field.";
+            }
+
+            if (!File.Exists(edit.Path))
+            {
+                return $"Error: file not found — {edit.Path}";
+            }
+
+            if (!byFile.TryGetValue(edit.Path, out var list))
+            {
+                list = [];
+                byFile[edit.Path] = list;
+            }
+
+            list.Add(edit);
+        }
+
+        // Phase 1: Validate — apply edits in memory and check all oldTexts are found
+        var results = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (path, fileEdits) in byFile)
+        {
+            var content = File.ReadAllText(path);
+            foreach (var edit in fileEdits)
+            {
+                if (edit.OldText is null)
+                {
+                    return $"Error: edit for {path} missing 'oldText'.";
+                }
+
+                if (!content.Contains(edit.OldText, StringComparison.Ordinal))
+                {
+                    // Provide context about what was expected
+                    var preview = edit.OldText.Length > 60
+                        ? string.Concat(edit.OldText.AsSpan(0, 57), "...")
+                        : edit.OldText;
+                    return $"Error: old text not found in {path}: \"{preview}\". No files modified.";
+                }
+
+                content = content.Replace(edit.OldText, edit.NewText ?? "", StringComparison.Ordinal);
+            }
+
+            results[path] = content;
+        }
+
+        // Phase 2: Write all files
+        foreach (var (path, content) in results)
+        {
+            File.WriteAllText(path, content);
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Applied {edits.Length} edit(s) across {results.Count} file(s):");
+        foreach (var (path, fileEdits) in byFile)
+        {
+            sb.AppendLine($"  {path}: {fileEdits.Count} edit(s)");
+        }
+
+        return sb.ToString();
+    }
+
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed class EditEntry
+    {
+        public string? Path { get; set; }
+        public string? OldText { get; set; }
+        public string? NewText { get; set; }
+    }
+}

--- a/src/JD.AI.Core/Tools/DiffTools.cs
+++ b/src/JD.AI.Core/Tools/DiffTools.cs
@@ -1,0 +1,181 @@
+using System.ComponentModel;
+using System.Text;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// Tools for creating and applying unified diff patches.
+/// Enables structured multi-location file edits via standard patch format.
+/// </summary>
+public sealed class DiffTools
+{
+    [KernelFunction("create_patch")]
+    [Description(
+        "Create a unified diff patch from a list of file edits. Each edit specifies " +
+        "a file path, the old text to find, and the new text to replace it with. " +
+        "Returns a unified diff string that can be reviewed or applied with apply_patch.")]
+    public static string CreatePatch(
+        [Description("JSON array of edits: [{\"path\":\"file.cs\",\"oldText\":\"before\",\"newText\":\"after\"}]")]
+        string editsJson)
+    {
+        var edits = System.Text.Json.JsonSerializer.Deserialize<PatchEdit[]>(editsJson, JsonOptions);
+        if (edits is null || edits.Length == 0)
+        {
+            return "No edits provided.";
+        }
+
+        var sb = new StringBuilder();
+        foreach (var edit in edits)
+        {
+            if (string.IsNullOrEmpty(edit.Path))
+            {
+                sb.AppendLine("# Skipped edit: missing path");
+                continue;
+            }
+
+            if (!File.Exists(edit.Path))
+            {
+                sb.AppendLine($"# Skipped edit: file not found — {edit.Path}");
+                continue;
+            }
+
+            var original = File.ReadAllText(edit.Path);
+            var modified = original.Replace(edit.OldText ?? "", edit.NewText ?? "");
+
+            if (string.Equals(original, modified, StringComparison.Ordinal))
+            {
+                sb.AppendLine($"# No changes for {edit.Path} (old text not found)");
+                continue;
+            }
+
+            sb.AppendLine($"--- a/{edit.Path}");
+            sb.AppendLine($"+++ b/{edit.Path}");
+            AppendUnifiedDiff(sb, original, modified);
+        }
+
+        var result = sb.ToString();
+        return string.IsNullOrWhiteSpace(result) ? "No changes generated." : result;
+    }
+
+    [KernelFunction("apply_patch")]
+    [Description(
+        "Apply a set of text replacements to files. Each edit specifies a file path, " +
+        "old text to find, and new text to replace it with. All edits are applied atomically — " +
+        "if any edit fails to find its old text, no files are modified.")]
+    public static string ApplyPatch(
+        [Description("JSON array of edits: [{\"path\":\"file.cs\",\"oldText\":\"before\",\"newText\":\"after\"}]")]
+        string editsJson)
+    {
+        var edits = System.Text.Json.JsonSerializer.Deserialize<PatchEdit[]>(editsJson, JsonOptions);
+        if (edits is null || edits.Length == 0)
+        {
+            return "No edits provided.";
+        }
+
+        // Phase 1: Validate all edits before modifying anything
+        var pending = new List<(string Path, string Original, string Modified)>();
+        foreach (var edit in edits)
+        {
+            if (string.IsNullOrEmpty(edit.Path))
+            {
+                return "Error: edit missing 'path' field.";
+            }
+
+            if (!File.Exists(edit.Path))
+            {
+                return $"Error: file not found — {edit.Path}";
+            }
+
+            var content = File.ReadAllText(edit.Path);
+            if (edit.OldText is not null && !content.Contains(edit.OldText, StringComparison.Ordinal))
+            {
+                return $"Error: old text not found in {edit.Path}. Patch aborted (no files modified).";
+            }
+
+            var modified = edit.OldText is not null
+                ? content.Replace(edit.OldText, edit.NewText ?? "", StringComparison.Ordinal)
+                : content + (edit.NewText ?? "");
+
+            pending.Add((edit.Path, content, modified));
+        }
+
+        // Phase 2: Apply all edits
+        var applied = 0;
+        foreach (var (path, _, modified) in pending)
+        {
+            File.WriteAllText(path, modified);
+            applied++;
+        }
+
+        return $"Applied {applied} edit(s) across {pending.Select(p => p.Path).Distinct(StringComparer.Ordinal).Count()} file(s).";
+    }
+
+    private static void AppendUnifiedDiff(StringBuilder sb, string original, string modified)
+    {
+        var oldLines = original.Split('\n');
+        var newLines = modified.Split('\n');
+
+        // Simple context diff — show changed lines with 3 lines of context
+        var oldIdx = 0;
+        var newIdx = 0;
+        while (oldIdx < oldLines.Length || newIdx < newLines.Length)
+        {
+            if (oldIdx < oldLines.Length && newIdx < newLines.Length && string.Equals(oldLines[oldIdx], newLines[newIdx], StringComparison.Ordinal))
+            {
+                oldIdx++;
+                newIdx++;
+                continue;
+            }
+
+            // Found a difference — emit hunk
+            var hunkStart = Math.Max(0, oldIdx - 3);
+            sb.AppendLine($"@@ -{hunkStart + 1},{Math.Min(oldLines.Length, oldIdx + 4) - hunkStart} +{hunkStart + 1},{Math.Min(newLines.Length, newIdx + 4) - hunkStart} @@");
+
+            // Context before
+            for (var i = hunkStart; i < oldIdx; i++)
+            {
+                sb.AppendLine($" {oldLines[i]}");
+            }
+
+            // Changed lines
+            while (oldIdx < oldLines.Length && (newIdx >= newLines.Length || !string.Equals(oldLines[oldIdx], newLines[newIdx], StringComparison.Ordinal)))
+            {
+                sb.AppendLine($"-{oldLines[oldIdx]}");
+                oldIdx++;
+            }
+
+            while (newIdx < newLines.Length && (oldIdx >= oldLines.Length || !string.Equals(oldLines[oldIdx], newLines[newIdx], StringComparison.Ordinal)))
+            {
+                sb.AppendLine($"+{newLines[newIdx]}");
+                newIdx++;
+            }
+
+            // Context after
+            var contextEnd = Math.Min(oldLines.Length, oldIdx + 3);
+            for (var i = oldIdx; i < contextEnd; i++)
+            {
+                if (i < oldLines.Length)
+                {
+                    sb.AppendLine($" {oldLines[i]}");
+                }
+            }
+
+            oldIdx = contextEnd;
+            newIdx = Math.Min(newLines.Length, newIdx + 3);
+        }
+    }
+
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed class PatchEdit
+    {
+        public string? Path { get; set; }
+        public string? OldText { get; set; }
+        public string? NewText { get; set; }
+    }
+}

--- a/src/JD.AI.Core/Tools/UsageTools.cs
+++ b/src/JD.AI.Core/Tools/UsageTools.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel;
+using System.Text;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// Tools for tracking token usage and costs across the session.
+/// </summary>
+public sealed class UsageTools
+{
+    private long _promptTokens;
+    private long _completionTokens;
+    private int _toolCalls;
+    private int _turns;
+
+    /// <summary>
+    /// Records token usage for a turn. Called by the agent loop after each response.
+    /// </summary>
+    public void RecordUsage(long promptTokens, long completionTokens, int toolCalls)
+    {
+        Interlocked.Add(ref _promptTokens, promptTokens);
+        Interlocked.Add(ref _completionTokens, completionTokens);
+        Interlocked.Add(ref _toolCalls, toolCalls);
+        Interlocked.Increment(ref _turns);
+    }
+
+    [KernelFunction("get_usage")]
+    [Description(
+        "Get token usage and cost statistics for the current session. " +
+        "Shows prompt tokens, completion tokens, total tokens, tool calls, " +
+        "and estimated cost based on common model pricing.")]
+    public string GetUsage()
+    {
+        var prompt = Interlocked.Read(ref _promptTokens);
+        var completion = Interlocked.Read(ref _completionTokens);
+        var total = prompt + completion;
+        var tools = _toolCalls;
+        var turns = _turns;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("=== Session Usage ===");
+        sb.AppendLine($"Turns: {turns}");
+        sb.AppendLine($"Prompt tokens: {prompt:N0}");
+        sb.AppendLine($"Completion tokens: {completion:N0}");
+        sb.AppendLine($"Total tokens: {total:N0}");
+        sb.AppendLine($"Tool calls: {tools}");
+        sb.AppendLine();
+        sb.AppendLine("=== Estimated Cost ===");
+
+        // Common pricing tiers (approximate, may be outdated)
+        var costs = new (string Model, decimal PromptPer1K, decimal CompletionPer1K)[]
+        {
+            ("Claude Sonnet 4", 0.003m, 0.015m),
+            ("Claude Haiku 4", 0.0008m, 0.004m),
+            ("GPT-4.1", 0.002m, 0.008m),
+            ("GPT-5-mini", 0.00015m, 0.0006m),
+            ("Local (Ollama/LLamaSharp)", 0m, 0m),
+        };
+
+        foreach (var (model, promptRate, completionRate) in costs)
+        {
+            var cost = (prompt / 1000m * promptRate) + (completion / 1000m * completionRate);
+            sb.AppendLine($"  {model}: ${cost:F4}");
+        }
+
+        return sb.ToString();
+    }
+
+    [KernelFunction("reset_usage")]
+    [Description("Reset session usage counters to zero.")]
+    public string ResetUsage()
+    {
+        Interlocked.Exchange(ref _promptTokens, 0);
+        Interlocked.Exchange(ref _completionTokens, 0);
+        Interlocked.Exchange(ref _toolCalls, 0);
+        Interlocked.Exchange(ref _turns, 0);
+        return "Usage counters reset.";
+    }
+}

--- a/src/JD.AI/Agent/ToolConfirmationFilter.cs
+++ b/src/JD.AI/Agent/ToolConfirmationFilter.cs
@@ -34,6 +34,8 @@ public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
             ["list_tasks"] = SafetyTier.AutoApprove,
             ["export_tasks"] = SafetyTier.AutoApprove,
             ["read_clipboard"] = SafetyTier.AutoApprove,
+            ["get_usage"] = SafetyTier.AutoApprove,
+            ["create_patch"] = SafetyTier.AutoApprove,
 
             // Write ops — confirm once per session
             ["write_file"] = SafetyTier.ConfirmOnce,
@@ -51,6 +53,9 @@ public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
             ["write_clipboard"] = SafetyTier.ConfirmOnce,
             ["spawn_agent"] = SafetyTier.ConfirmOnce,
             ["spawn_team"] = SafetyTier.ConfirmOnce,
+            ["apply_patch"] = SafetyTier.ConfirmOnce,
+            ["batch_edit_files"] = SafetyTier.ConfirmOnce,
+            ["reset_usage"] = SafetyTier.ConfirmOnce,
 
             // Dangerous — always confirm
             ["run_command"] = SafetyTier.AlwaysConfirm,

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -188,8 +188,12 @@ kernel.Plugins.AddFromType<ThinkTools>("think");
 kernel.Plugins.AddFromType<EnvironmentTools>("environment");
 kernel.Plugins.AddFromType<NotebookTools>("notebook");
 kernel.Plugins.AddFromType<ClipboardTools>("clipboard");
+kernel.Plugins.AddFromType<DiffTools>("diff");
+kernel.Plugins.AddFromType<BatchEditTools>("batchEdit");
 kernel.Plugins.AddFromObject(new MemoryTools(), "memory");
 kernel.Plugins.AddFromObject(new TaskTools(), "tasks");
+var usageTools = new UsageTools();
+kernel.Plugins.AddFromObject(usageTools, "usage");
 kernel.Plugins.AddFromObject(
     new QuestionTools(req => QuestionnaireSession.Run(req)), "questions");
 

--- a/tests/JD.AI.Tests/BatchEditToolsTests.cs
+++ b/tests/JD.AI.Tests/BatchEditToolsTests.cs
@@ -1,0 +1,112 @@
+using JD.AI.Core.Tools;
+
+namespace JD.AI.Tests;
+
+public sealed class BatchEditToolsTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public BatchEditToolsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-batch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    private static string EscapePath(string path) => path.Replace("\\", "\\\\");
+
+    [Fact]
+    public void BatchEdit_SingleFile_AppliesEdit()
+    {
+        var file = Path.Combine(_tempDir, "single.cs");
+        File.WriteAllText(file, "var x = 1;\nvar y = 2;\n");
+        var escaped = EscapePath(file);
+
+        var json = "[{\"path\":\"" + escaped + "\",\"oldText\":\"var x = 1;\",\"newText\":\"var x = 42;\"}]";
+
+        var result = BatchEditTools.BatchEditFiles(json);
+
+        Assert.Contains("Applied 1 edit(s)", result);
+        Assert.Contains("var x = 42;", File.ReadAllText(file));
+    }
+
+    [Fact]
+    public void BatchEdit_MultipleEditsInSameFile_AppliesSequentially()
+    {
+        var file = Path.Combine(_tempDir, "multi.cs");
+        File.WriteAllText(file, "class Foo\n{\n    int a;\n    int b;\n}\n");
+        var escaped = EscapePath(file);
+
+        var json = "[{\"path\":\"" + escaped + "\",\"oldText\":\"int a;\",\"newText\":\"int alpha;\"},"
+                 + "{\"path\":\"" + escaped + "\",\"oldText\":\"int b;\",\"newText\":\"int beta;\"}]";
+
+        var result = BatchEditTools.BatchEditFiles(json);
+
+        Assert.Contains("2 edit(s)", result);
+        var content = File.ReadAllText(file);
+        Assert.Contains("int alpha;", content);
+        Assert.Contains("int beta;", content);
+    }
+
+    [Fact]
+    public void BatchEdit_AcrossMultipleFiles_AppliesAll()
+    {
+        var file1 = Path.Combine(_tempDir, "f1.cs");
+        var file2 = Path.Combine(_tempDir, "f2.cs");
+        File.WriteAllText(file1, "aaa");
+        File.WriteAllText(file2, "bbb");
+
+        var json = "[{\"path\":\"" + EscapePath(file1) + "\",\"oldText\":\"aaa\",\"newText\":\"AAA\"},"
+                 + "{\"path\":\"" + EscapePath(file2) + "\",\"oldText\":\"bbb\",\"newText\":\"BBB\"}]";
+
+        var result = BatchEditTools.BatchEditFiles(json);
+
+        Assert.Contains("2 file(s)", result);
+        Assert.Equal("AAA", File.ReadAllText(file1));
+        Assert.Equal("BBB", File.ReadAllText(file2));
+    }
+
+    [Fact]
+    public void BatchEdit_OldTextNotFound_AbortsAll()
+    {
+        var file1 = Path.Combine(_tempDir, "ok.cs");
+        var file2 = Path.Combine(_tempDir, "bad.cs");
+        File.WriteAllText(file1, "good content");
+        File.WriteAllText(file2, "other content");
+
+        var json = "[{\"path\":\"" + EscapePath(file1) + "\",\"oldText\":\"good content\",\"newText\":\"modified\"},"
+                 + "{\"path\":\"" + EscapePath(file2) + "\",\"oldText\":\"MISSING\",\"newText\":\"replaced\"}]";
+
+        var result = BatchEditTools.BatchEditFiles(json);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("not found", result);
+        Assert.Equal("good content", File.ReadAllText(file1));
+        Assert.Equal("other content", File.ReadAllText(file2));
+    }
+
+    [Fact]
+    public void BatchEdit_EmptyEdits_ReturnsMessage()
+    {
+        var result = BatchEditTools.BatchEditFiles("[]");
+
+        Assert.Equal("No edits provided.", result);
+    }
+
+    [Fact]
+    public void BatchEdit_MissingFile_ReturnsError()
+    {
+        var json = "[{\"path\":\"nonexistent.cs\",\"oldText\":\"x\",\"newText\":\"y\"}]";
+
+        var result = BatchEditTools.BatchEditFiles(json);
+
+        Assert.Contains("file not found", result);
+    }
+}

--- a/tests/JD.AI.Tests/DiffToolsTests.cs
+++ b/tests/JD.AI.Tests/DiffToolsTests.cs
@@ -1,0 +1,105 @@
+using JD.AI.Core.Tools;
+
+namespace JD.AI.Tests;
+
+public sealed class DiffToolsTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DiffToolsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-diff-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+
+    private static string EscapePath(string path) => path.Replace("\\", "\\\\");
+
+    [Fact]
+    public void CreatePatch_WithValidEdits_ReturnsDiff()
+    {
+        var file = Path.Combine(_tempDir, "test.cs");
+        File.WriteAllText(file, "int x = 1;\nint y = 2;\n");
+
+        var json = "[{\"path\":\"" + EscapePath(file) + "\",\"oldText\":\"int x = 1;\",\"newText\":\"int x = 42;\"}]";
+
+        var result = DiffTools.CreatePatch(json);
+
+        Assert.Contains("---", result);
+        Assert.Contains("+++", result);
+        Assert.Contains("-int x = 1;", result);
+        Assert.Contains("+int x = 42;", result);
+    }
+
+    [Fact]
+    public void CreatePatch_MissingFile_ReportsSkipped()
+    {
+        var json = "[{\"path\":\"nonexistent.cs\",\"oldText\":\"x\",\"newText\":\"y\"}]";
+
+        var result = DiffTools.CreatePatch(json);
+
+        Assert.Contains("file not found", result);
+    }
+
+    [Fact]
+    public void CreatePatch_NoEdits_ReturnsMessage()
+    {
+        var result = DiffTools.CreatePatch("[]");
+
+        Assert.Equal("No edits provided.", result);
+    }
+
+    [Fact]
+    public void ApplyPatch_WithValidEdits_ModifiesFiles()
+    {
+        var file = Path.Combine(_tempDir, "apply.cs");
+        File.WriteAllText(file, "var name = \"old\";\n");
+
+        var json = "[{\"path\":\"" + EscapePath(file) + "\",\"oldText\":\"\\\"old\\\"\",\"newText\":\"\\\"new\\\"\"}]";
+
+        var result = DiffTools.ApplyPatch(json);
+
+        Assert.Contains("Applied 1 edit(s)", result);
+        Assert.Contains("\"new\"", File.ReadAllText(file));
+    }
+
+    [Fact]
+    public void ApplyPatch_OldTextNotFound_AbortsAll()
+    {
+        var file = Path.Combine(_tempDir, "abort.cs");
+        File.WriteAllText(file, "original content\n");
+
+        var json = "[{\"path\":\"" + EscapePath(file) + "\",\"oldText\":\"missing text\",\"newText\":\"replacement\"}]";
+
+        var result = DiffTools.ApplyPatch(json);
+
+        Assert.Contains("Error", result);
+        Assert.Contains("not found", result);
+        Assert.Equal("original content\n", File.ReadAllText(file));
+    }
+
+    [Fact]
+    public void ApplyPatch_MultipleEdits_AllApplied()
+    {
+        var file1 = Path.Combine(_tempDir, "multi1.cs");
+        var file2 = Path.Combine(_tempDir, "multi2.cs");
+        File.WriteAllText(file1, "aaa");
+        File.WriteAllText(file2, "bbb");
+
+        var json = "[{\"path\":\"" + EscapePath(file1) + "\",\"oldText\":\"aaa\",\"newText\":\"AAA\"},"
+                 + "{\"path\":\"" + EscapePath(file2) + "\",\"oldText\":\"bbb\",\"newText\":\"BBB\"}]";
+
+        var result = DiffTools.ApplyPatch(json);
+
+        Assert.Contains("2 edit(s)", result);
+        Assert.Equal("AAA", File.ReadAllText(file1));
+        Assert.Equal("BBB", File.ReadAllText(file2));
+    }
+}

--- a/tests/JD.AI.Tests/UsageToolsTests.cs
+++ b/tests/JD.AI.Tests/UsageToolsTests.cs
@@ -1,0 +1,62 @@
+using JD.AI.Core.Tools;
+
+namespace JD.AI.Tests;
+
+public sealed class UsageToolsTests
+{
+    [Fact]
+    public void GetUsage_WithNoRecords_ShowsZeros()
+    {
+        var tools = new UsageTools();
+
+        var result = tools.GetUsage();
+
+        Assert.Contains("Turns: 0", result);
+        Assert.Contains("Prompt tokens: 0", result);
+        Assert.Contains("Total tokens: 0", result);
+    }
+
+    [Fact]
+    public void GetUsage_AfterRecording_ShowsAccumulated()
+    {
+        var tools = new UsageTools();
+        tools.RecordUsage(100, 50, 3);
+        tools.RecordUsage(200, 100, 2);
+
+        var result = tools.GetUsage();
+
+        Assert.Contains("Turns: 2", result);
+        Assert.Contains("Prompt tokens: 300", result);
+        Assert.Contains("Completion tokens: 150", result);
+        Assert.Contains("Total tokens: 450", result);
+        Assert.Contains("Tool calls: 5", result);
+    }
+
+    [Fact]
+    public void ResetUsage_ClearsCounters()
+    {
+        var tools = new UsageTools();
+        tools.RecordUsage(500, 250, 10);
+
+        var resetResult = tools.ResetUsage();
+        Assert.Contains("reset", resetResult, StringComparison.OrdinalIgnoreCase);
+
+        var result = tools.GetUsage();
+        Assert.Contains("Turns: 0", result);
+        Assert.Contains("Total tokens: 0", result);
+    }
+
+    [Fact]
+    public void GetUsage_ShowsEstimatedCosts()
+    {
+        var tools = new UsageTools();
+        tools.RecordUsage(1000, 500, 5);
+
+        var result = tools.GetUsage();
+
+        Assert.Contains("Estimated Cost", result);
+        Assert.Contains("Claude Sonnet 4", result);
+        Assert.Contains("Local (Ollama/LLamaSharp)", result);
+        Assert.Contains("$0.0000", result); // Local should be free
+    }
+}


### PR DESCRIPTION
## Summary

Adds 3 new tool categories (6 new KernelFunctions) to expand JD.AI's editing and monitoring capabilities:

### New Tools

| Tool | Category | Description |
|------|----------|-------------|
| \create_patch\ | Diff/Patch | Preview unified diff without modifying files |
| \pply_patch\ | Diff/Patch | Atomic multi-file text replacements with validation |
| \atch_edit_files\ | Batch Edit | Coordinated multi-file edits (atomic — all-or-nothing) |
| \get_usage\ | Usage | Session token counts + estimated costs across model tiers |
| \eset_usage\ | Usage | Reset session usage counters |

### Safety Tiers
- **Auto-approve**: \create_patch\, \get_usage\ (read-only)
- **Confirm once**: \pply_patch\, \atch_edit_files\, \eset_usage\ (write operations)

### Testing
- 16 new unit tests covering all tools and edge cases
- All 672 tests passing (1 pre-existing timing flake excluded)
- 0 warnings, 0 errors, formatting clean

### Documentation
- Updated \	ools-reference.md\ with all new tool sections
- Updated \index.md\ tool category count (13 → 16)
- Updated safety tiers table
