### PR TITLE
fix(ci): suppress NU5104 for prerelease SK connector dependencies

### DIFF
--- a/src/JD.AI.Core/JD.AI.Core.csproj
+++ b/src/JD.AI.Core/JD.AI.Core.csproj
@@ -5,8 +5,9 @@
     <RootNamespace>JD.AI.Core</RootNamespace>
     <Description>Core library for JD.AI — agents, providers, sessions, tools, orchestration, and event bus. Shared by the TUI, Gateway, and channel adapters.</Description>
     <PackageTags>ai;semantic-kernel;agents;gateway</PackageTags>
-    <!-- LLamaSharp.Backend.Cpu ships multiple AVX variants with the same filename; suppress pack warnings -->
-    <NoWarn>$(NoWarn);NU5118;NU5100</NoWarn>
+    <!-- NU5118/NU5100: LLamaSharp.Backend.Cpu ships multiple AVX variants with same filename -->
+    <!-- NU5104: SK connectors for Google, Mistral, Amazon, HuggingFace are intentionally alpha/preview -->
+    <NoWarn>$(NoWarn);NU5118;NU5100;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

CI pack step fails with NU5104 because JD.AI.Core (a stable-versioned package) depends on prerelease SK connectors:
- \Microsoft.SemanticKernel.Connectors.Google\ (1.72.0-alpha)
- \Microsoft.SemanticKernel.Connectors.MistralAI\ (1.72.0-alpha)
- \Microsoft.SemanticKernel.Connectors.Amazon\ (1.72.0-alpha)
- \Microsoft.SemanticKernel.Connectors.HuggingFace\ (1.72.0-preview)

## Fix

Suppress \NU5104\ in \JD.AI.Core.csproj\ alongside the existing \NU5118\/\NU5100\ suppressions. These prerelease dependencies are intentional — these SK connectors haven't reached stable yet but are the official Microsoft packages.

## Changes
- \src/JD.AI.Core/JD.AI.Core.csproj\: Add \NU5104\ to \<NoWarn>\
