### PR TITLE
feat: Add SSH remote execution tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="LLamaSharp" Version="0.26.0" />
     <PackageVersion Include="LLamaSharp.Backend.Cpu" Version="0.26.0" />
+    <PackageVersion Include="SSH.NET" Version="2024.2.0" />
   </ItemGroup>
   <!-- Gateway -->
   <ItemGroup>

--- a/src/JD.AI.Core/JD.AI.Core.csproj
+++ b/src/JD.AI.Core/JD.AI.Core.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="LLamaSharp" />
     <PackageReference Include="LLamaSharp.Backend.Cpu" />
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JD.AI.Core/Tools/SshTools.cs
+++ b/src/JD.AI.Core/Tools/SshTools.cs
@@ -1,0 +1,288 @@
+using System.ComponentModel;
+using System.Text;
+using Microsoft.SemanticKernel;
+using Renci.SshNet;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// SSH remote execution tools for the AI agent.
+/// Allows connecting to remote machines and executing commands.
+/// </summary>
+public sealed class SshTools : IDisposable
+{
+    private SshClient? _client;
+    private string? _currentHost;
+    private string? _currentUsername;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets whether there is an active SSH connection.
+    /// </summary>
+    public bool IsConnected => _client?.IsConnected == true;
+
+    /// <summary>
+    /// Gets the current connected host, or null if not connected.
+    /// </summary>
+    public string? CurrentHost => IsConnected ? _currentHost : null;
+
+    /// <summary>
+    /// Gets the current username, or null if not connected.
+    /// </summary>
+    public string? CurrentUsername => IsConnected ? _currentUsername : null;
+
+    [KernelFunction("connect_ssh")]
+    [Description("Establish an SSH connection to a remote host. Supports key-based auth (default) or password auth.")]
+    public Task<string> ConnectSshAsync(
+        [Description("Hostname or IP address to connect to (Tailscale names work)")] string host,
+        [Description("Username for SSH authentication")] string username,
+        [Description("Password for auth (optional, uses key auth if not provided)")] string? password = null,
+        [Description("Path to private key file (default: ~/.ssh/id_rsa)")] string? privateKeyPath = null,
+        [Description("SSH port (default: 22)")] int port = 22,
+        [Description("Connection timeout in seconds (default: 30)")] int timeoutSeconds = 30)
+    {
+        try
+        {
+            // Disconnect existing connection if any
+            DisconnectInternal();
+
+            var authMethods = new List<AuthenticationMethod>();
+
+            // Try password auth if provided
+            if (!string.IsNullOrEmpty(password))
+            {
+                authMethods.Add(new PasswordAuthenticationMethod(username, password));
+            }
+
+            // Try key-based auth
+            var keyPath = privateKeyPath ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".ssh",
+                "id_rsa");
+
+            if (File.Exists(keyPath))
+            {
+                try
+                {
+                    var keyFile = new PrivateKeyFile(keyPath);
+                    authMethods.Add(new PrivateKeyAuthenticationMethod(username, keyFile));
+                }
+                catch (Exception ex)
+                {
+                    // If key auth was explicitly requested but failed, report error
+                    if (privateKeyPath != null)
+                    {
+                        return Task.FromResult($"Error: Failed to load private key at '{keyPath}': {ex.Message}");
+                    }
+                    // Otherwise, continue with other auth methods
+                }
+            }
+            else if (privateKeyPath != null)
+            {
+                // Explicitly requested key path doesn't exist
+                return Task.FromResult($"Error: Private key file not found at '{privateKeyPath}'");
+            }
+
+            if (authMethods.Count == 0)
+            {
+                return Task.FromResult("Error: No authentication method available. Provide a password or ensure SSH key exists at ~/.ssh/id_rsa");
+            }
+
+            var connectionInfo = new ConnectionInfo(host, port, username, authMethods.ToArray())
+            {
+                Timeout = TimeSpan.FromSeconds(timeoutSeconds),
+            };
+
+            _client = new SshClient(connectionInfo);
+            _client.Connect();
+
+            _currentHost = host;
+            _currentUsername = username;
+
+            return Task.FromResult($"Connected to {username}@{host}:{port}");
+        }
+        catch (Exception ex)
+        {
+            DisconnectInternal();
+            return Task.FromResult($"Error: Failed to connect to {host}: {ex.Message}");
+        }
+    }
+
+    [KernelFunction("run_remote_command")]
+    [Description("Execute a command on the connected remote host and return its output.")]
+    public Task<string> RunRemoteCommandAsync(
+        [Description("The command to execute on the remote host")] string command,
+        [Description("Timeout in seconds (default: 60)")] int timeoutSeconds = 60)
+    {
+        if (!IsConnected || _client == null)
+        {
+            return Task.FromResult("Error: Not connected to any SSH host. Use connect_ssh first.");
+        }
+
+        try
+        {
+            using var cmd = _client.CreateCommand(command);
+            cmd.CommandTimeout = TimeSpan.FromSeconds(timeoutSeconds);
+
+            var result = cmd.Execute();
+            var stderr = cmd.Error;
+            var exitCode = cmd.ExitStatus;
+
+            var output = new StringBuilder();
+            output.AppendLine($"Exit code: {exitCode}");
+
+            if (!string.IsNullOrEmpty(result))
+            {
+                output.AppendLine("--- stdout ---");
+                output.Append(result);
+            }
+
+            if (!string.IsNullOrEmpty(stderr))
+            {
+                output.AppendLine("--- stderr ---");
+                output.Append(stderr);
+            }
+
+            // Truncate very long output
+            const int maxLength = 10000;
+            var outputStr = output.ToString();
+            if (outputStr.Length > maxLength)
+            {
+                outputStr = string.Concat(outputStr.AsSpan(0, maxLength), $"\n... [truncated, {outputStr.Length - maxLength} more chars]");
+            }
+
+            return Task.FromResult(outputStr);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult($"Error: Command execution failed: {ex.Message}");
+        }
+    }
+
+    [KernelFunction("disconnect_ssh")]
+    [Description("Close the current SSH connection.")]
+    public Task<string> DisconnectSshAsync()
+    {
+        if (!IsConnected)
+        {
+            return Task.FromResult("Not connected to any SSH host.");
+        }
+
+        var host = _currentHost;
+        DisconnectInternal();
+        return Task.FromResult($"Disconnected from {host}");
+    }
+
+    [KernelFunction("get_remote_info")]
+    [Description("Get information about the connected remote system (OS, hostname, etc.).")]
+    public async Task<string> GetRemoteInfoAsync()
+    {
+        if (!IsConnected || _client == null)
+        {
+            return "Error: Not connected to any SSH host. Use connect_ssh first.";
+        }
+
+        try
+        {
+            var info = new StringBuilder();
+            info.AppendLine($"Connected to: {_currentUsername}@{_currentHost}");
+            info.AppendLine();
+
+            // Get hostname
+            var hostnameResult = await RunRemoteCommandAsync("hostname", timeoutSeconds: 5);
+            if (!hostnameResult.Contains("Error"))
+            {
+                var hostname = ExtractStdout(hostnameResult);
+                info.AppendLine($"Hostname: {hostname}");
+            }
+
+            // Get OS info (works on Linux/macOS)
+            var unameResult = await RunRemoteCommandAsync("uname -a", timeoutSeconds: 5);
+            if (!unameResult.Contains("Error"))
+            {
+                var uname = ExtractStdout(unameResult);
+                info.AppendLine($"System: {uname}");
+            }
+
+            // Try to get more detailed OS info
+            var osReleaseResult = await RunRemoteCommandAsync("cat /etc/os-release 2>/dev/null | head -5 || sw_vers 2>/dev/null", timeoutSeconds: 5);
+            if (!osReleaseResult.Contains("Error"))
+            {
+                var osRelease = ExtractStdout(osReleaseResult);
+                if (!string.IsNullOrWhiteSpace(osRelease))
+                {
+                    info.AppendLine($"OS Details:\n{osRelease}");
+                }
+            }
+
+            // Get uptime
+            var uptimeResult = await RunRemoteCommandAsync("uptime", timeoutSeconds: 5);
+            if (!uptimeResult.Contains("Error"))
+            {
+                var uptime = ExtractStdout(uptimeResult);
+                info.AppendLine($"Uptime: {uptime}");
+            }
+
+            return info.ToString().TrimEnd();
+        }
+        catch (Exception ex)
+        {
+            return $"Error: Failed to get remote info: {ex.Message}";
+        }
+    }
+
+    private static string ExtractStdout(string commandResult)
+    {
+        // Extract content between "--- stdout ---" and either "--- stderr ---" or end
+        var lines = commandResult.Split('\n');
+        var inStdout = false;
+        var result = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            if (line.Contains("--- stdout ---"))
+            {
+                inStdout = true;
+                continue;
+            }
+
+            if (line.Contains("--- stderr ---"))
+            {
+                break;
+            }
+
+            if (inStdout)
+            {
+                result.AppendLine(line);
+            }
+        }
+
+        return result.ToString().Trim();
+    }
+
+    private void DisconnectInternal()
+    {
+        if (_client != null)
+        {
+            if (_client.IsConnected)
+            {
+                _client.Disconnect();
+            }
+
+            _client.Dispose();
+            _client = null;
+        }
+
+        _currentHost = null;
+        _currentUsername = null;
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            DisconnectInternal();
+            _disposed = true;
+        }
+    }
+}

--- a/tests/JD.AI.Tests/SshToolsTests.cs
+++ b/tests/JD.AI.Tests/SshToolsTests.cs
@@ -1,0 +1,179 @@
+using JD.AI.Core.Tools;
+
+namespace JD.AI.Tests;
+
+public sealed class SshToolsTests : IDisposable
+{
+    private readonly SshTools _sshTools = new();
+
+    public void Dispose() => _sshTools.Dispose();
+
+    #region connect_ssh tests
+
+    [Fact]
+    public async Task ConnectSsh_WithInvalidHost_ReturnsError()
+    {
+        var result = await _sshTools.ConnectSshAsync(
+            host: "nonexistent.invalid.host.local",
+            username: "testuser",
+            timeoutSeconds: 2);
+
+        Assert.Contains("Error", result);
+    }
+
+    [Fact]
+    public async Task ConnectSsh_WithMissingKeyFile_ReturnsError()
+    {
+        var result = await _sshTools.ConnectSshAsync(
+            host: "localhost",
+            username: "testuser",
+            privateKeyPath: "/nonexistent/path/to/key");
+
+        Assert.Contains("Error", result);
+        Assert.Contains("key", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ConnectSsh_HasCorrectKernelFunctionAttribute()
+    {
+        var method = typeof(SshTools).GetMethod(nameof(SshTools.ConnectSshAsync));
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttributes(typeof(Microsoft.SemanticKernel.KernelFunctionAttribute), false);
+        Assert.Single(attr);
+
+        var kernelFunc = (Microsoft.SemanticKernel.KernelFunctionAttribute)attr[0];
+        Assert.Equal("connect_ssh", kernelFunc.Name);
+    }
+
+    #endregion
+
+    #region run_remote_command tests
+
+    [Fact]
+    public async Task RunRemoteCommand_WithoutConnection_ReturnsError()
+    {
+        var result = await _sshTools.RunRemoteCommandAsync("echo hello");
+
+        Assert.Contains("Error", result);
+        Assert.Contains("not connected", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RunRemoteCommand_HasCorrectKernelFunctionAttribute()
+    {
+        var method = typeof(SshTools).GetMethod(nameof(SshTools.RunRemoteCommandAsync));
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttributes(typeof(Microsoft.SemanticKernel.KernelFunctionAttribute), false);
+        Assert.Single(attr);
+
+        var kernelFunc = (Microsoft.SemanticKernel.KernelFunctionAttribute)attr[0];
+        Assert.Equal("run_remote_command", kernelFunc.Name);
+    }
+
+    #endregion
+
+    #region disconnect_ssh tests
+
+    [Fact]
+    public async Task DisconnectSsh_WithoutConnection_ReturnsNotConnectedMessage()
+    {
+        var result = await _sshTools.DisconnectSshAsync();
+
+        Assert.Contains("not connected", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DisconnectSsh_HasCorrectKernelFunctionAttribute()
+    {
+        var method = typeof(SshTools).GetMethod(nameof(SshTools.DisconnectSshAsync));
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttributes(typeof(Microsoft.SemanticKernel.KernelFunctionAttribute), false);
+        Assert.Single(attr);
+
+        var kernelFunc = (Microsoft.SemanticKernel.KernelFunctionAttribute)attr[0];
+        Assert.Equal("disconnect_ssh", kernelFunc.Name);
+    }
+
+    #endregion
+
+    #region get_remote_info tests
+
+    [Fact]
+    public async Task GetRemoteInfo_WithoutConnection_ReturnsError()
+    {
+        var result = await _sshTools.GetRemoteInfoAsync();
+
+        Assert.Contains("Error", result);
+        Assert.Contains("not connected", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetRemoteInfo_HasCorrectKernelFunctionAttribute()
+    {
+        var method = typeof(SshTools).GetMethod(nameof(SshTools.GetRemoteInfoAsync));
+        Assert.NotNull(method);
+
+        var attr = method!.GetCustomAttributes(typeof(Microsoft.SemanticKernel.KernelFunctionAttribute), false);
+        Assert.Single(attr);
+
+        var kernelFunc = (Microsoft.SemanticKernel.KernelFunctionAttribute)attr[0];
+        Assert.Equal("get_remote_info", kernelFunc.Name);
+    }
+
+    #endregion
+
+    #region Connection state tests
+
+    [Fact]
+    public void IsConnected_Initially_ReturnsFalse()
+    {
+        Assert.False(_sshTools.IsConnected);
+    }
+
+    [Fact]
+    public void ConnectionInfo_Initially_ReturnsNull()
+    {
+        Assert.Null(_sshTools.CurrentHost);
+        Assert.Null(_sshTools.CurrentUsername);
+    }
+
+    #endregion
+
+    #region Integration tests (require real SSH server - skipped by default)
+
+    [Fact(Skip = "Requires local SSH server - run manually")]
+    public async Task Integration_ConnectToLocalhost_RequiresSSHServer()
+    {
+        var result = await _sshTools.ConnectSshAsync(
+            host: "localhost",
+            username: Environment.UserName);
+
+        // If we get here, connection was attempted
+        // Result depends on whether key auth is configured
+        Assert.NotNull(result);
+    }
+
+    [Fact(Skip = "Requires local SSH server - run manually")]
+    public async Task Integration_RunCommandOnLocalhost_RequiresSSHServer()
+    {
+        var connectResult = await _sshTools.ConnectSshAsync(
+            host: "localhost",
+            username: Environment.UserName);
+
+        // Skip if connection failed
+        if (connectResult.Contains("Error"))
+        {
+            return;
+        }
+
+        var result = await _sshTools.RunRemoteCommandAsync("echo hello");
+        Assert.Contains("hello", result);
+
+        await _sshTools.DisconnectSshAsync();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
Add SSH remote execution capabilities to jd.ai TUI.

## Features
- `connect_ssh` - Establish SSH connection with key-based or password authentication
- `run_remote_command` - Execute commands on connected remote hosts
- `disconnect_ssh` - Close SSH connection
- `get_remote_info` - Get remote system information (OS, hostname, uptime)

## Implementation Details
- Uses SSH.NET package for cross-platform SSH support
- Follows existing tool patterns (similar to ShellTools.cs)
- Supports Tailscale hostnames (they work as regular hostnames)
- Default key auth from ~/.ssh/id_rsa, with fallback to password auth

## Testing
- 11 unit tests covering all functions
- Tests for error handling (invalid hosts, missing keys, not connected states)
- Integration tests (skipped by default, require real SSH server)

## Changes
- Added `SSH.NET` to Directory.Packages.props
- Added package reference to JD.AI.Core.csproj
- Created `src/JD.AI.Core/Tools/SshTools.cs`
- Created `tests/JD.AI.Tests/SshToolsTests.cs`