### PR TITLE
docs: comprehensive documentation refresh across all markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,120 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to JD.AI are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-via [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions are auto-managed by [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning);
+entries are grouped by feature milestones.
 
 ## [Unreleased]
 
 ### Added
-- Initial standalone release extracted from JD.SemanticKernel.Extensions samples
-- Multi-provider support: Claude Code, GitHub Copilot, Ollama
-- Streaming responses with thinking block rendering
-- Interactive TUI with Spectre.Console
-- Tool system: file operations, shell commands, web fetch
-- Slash commands: /help, /model, /provider, /compact, /save, /load, /quit
-- Session persistence (save/load conversations)
-- Auto-update checking via NuGet
-- Clipboard paste support (text blocks, images, files)
-- Subagent orchestration (explore, task, plan, review, general)
-- Team execution strategies: sequential, fan-out, supervisor, debate
-- JDAI.md project instructions support
-- Comprehensive test suite (281+ unit tests)
-- CI/CD with GitHub Actions
-- DocFX documentation
+- **Multi-provider API key support** — 8 new API-key providers: OpenAI, Azure OpenAI, Anthropic, Google Gemini, Mistral, AWS Bedrock, HuggingFace, and OpenAI-Compatible (#42)
+- **Dynamic provider/model switching** — ConversationTransformer with 5 handoff modes, AtomicConfigStore, model search, and `/default` commands (#44)
+- **Observability** — OpenTelemetry tracing & metrics, health-check endpoints, and `/docs` command integration via JD.AI.Telemetry (#39)
+- **Microsoft Foundry Local provider** — native integration with Microsoft Foundry Local (#38)
+
+### Fixed
+- CI pack: suppress NU5104 for prerelease Semantic Kernel connector dependencies (#45)
+
+## [1.0.x] — Claude Code Parity & MCP
+
+### Added
+- **Claude Code feature parity** — print mode, system prompts, 7 new slash commands, and interactive enhancements (#24)
+- **MCP server support** — `/mcp add`, `/mcp list`, `/mcp remove` commands with config-file loading (#22)
+- **Diff/patch, batch edit & usage tracking tools** — extend the tool system with diff apply, multi-file batch edits, and token-usage tracking (#19)
+- **17 new tools** — clipboard read/write, code execution, glob/grep, web fetch enhancements, file-tree, and more for Claude Code/Copilot parity (#18)
+- **Ask-questions tool** — interactive TUI questionnaire for gathering user input during agent runs (#17)
+
+### Changed
+- Updated tools-reference and index documentation for the 17 new tools
+
+### Fixed
+- NU5118/NU5100: suppress LLamaSharp native-file pack conflicts in CI
+
+## [1.0.x] — Local Inference & Codex
+
+### Added
+- **Local model inference** — LLamaSharp integration with model discovery, download, and `/local` commands (#15)
+- **OpenAI Codex connector** — new provider for OpenAI Codex models (#14)
+- Comprehensive documentation for Codex, local models, and new commands
+
+### Fixed
+- UTF-8 console encoding and replacement of emoji with safe Unicode glyphs (#13)
+
+## [1.0.x] — Workflows & Spinner Styles
+
+### Added
+- **Workflows** — JD.AI.Workflows package with WorkflowFramework integration, in-memory catalog, two-tier matcher, and `/workflow run/list/refine` TUI commands (#11)
+- **TUI spinner styles** — configurable spinner animations via `/spinner` command; removed input echo (#12)
+- Spinner style and TUI settings tests with VHS tapes
+
+### Fixed
+- Use collection abstractions for public API properties
+- Credential scanning for user profiles when running as a service
+- Duplicate skill and plugin name handling in TUI
+
+## [1.0.x] — Gateway, Channels & Dashboard
+
+### Added
+- **Blazor WebAssembly dashboard** — real-time gateway dashboard with web chat, streaming agent responses, WYSIWYG settings editor (6 tabbed sections), and comprehensive UI refresh
+- **Gateway control plane** — extracted JD.AI.Core library; config-driven channel registration, agent auto-spawn, and routing
+- **6 channel adapters** — Discord, Signal, Slack, Telegram, Web, and OpenClaw bridge projects
+- **Channel slash commands** — remote agent and provider control via gateway; `/jdai-` prefixed aliases
+- **Daemon mode** — consolidated Gateway API + Dashboard into all-in-one service with systemd/Windows Service support, service deployment CLI, and auto-update system
+- **OpenClaw bridge** — WebSocket JSON-RPC with Ed25519 device auth, per-channel routing modes, native agent registration
+- **Plugin SDK** — extensible plugin loader, security middleware, memory/embeddings API
+- Configurable model parameters (temperature, top-p/k, context window, etc.)
+- Retry resilience for transient Ollama errors
+- Interactive model picker for `/model` and `/models` commands
+
+### Fixed
+- Blazor WASM dashboard asset loading in production
+- Dashboard sans-serif font fallback and client model alignment
+- OpenClaw routing lifecycle event handling and agent registrar RPC protocol
+- Daemon content-root and tool-deployment path resolution
+- Sanitize user-controlled values in PluginLoader log entries
+- Flaky SlidingWindowRateLimiter expiration boundary in security tests
+- Streaming display wiring (SpectreAgentOutput → ChatRenderer)
+
+### Changed
+- Centralized data-directory resolution for service accounts
+- Replaced PowerShell with bash in all VHS tape files (#8)
+
+## [1.0.x] — Subagents, Sessions & Core TUI
+
+### Added
+- **Subagent system** — 5 agent types (explore, task, plan, review, general) with swarm orchestration (#15 precursors)
+- **Team execution strategies** — Sequential, Fan-Out, Supervisor, and Debate orchestration patterns
+- **Feature parity phases** — JDAI.md project instructions, checkpoints, web search, sandbox support
+- **Session persistence** — SQLite conversation store, JSON export, `/save`, `/sessions`, `/resume` commands
+- **Interactive history viewer** and idle double-ESC handler
+- **Clipboard paste** — text blocks, images, and files with collapsible chips
+- **Streaming output** with mid-turn steering input and thinking/reasoning display (dim gray text)
+- **Ghost-text completions** — interactive input with dropdown suggestion menu
+- `--dangerously-skip-permissions` flag and `/permissions` command
+- Double-tap ESC to cancel running operations
+- Auto-update check on startup with `/update` command
+- Auto-refresh of expired auth via CLI when providers are installed
+- Ollama integration test workflow for GitHub Actions
+
+### Fixed
+- Graceful Ctrl+C with double-tap exit (no crash)
+- ESC treated as "no" in tool permission prompts
+- Line-wrapping crash in InteractiveInput on long input
+- Ollama HttpClient timeout increased to 10 minutes
+- Markup escaping in model selector to prevent Spectre parse errors
+- All CI analyzer warnings treated as errors
+
+## [1.0.x] — Initial Release
+
+### Added
+- **Standalone extraction** from JD.SemanticKernel.Extensions samples
+- **Multi-provider support** — Claude Code, GitHub Copilot, Ollama
+- **Interactive TUI** — Spectre.Console-based agent with streaming responses
+- **Tool system** — file operations, shell commands, web fetch
+- **Slash commands** — `/help`, `/model`, `/provider`, `/compact`, `/save`, `/load`, `/quit`
+- **SK extensions integration** — skills, plugins, hooks, compaction
+- **DocFX documentation site** — branded theme with light/dark support, 18 articles, VHS tape screenshots, Open Graph/Twitter Card meta tags
+- **CI/CD** — GitHub Actions workflows, community files
+- Comprehensive TUI unit and integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,46 @@ dotnet test --filter "Category!=Integration"
 dotnet test
 ```
 
+### Test Categories
+
+The project has **772+ tests** across **3 test projects** (`JD.AI.Tests`, `JD.AI.Gateway.Tests`, `JD.AI.IntegrationTests`). Follow these test naming conventions:
+
+- Test methods: `MethodName_Scenario_ExpectedResult`
+- Test classes: `{ClassUnderTest}Tests`
+- Integration tests must be marked with `[Trait("Category", "Integration")]`
+
 ## Code Style
 
 - Follow `.editorconfig` rules
 - Run `dotnet format` before committing
 - Add XML doc comments for public APIs
 - Keep test coverage high
+
+## Code Quality Requirements
+
+All pull requests must pass the following analyzer checks (CI enforced):
+
+- **Formatting**: `dotnet format --verify-no-changes` must pass with zero warnings
+- **Meziantou.Analyzer**:
+  - `MA0006` — Use `StringComparison` for string comparisons
+  - `MA0144` — Use `OperatingSystem.IsWindows()` instead of `RuntimeInformation`
+- **xUnit**: `xUnit1030` — Do not use `ConfigureAwait(false)` in test methods
+- **Code Analysis**:
+  - `CA1002` / `CA2227` — Use proper collection types (`List<T>` suppressed only for POCO serialization scenarios)
+- **Additional analyzers active**: SonarAnalyzer, AsyncFixer, Roslynator
+
+## Project Structure
+
+The solution contains **17 projects** (14 src + 3 test), organized by layer:
+
+| Layer | Projects |
+|-------|----------|
+| **Core** | `JD.AI.Core` (shared library) |
+| **Applications** | `JD.AI` (TUI), `JD.AI.Gateway`, `JD.AI.Daemon` |
+| **Channels** | `Discord`, `Signal`, `Slack`, `Telegram`, `Web`, `OpenClaw` |
+| **Libraries** | `Plugins.SDK`, `Workflows`, `Telemetry` |
+| **UI** | `Dashboard.Wasm` |
+| **Tests** | `JD.AI.Tests` (unit), `JD.AI.Gateway.Tests`, `JD.AI.IntegrationTests` |
 
 ## Commit Messages
 
@@ -51,6 +85,26 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - `test:` — Test additions/changes
 - `chore:` — Maintenance tasks
 - `refactor:` — Code restructuring
+
+## CI Checks
+
+Every pull request must pass the following **11 CI checks**:
+
+1. Label PR
+2. pr-checks
+3. analyze
+4. Dependency Review
+5. Validate PR
+6. validate-docs
+7. release
+8. publish-docs
+9. Label PR Size
+10. CodeQL
+11. Test Results
+
+## Versioning
+
+This project uses [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) for automatic semantic versioning. Version numbers are derived from `version.json` and the git height — do not manually set version numbers.
 
 ## Pull Request Process
 

--- a/README.md
+++ b/README.md
@@ -1,128 +1,207 @@
 # JD.AI
 
-AI-powered terminal assistant and multi-channel AI platform built on [Semantic Kernel](https://github.com/microsoft/semantic-kernel) — like Claude Code, but .NET. Includes a TUI client, gateway control plane, six channel adapters, and a plugin SDK across 12 projects.
+[![CI](https://github.com/JerrettDavis/JD.AI/actions/workflows/ci.yml/badge.svg)](https://github.com/JerrettDavis/JD.AI/actions/workflows/ci.yml)
+[![NuGet](https://img.shields.io/nuget/v/JD.AI.svg)](https://www.nuget.org/packages/JD.AI)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)
+
+AI-powered terminal assistant and multi-channel platform built on [Semantic Kernel](https://github.com/microsoft/semantic-kernel). 14 AI providers, 17 tool categories, 33+ slash commands, MCP server integration, workflow engine, subagent orchestration, team strategies, and six channel adapters — across 18 projects with 772+ tests.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────┐
-│           TUI Client (jdai)         │
-└──────────────────┬──────────────────┘
-                   │
-┌──────────────────▼──────────────────┐
-│     Gateway Control Plane           │
-│   (REST API + SignalR Hubs)         │
-└──────────────────┬──────────────────┘
-                   │
-┌──────────────────▼──────────────────┐
-│      Agent Pool + Routing           │
-│  (Single / Multi-turn / Teams)      │
-└───────┬─────────────────┬───────────┘
-        │                 │
-┌───────▼───────┐ ┌───────▼───────────┐
-│   Channel     │ │  Memory /         │
-│   Adapters    │ │  Embeddings       │
-│ (6 channels)  │ │  (SQLite vectors) │
-└───────────────┘ └───────────────────┘
-        │
-┌───────▼───────────────────────────┐
-│         Plugin System             │
-│  (SDK + extensible tools/hooks)   │
-└───────────────────────────────────┘
+┌──────────────────────────────────────────────┐
+│              TUI Client (jdai)               │
+│  33+ slash commands · model search · sessions│
+└──────────────────────┬───────────────────────┘
+                       │
+┌──────────────────────▼───────────────────────┐
+│         Gateway Control Plane                │
+│       (REST API + SignalR Hubs)              │
+└──────┬────────────┬────────────┬─────────────┘
+       │            │            │
+┌──────▼──────┐ ┌───▼──────┐ ┌──▼─────────────┐
+│  Telemetry  │ │ Workflows│ │  MCP Servers    │
+│ OpenTelemetry│ │  Engine  │ │ (add/list/rm)  │
+│ tracing,    │ │ run/list │ │                 │
+│ metrics,    │ │ /refine  │ │                 │
+│ health      │ │          │ │                 │
+└─────────────┘ └──────────┘ └─────────────────┘
+       │
+┌──────▼──────────────────────────────────────┐
+│     Agent Pool + Routing                    │
+│  5 subagent types · 4 team strategies       │
+│  ConversationTransformer (5 modes)          │
+└──────┬──────────────────┬───────────────────┘
+       │                  │
+┌──────▼──────┐   ┌───────▼───────────┐
+│  Channel    │   │  Memory /         │
+│  Adapters   │   │  Embeddings       │
+│ (6 channels)│   │  (SQLite vectors) │
+└─────────────┘   └───────────────────┘
+       │
+┌──────▼──────────────────────────────────────┐
+│   14 AI Providers · 17 Tool Categories      │
+│   Plugin SDK · Credential Store · Sessions  │
+└─────────────────────────────────────────────┘
 ```
 
 ## Features
 
-- **Multi-provider support** — Claude Code, GitHub Copilot, and Ollama out of the box
-- **Developer tools** — File, Git, Shell, Search, and Web tools with permission management
-- **Semantic memory** — SQLite-backed vector memory with conversation recall
-- **Context compaction** — Automatic conversation summarization to stay within context limits
-- **Subagent orchestration** — Single-turn, multi-turn, and team-based agent execution
-- **Session persistence** — Full conversation history with resume, replay, and export
-- **Interactive TUI** — Spectre.Console rendering with streaming, thinking display, and tab-completion
+| Area | Details |
+|------|---------|
+| **AI Providers** | 14 providers — OAuth, API key, local, and AWS SDK auth (see [table below](#providers)) |
+| **Tools** | 17 categories: File, Search, Shell, Git, Web, Web Search, Memory, Subagent, Think, Environment, Tasks, Code Execution, Clipboard, Questions, Diff & Patch, Batch Edit, Usage Tracking |
+| **Slash Commands** | 33+ commands for model management, sessions, providers, workflows, MCP, diagnostics, and more |
+| **Subagents** | 5 types: Explore, Task, Plan, Review, General-purpose |
+| **Team Orchestration** | 4 strategies: Sequential, Fan-Out, Supervisor, Debate |
+| **MCP Integration** | `/mcp add`, `/mcp list`, `/mcp remove` — connect external tool servers |
+| **Workflows** | `/workflow run`, `/workflow list`, `/workflow refine` — composable multi-step automation |
+| **Dynamic Switching** | 5-mode ConversationTransformer (Preserve, Compact, Transform, Fresh, Cancel) with fork points |
+| **Model Search** | `/model search` across Ollama, HuggingFace, and Foundry Local remote catalogs |
+| **Session Persistence** | SQLite-backed history, model switch tracking, fork points; `--continue`/`--resume` restores model state |
+| **Git Checkpointing** | Stash, directory, and commit strategies for safe rollback |
+| **Credentials** | Encrypted credential store (DPAPI/AES); `/provider add` wizard |
+| **Global Defaults** | `~/.jdai/config.json` with per-project overrides via AtomicConfigStore |
+| **Observability** | OpenTelemetry tracing, metrics, and health checks (JD.AI.Telemetry) |
+| **Dashboard** | Blazor WebAssembly dashboard with MudBlazor UI (JD.AI.Dashboard.Wasm) |
+| **Interactive TUI** | Spectre.Console rendering with streaming, thinking display, and tab-completion |
 
-## Install
+## Quick Start
 
 ```bash
-dotnet tool install -g JD.AI
-```
-
-## Usage
-
-```bash
-jdai
+dotnet tool install -g JD.AI   # Install globally
+jdai                            # Launch the TUI
+/provider add                   # Add an AI provider
+/help                           # List all commands
 ```
 
 ## Providers
 
-| Provider | Detection | Auth |
-|----------|-----------|------|
-| Claude Code | `claude` CLI | OAuth via Claude CLI |
-| GitHub Copilot | VS Code extension | Device flow |
-| Ollama | HTTP localhost:11434 | None (local) |
+### OAuth / Local (zero API key)
 
-## Commands
+| Provider | Auth | Notes |
+|----------|------|-------|
+| Claude Code | OAuth (claude CLI) | Requires `claude` installed |
+| GitHub Copilot | OAuth (device flow) | Uses VS Code Copilot token |
+| OpenAI Codex | OAuth | Codex CLI authentication |
+| Ollama | None (local) | HTTP `localhost:11434` |
+| Local Models / LLamaSharp | None (local) | Load `.gguf` files directly |
+| Microsoft Foundry Local | None (local) | Microsoft Foundry runtime |
 
-Type `/help` in the TUI for a full list of slash commands.
+### API Key
 
-## Gateway Control Plane
+| Provider | Auth | Notes |
+|----------|------|-------|
+| OpenAI | API key | GPT-4o, o1, o3, etc. |
+| Azure OpenAI | API key | Azure-hosted OpenAI deployments |
+| Anthropic | API key | Claude 3.5/4 via Anthropic API |
+| Google Gemini | API key | Gemini 2.x models |
+| Mistral | API key | Mistral / Mixtral models |
+| HuggingFace | API key | Inference API models |
+| OpenAI-Compatible | API key | Groq, Together, DeepSeek, OpenRouter, Fireworks, Perplexity |
 
-The gateway (`JD.AI.Gateway`) is an ASP.NET Core service that exposes a REST API and SignalR hubs for real-time agent communication. It handles authentication, rate limiting, channel management, and plugin orchestration.
+### AWS SDK
 
-See [docs/articles/gateway-api.md](docs/articles/gateway-api.md) for endpoint reference and configuration.
+| Provider | Auth | Notes |
+|----------|------|-------|
+| AWS Bedrock | AWS SDK credentials | Claude, Titan, Llama via Bedrock |
 
-## Channel Adapters
+## Key Commands
 
-| Channel | Description |
+| Command | Description |
 |---------|-------------|
-| **Discord** | Guild channels, DMs, and threads via Discord.Net |
-| **Signal** | Encrypted messaging via signal-cli JSON-RPC bridge |
-| **Slack** | Workspace integration using SlackNet Socket Mode |
-| **Telegram** | Private chats, groups, and inline commands via Telegram.Bot SDK |
-| **WebChat** | Browser-based chat using SignalR |
-| **OpenClaw** | Cross-gateway message forwarding to external OpenClaw instances |
+| `/help` | List all available commands |
+| `/model` | Show or switch the active model |
+| `/model search <query>` | Search Ollama, HuggingFace, Foundry Local catalogs |
+| `/models` | List available models for the current provider |
+| `/provider` | Show or switch the active provider |
+| `/providers` | List all configured providers |
+| `/provider add` | Interactive provider setup wizard |
+| `/default provider <name>` | Set default provider |
+| `/default model <name>` | Set default model |
+| `/compact` | Compact conversation context |
+| `/save` | Save the current session |
+| `/sessions` | List saved sessions |
+| `/resume` | Resume a saved session (restores model state) |
+| `/fork` | Fork conversation at the current point |
+| `/cost` | Show token usage and estimated cost |
+| `/mcp add <url>` | Register an MCP tool server |
+| `/workflow run <name>` | Execute a named workflow |
+| `/autorun` | Toggle automatic tool execution |
+| `/doctor` | Run environment diagnostics |
+| `/export` | Export conversation to file |
 
-See [docs/articles/channels.md](docs/articles/channels.md) for setup and configuration.
+Run `/help` in the TUI for the complete list.
 
-## Plugin SDK
+## Gateway & Channels
 
-The Plugin SDK (`JD.AI.Plugins.SDK`) defines the contract for extensible plugins — custom functions, tools, hooks, and configuration. Build and register plugins to extend agent capabilities without modifying the core.
+The **Gateway** (`JD.AI.Gateway`) is an ASP.NET Core control plane exposing REST endpoints and SignalR hubs for real-time agent communication, authentication, rate limiting, and plugin orchestration.
 
-See [docs/articles/plugins.md](docs/articles/plugins.md) for the plugin development guide.
+Six channel adapters connect the agent pool to external platforms:
 
-## OpenClaw Integration
+| Channel | Technology |
+|---------|------------|
+| Discord | Discord.Net — guilds, DMs, threads |
+| Signal | signal-cli JSON-RPC bridge |
+| Slack | SlackNet Socket Mode |
+| Telegram | Telegram.Bot SDK |
+| WebChat | SignalR browser client |
+| OpenClaw | Cross-gateway HTTP forwarding |
 
-OpenClaw enables cross-gateway orchestration by forwarding messages between JD.AI instances and external OpenClaw gateways over HTTP. This allows federated agent collaboration across deployments.
-
-See [docs/articles/openclaw-integration.md](docs/articles/openclaw-integration.md) for details.
+See [docs/articles/gateway-api.md](docs/articles/gateway-api.md) and [docs/articles/channels.md](docs/articles/channels.md).
 
 ## Project Structure
 
 ```
 src/
-├── JD.AI                    # TUI client (dotnet tool)
-├── JD.AI.Core               # Shared: agents, providers, sessions, tools, memory, event bus
-├── JD.AI.Daemon             # Background service host (Windows/Linux)
-├── JD.AI.Gateway            # ASP.NET Core control plane (REST + SignalR)
-├── JD.AI.Plugins.SDK        # Plugin interface library
-├── JD.AI.Channels.Discord   # Discord adapter
-├── JD.AI.Channels.Signal    # Signal adapter
-├── JD.AI.Channels.Slack     # Slack adapter
-├── JD.AI.Channels.Telegram  # Telegram adapter
-├── JD.AI.Channels.Web       # WebChat adapter
-└── JD.AI.Channels.OpenClaw  # OpenClaw bridge adapter
+├── JD.AI                      # TUI client (dotnet tool)
+├── JD.AI.Core                 # Agents, providers, sessions, tools, memory, event bus
+├── JD.AI.Gateway              # ASP.NET Core control plane (REST + SignalR)
+├── JD.AI.Daemon               # Background service host (Windows/Linux)
+├── JD.AI.Plugins.SDK          # Plugin interface library
+├── JD.AI.Workflows            # Workflow engine (run/list/refine)
+├── JD.AI.Telemetry            # OpenTelemetry tracing, metrics, health checks
+├── JD.AI.Dashboard.Wasm       # Blazor WASM dashboard (MudBlazor)
+├── JD.AI.Channels.Discord     # Discord adapter
+├── JD.AI.Channels.Signal      # Signal adapter
+├── JD.AI.Channels.Slack       # Slack adapter
+├── JD.AI.Channels.Telegram    # Telegram adapter
+├── JD.AI.Channels.Web         # WebChat adapter
+└── JD.AI.Channels.OpenClaw    # OpenClaw bridge adapter
 tests/
-├── JD.AI.Tests              # Unit tests
-├── JD.AI.Gateway.Tests      # Gateway unit tests
-└── JD.AI.IntegrationTests   # Integration tests
+├── JD.AI.Tests                # Core unit tests
+├── JD.AI.Gateway.Tests        # Gateway unit tests
+├── JD.AI.Workflows.Tests      # Workflow engine tests
+└── JD.AI.IntegrationTests     # End-to-end integration tests
 ```
 
 ## Dependencies
 
-- [JD.SemanticKernel.Extensions](https://github.com/JerrettDavis/JD.SemanticKernel.Extensions) — Compaction, memory, skills, hooks
-- [JD.SemanticKernel.Connectors.ClaudeCode](https://www.nuget.org/packages/JD.SemanticKernel.Connectors.ClaudeCode)
-- [JD.SemanticKernel.Connectors.GitHubCopilot](https://www.nuget.org/packages/JD.SemanticKernel.Connectors.GitHubCopilot)
+| Package | Purpose |
+|---------|---------|
+| [JD.SemanticKernel.Extensions](https://github.com/JerrettDavis/JD.SemanticKernel.Extensions) | Compaction, memory, skills, hooks |
+| [JD.SemanticKernel.Extensions.Mcp](https://www.nuget.org/packages/JD.SemanticKernel.Extensions.Mcp) | MCP server integration |
+| [JD.SemanticKernel.Connectors.ClaudeCode](https://www.nuget.org/packages/JD.SemanticKernel.Connectors.ClaudeCode) | Claude Code OAuth connector |
+| [JD.SemanticKernel.Connectors.GitHubCopilot](https://www.nuget.org/packages/JD.SemanticKernel.Connectors.GitHubCopilot) | GitHub Copilot OAuth connector |
+| [JD.SemanticKernel.Connectors.OpenAICodex](https://www.nuget.org/packages/JD.SemanticKernel.Connectors.OpenAICodex) | OpenAI Codex OAuth connector |
+| [Microsoft.SemanticKernel](https://www.nuget.org/packages/Microsoft.SemanticKernel) | Core AI orchestration (v1.72.0) |
+| [LLamaSharp](https://www.nuget.org/packages/LLamaSharp) | Local GGUF model inference |
+| [OpenTelemetry](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting) | Distributed tracing and metrics |
+| [MudBlazor](https://www.nuget.org/packages/MudBlazor) | Dashboard UI components |
+
+## Documentation
+
+Full documentation is built with [docfx](https://dotnet.github.io/docfx/) and published from the `docs/` directory.
+
+- [API Reference](docs/api/) — Auto-generated from XML doc comments
+- [Articles](docs/articles/) — Architecture, channels, gateway, plugins, workflows
+- [Getting Started](docs/index.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. The project uses central package management, Nerdbank.GitVersioning, and enforces code style via Meziantou.Analyzer.
 
 ## License
 
-MIT
+[MIT](LICENSE) © JD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,3 +24,29 @@ Users should:
 - Use sandboxed execution modes when available
 - Avoid running with elevated privileges unnecessarily
 - Be cautious with untrusted AI provider endpoints
+
+## Credential Management
+
+JD.AI uses an encrypted credential store to protect API keys and tokens:
+
+- **Windows**: Credentials are encrypted using DPAPI (Data Protection API)
+- **Linux / macOS**: Credentials are encrypted using AES
+- API keys are **always stored encrypted**, never in plain text
+- Credential resolution chain (in priority order):
+  1. CLI flags (e.g., `--api-key`)
+  2. Environment variables
+  3. Encrypted credential store
+  4. OAuth flow (interactive)
+- Use the `/provider add` wizard for secure credential setup
+
+## MCP Security
+
+MCP (Model Context Protocol) server connections are **local-only by default**. Users must explicitly configure remote MCP servers — no remote connections are made automatically.
+
+## Local Model Security
+
+Local model files are loaded **only from user-specified paths**. JD.AI does not automatically download remote model files without explicit user consent.
+
+## Session Data
+
+Session data is stored in a local SQLite database. There is **no cloud sync** — all session data remains on the user's machine.

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -79,6 +79,94 @@ You need at least one AI provider. JD.AI auto-detects all available providers.
    Or set the `OPENAI_API_KEY` environment variable directly.
 3. JD.AI detects the session automatically on next launch.
 
+### OpenAI
+
+Use the CLI flag or set an environment variable:
+
+```bash
+# CLI flag
+jdai --provider openai
+
+# Or set the environment variable
+export OPENAI_API_KEY=sk-...
+```
+
+When using the CLI flag without an environment variable, JD.AI prompts for the API key on first use and stores it in the encrypted credential store.
+
+### Azure OpenAI
+
+Provide your Azure endpoint and API key:
+
+```bash
+jdai --provider azure-openai
+```
+
+You will be prompted for:
+- **Endpoint** — your Azure OpenAI resource URL (e.g. `https://myresource.openai.azure.com/`)
+- **API Key** — your Azure OpenAI key
+
+Both can also be set via the `/provider add` wizard.
+
+### Anthropic
+
+```bash
+# CLI flag
+jdai --provider anthropic
+
+# Or set the environment variable
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Google Gemini
+
+```bash
+# CLI flag
+jdai --provider google-gemini
+
+# Or set the environment variable
+export GOOGLE_AI_API_KEY=...
+```
+
+### Mistral
+
+```bash
+# CLI flag
+jdai --provider mistral
+
+# Or set the environment variable
+export MISTRAL_API_KEY=...
+```
+
+### AWS Bedrock
+
+```bash
+jdai --provider aws-bedrock
+```
+
+Uses your standard AWS credentials (environment variables, `~/.aws/credentials`, or IAM role). Ensure `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` are configured.
+
+### HuggingFace
+
+```bash
+# CLI flag
+jdai --provider huggingface
+
+# Or set the environment variable
+export HUGGINGFACE_API_KEY=hf_...
+```
+
+### OpenAI-Compatible
+
+Connect to any OpenAI-compatible API (LM Studio, vLLM, text-generation-webui, etc.):
+
+```bash
+jdai --provider openai-compatible
+```
+
+You will be prompted for:
+- **Base URL** — the API endpoint (e.g. `http://localhost:1234/v1`)
+- **API Key** — optional, depending on the server
+
 ### Ollama (local, free)
 
 1. Install Ollama from [ollama.com](https://ollama.com)
@@ -95,9 +183,13 @@ You need at least one AI provider. JD.AI auto-detects all available providers.
    ollama pull all-minilm
    ```
 
-### Local models (fully standalone)
+### Local models (GGUF, fully standalone)
 
 No external service needed — run GGUF models directly in-process via LLamaSharp:
+
+```bash
+jdai --provider local
+```
 
 1. Place `.gguf` model files in `~/.jdai/models/` (or any directory).
 2. JD.AI detects them automatically on startup.
@@ -108,6 +200,82 @@ No external service needed — run GGUF models directly in-process via LLamaShar
    ```
 
 See [Local Models](local-models.md) for the full guide.
+
+### Microsoft Foundry Local
+
+```bash
+jdai --provider foundry-local
+```
+
+Uses locally available Foundry models. No API key required — models run on-device via the Foundry Local runtime.
+
+## Credential management
+
+JD.AI provides multiple ways to configure and secure provider credentials.
+
+### Interactive setup with `/provider add`
+
+The fastest way to configure a new provider is the interactive wizard:
+
+```text
+/provider add
+```
+
+The wizard walks you through selecting a provider, entering credentials, and verifying connectivity. Credentials are saved to the encrypted store automatically.
+
+### Encrypted credential store
+
+All credentials saved through the wizard or CLI are stored in an encrypted credential store:
+
+- **Windows** — DPAPI (Data Protection API)
+- **macOS / Linux** — AES-256 encryption with a machine-scoped key
+
+Credentials are stored in `~/.jdai/credentials.enc` and are never written in plain text.
+
+### Environment variable alternatives
+
+Every provider supports environment variables as an alternative to the credential store. Environment variables take precedence when both are present.
+
+### Credential resolution chain
+
+When JD.AI needs a credential, it checks sources in this order:
+
+1. **CLI flags** — `--provider`, `--api-key`, etc.
+2. **Environment variables** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.
+3. **Encrypted credential store** — `~/.jdai/credentials.enc`
+4. **OAuth / session tokens** — Claude Code, GitHub Copilot, Codex sessions
+
+The first source that provides a valid credential wins.
+
+## Default configuration
+
+### Setting defaults
+
+Use the `/default` command to persist your preferred provider and model:
+
+```text
+/default provider openai
+/default model gpt-4.1
+```
+
+These are saved to `~/.jdai/config.json` and used for all future sessions unless overridden.
+
+### Global config file
+
+`~/.jdai/config.json` stores global defaults:
+
+```json
+{
+  "defaultProvider": "openai",
+  "defaultModel": "gpt-4.1"
+}
+```
+
+Edit this file directly or use the `/default` commands.
+
+### Per-project configuration
+
+Create a `JDAI.md` file in your repository root to set project-specific instructions, preferred providers, or model overrides. JD.AI reads this file automatically on startup.
 
 ## Switching providers and models
 
@@ -122,8 +290,18 @@ See [Local Models](local-models.md) for the full guide.
 
 | Flag | Description |
 |------|-------------|
+| `--provider <name>` | Use a specific provider (e.g. `openai`, `anthropic`, `azure-openai`) |
+| `--model <name>` | Use a specific model |
 | `--resume <id>` | Resume a previous session by ID |
+| `--continue` | Continue the most recent session |
+| `--session-id <id>` | Attach to or create a session with a specific ID |
 | `--new` | Start a fresh session |
+| `--print` | Run in non-interactive mode and print the response |
+| `--output-format <fmt>` | Output format for non-interactive mode (`text`, `json`, `markdown`) |
+| `--system-prompt <text>` | Override the system prompt |
+| `--append-system-prompt <text>` | Append to the default system prompt |
+| `--max-turns <n>` | Limit the number of agentic turns |
+| `--verbose` | Enable verbose/debug logging |
 | `--force-update-check` | Force NuGet update check |
 | `--dangerously-skip-permissions` | Skip all tool confirmations |
 | `--gateway` | Start in gateway mode |

--- a/docs/articles/overview.md
+++ b/docs/articles/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "What JD.AI is, how it works, and what it offers — an AI-powered terminal assistant built on Microsoft Semantic Kernel."
+description: "What JD.AI is, how it works, and what it offers — an AI-powered terminal assistant with 14 providers, 17 tool categories, and 33+ slash commands built on Microsoft Semantic Kernel."
 ---
 
 # Overview
@@ -40,7 +40,7 @@ jdai
 > [!NOTE]
 > Requires .NET 10.0 SDK or later and at least one configured AI provider.
 
-JD.AI automatically detects available providers and selects the best one. Choose from **Claude Code**, **GitHub Copilot**, **OpenAI Codex**, **Ollama**, or **local GGUF models** — or switch on the fly with `/provider`.
+JD.AI automatically detects available providers and selects the best one. Choose from **14 providers** — Claude Code, GitHub Copilot, OpenAI Codex, Ollama, Foundry Local, local GGUF models, OpenAI, Azure OpenAI, Anthropic, Google Gemini, Mistral, AWS Bedrock, HuggingFace, or any OpenAI-compatible endpoint — or switch on the fly with `/provider`.
 
 ## What you can do
 
@@ -61,16 +61,34 @@ JD.AI ships with a broad set of capabilities out of the box:
 
 | Feature | Summary | Learn more |
 |---|---|---|
-| **5 AI providers** | Claude Code, Copilot, OpenAI Codex, Ollama, and local GGUF models | [Providers](providers.md) |
+| **14 AI providers** | Claude Code, Copilot, Codex, Ollama, Foundry Local, Local GGUF, OpenAI, Azure OpenAI, Anthropic, Gemini, Mistral, Bedrock, HuggingFace, and OpenAI-compatible endpoints | [Providers](providers.md) |
 | **Local model inference** | Run GGUF models in-process via LLamaSharp — fully offline | [Local models](local-models.md) |
-| **8 tool categories** | File I/O, shell, search, git, web, and more | [Tools reference](tools-reference.md) |
-| **23+ slash commands** | `/help`, `/model`, `/local`, `/spinner`, `/workflow`, and others | [Commands reference](commands-reference.md) |
+| **17 tool categories** | File, search, shell, git, web, web search, memory, subagents, think, environment, tasks, code execution, clipboard, questions, diff/patch, batch edit, and usage tracking | [Tools reference](tools-reference.md) |
+| **33+ slash commands** | `/help`, `/model`, `/local`, `/default`, `/spinner`, `/workflow`, and others | [Commands reference](commands-reference.md) |
 | **5 subagent types** | Specialized agents for explore, code review, testing, and more | [Subagents](subagents.md) |
 | **4 orchestration strategies** | Coordinate teams of agents for complex tasks | [Orchestration](orchestration.md) |
 | **Session persistence** | Save and resume conversations across sessions | [Persistence](persistence.md) |
 | **Project instructions** | Configure behavior per-project via `JDAI.md` files | [Configuration](configuration.md) |
 | **Git checkpointing** | Automatic checkpoints before destructive operations | [Checkpointing](checkpointing.md) |
 | **Auto-update** | Stay current via `dotnet tool update --global JD.AI` | — |
+
+## Architecture highlights
+
+JD.AI is organized into **17 projects** (14 `src` + 3 `test`) with **772+ tests**:
+
+| Layer | Description |
+|---|---|
+| **Core** | Providers, tools, agents, config (`AtomicConfigStore` with `~/.jdai/config.json`), and MCP integration |
+| **Telemetry** | OpenTelemetry distributed tracing, metrics, and health checks via `JD.AI.Telemetry` |
+| **Workflows** | Replayable, refinable multi-step workflows via `JD.AI.Workflows` |
+| **Channels** | 6 channel adapters — Discord, Signal, Slack, Telegram, Web, and OpenClaw |
+| **Gateway** | Central HTTP gateway for multi-channel routing and the Blazor dashboard |
+
+**Provider authentication** spans four methods: OAuth (Claude Code, Copilot, Codex), API key (OpenAI, Anthropic, Gemini, Mistral, HuggingFace, OpenAI-compatible), local/file (Ollama, Foundry Local, LLamaSharp GGUF), and AWS SDK (Bedrock). Credentials are resolved through an encrypted secure store (`~/.jdai/credentials/`), configuration files, and environment variables — in that priority order.
+
+**Dynamic model switching** uses `ConversationTransformer` with 5 modes: Preserve (keep full history), Compact (summarize), Transform (handoff briefing), Fresh (clean slate), and Cancel. The `/model search` command searches across Ollama, HuggingFace, and Foundry Local catalogs.
+
+**Global defaults** are managed by `AtomicConfigStore`, persisted to `~/.jdai/config.json`, and configurable via `/default provider`, `/default model`, and per-project overrides.
 
 ## Next steps
 

--- a/docs/articles/quickstart.md
+++ b/docs/articles/quickstart.md
@@ -15,6 +15,16 @@ Make sure you have:
 - **JD.AI installed** — `dotnet tool install -g JD.AI`
 - **At least one provider configured** — Claude Code, GitHub Copilot, OpenAI Codex, Ollama, or a local GGUF model
 
+**Quick provider setup** — the fastest way to get running with an API key provider:
+
+```bash
+# Set your API key as an environment variable, then launch
+export OPENAI_API_KEY=sk-...
+jdai --provider openai
+```
+
+This works for any key-based provider — just swap the variable and flag (e.g. `ANTHROPIC_API_KEY` + `--provider anthropic`).
+
 See [Getting Started](getting-started.md) for full installation and provider setup instructions.
 
 ## Step 1: Start JD.AI in your project
@@ -26,7 +36,19 @@ jdai
 
 On startup JD.AI detects every available provider, selects the best model, and displays a welcome banner with the active provider and model name. If multiple providers are available you can switch at any time with `/provider`.
 
-## Step 2: Explore your codebase
+## Step 2: Find and select a model
+
+Use `/model search` to discover available models across all configured providers:
+
+```text
+/model search gpt-4
+/model search claude
+/model search llama
+```
+
+Select a result to switch to it immediately. You can also pull new local models this way.
+
+## Step 3: Explore your codebase
 
 Ask plain-language questions to orient yourself:
 
@@ -38,7 +60,7 @@ where is the main entry point?
 
 JD.AI reads files, follows references, and synthesizes an answer — no manual searching required.
 
-## Step 3: Make a code change
+## Step 4: Make a code change
 
 Describe the change you want:
 
@@ -48,7 +70,7 @@ add input validation to the user registration form
 
 JD.AI locates the relevant files, proposes edits, and asks you to confirm before applying them. Each tool invocation (file read, file write, shell command) requires your approval unless you have opted into auto-run.
 
-## Step 4: Use tools
+## Step 5: Use tools
 
 JD.AI has built-in developer tools — file I/O, grep, shell, git, and web search. Ask naturally and the right tool is selected automatically:
 
@@ -58,7 +80,7 @@ search for all TODO comments in the codebase
 
 The assistant invokes the grep tool, streams results back, and summarizes the findings.
 
-## Step 5: Work with git
+## Step 6: Work with git
 
 ```text
 what files have I changed?
@@ -67,7 +89,7 @@ commit my changes with a descriptive message
 
 JD.AI runs `git status` and `git diff`, drafts a commit message, and executes the commit after your approval.
 
-## Step 6: Spawn a subagent
+## Step 7: Spawn a subagent
 
 For larger tasks you can delegate to a scoped subagent:
 
@@ -77,7 +99,20 @@ use an explore agent to find how authentication works in this codebase
 
 Subagents run in their own context with scoped tool access and report results back to the main conversation.
 
-## Step 7: Use slash commands
+## Step 8: Switch providers mid-session
+
+You can change providers or models at any point without losing your conversation:
+
+```text
+/provider            # Show current provider
+/provider anthropic  # Switch to Anthropic
+/model gpt-4.1       # Switch to a specific model
+/providers           # List all available providers with status
+```
+
+Your conversation history carries over — the new model picks up where the previous one left off.
+
+## Step 9: Use slash commands
 
 Key commands to know:
 
@@ -87,7 +122,7 @@ Key commands to know:
 - `/save` — persist the current session
 - `/sessions` — list saved sessions
 
-## Step 8: Save and resume sessions
+## Step 10: Save and resume sessions
 
 Name and save your session so you can pick up later:
 
@@ -110,6 +145,14 @@ Resume it in a future run:
 | `jdai` | Start interactive mode |
 | `/help` | Show available commands |
 | `/models` | List available models |
+| `/model search <query>` | Search for models across providers |
+| `/default provider <name>` | Set the default provider |
+| `/default model <name>` | Set the default model |
+| `/provider` | Show or switch the active provider |
+| `/mcp` | Manage MCP server connections |
+| `/workflow` | Run a saved workflow |
+| `/plan` | Create or view an execution plan |
+| `/fork` | Fork the conversation into a new branch |
 | `/compact` | Compress conversation |
 | `/save` | Save current session |
 | `/quit` | Exit JD.AI |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 _layout: landing
-description: "AI-powered terminal assistant built on Microsoft Semantic Kernel. Multi-provider support for Claude Code, GitHub Copilot, and Ollama with tool execution, subagent swarms, and team orchestration."
+description: "AI-powered terminal assistant built on Microsoft Semantic Kernel. 14 AI providers, 17 tool categories, 33+ slash commands, subagent swarms, team orchestration, and 6 channel adapters."
 ---
 
 # JD.AI
@@ -41,13 +41,14 @@ JD.AI auto-detects available providers. No manual configuration needed.
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-provider** | [Claude Code, GitHub Copilot, Ollama, OpenAI Codex, Local Models](articles/providers.md) — auto-detected on startup |
-| **25+ slash commands** | [Model switching, sessions, context management](articles/commands-reference.md) |
-| **16 tool categories** | [Files, search, shell, git, web, memory, subagents, think, environment, tasks, code execution, clipboard, questions, diff/patch, batch edit, usage tracking](articles/tools-reference.md) |
+| **Multi-provider** | [14 AI providers](articles/providers.md) including Claude Code, Copilot, Ollama, OpenAI, Anthropic, Azure, Gemini, Bedrock, Foundry Local, and more — auto-detected on startup |
+| **33+ slash commands** | [Model switching, sessions, context, workflows, defaults](articles/commands-reference.md) |
+| **17 tool categories** | [Files, search, shell, git, web, web search, memory, subagents, think, environment, tasks, code execution, clipboard, questions, diff/patch, batch edit, usage tracking](articles/tools-reference.md) |
 | **5 subagent types** | [Explore, task, plan, review, general-purpose](articles/subagents.md) |
-| **Team orchestration** | [Sequential, fan-out, supervisor, debate](articles/orchestration.md) strategies |
+| **4 orchestration strategies** | [Sequential, fan-out, supervisor, debate](articles/orchestration.md) team coordination |
+| **6 channel adapters** | [Discord, Signal, Slack, Telegram, Web, OpenClaw](articles/channels.md) |
 | **Session persistence** | [Save, load, export conversations](articles/persistence.md) across sessions |
-| **Project instructions** | [JDAI.md for project-specific context](articles/configuration.md) |
+| **Project instructions** | [JDAI.md and `/default` global config](articles/configuration.md) via AtomicConfigStore |
 | **Git checkpointing** | [Safe rollback with stash/directory/commit](articles/checkpointing.md) strategies |
 | **Skills & plugins** | [Claude Code skills/plugins/hooks](articles/skills-and-plugins.md) integration |
 | **Auto-update** | Check and apply updates via NuGet from your terminal |
@@ -71,7 +72,7 @@ JD.AI auto-detects available providers. No manual configuration needed.
 ### Reference
 
 - [Tools Reference](articles/tools-reference.md) — All tools with parameters and examples
-- [Commands Reference](articles/commands-reference.md) — All 25+ slash commands
+- [Commands Reference](articles/commands-reference.md) — All 33+ slash commands
 - [CLI Reference](articles/cli-reference.md) — Flags, environment variables, exit codes
 - [AI Providers](articles/providers.md) — Provider setup and comparison
 
@@ -79,10 +80,13 @@ JD.AI auto-detects available providers. No manual configuration needed.
 
 - [Subagents](articles/subagents.md) — Specialized AI instances for scoped tasks
 - [Team Orchestration](articles/orchestration.md) — Multi-agent coordination strategies
+- [Channel Adapters](articles/channels.md) — Discord, Signal, Slack, Telegram, Web, OpenClaw
+- [Observability](articles/observability.md) — OpenTelemetry tracing, metrics, and health checks
+- [Local Models](articles/local-models.md) — In-process GGUF inference with LLamaSharp
 - [Skills, Plugins, and Hooks](articles/skills-and-plugins.md) — Extension system
 - [Extending JD.AI](articles/extending.md) — Writing custom tools and providers
 
 ### Support
 
 - [Troubleshooting](articles/troubleshooting.md) — Common issues and solutions
-- [API Reference](api/) — Generated API documentation
+- [API Reference](https://jerrettdavis.github.io/JD.AI/api/) — Generated API documentation


### PR DESCRIPTION
## Summary

Comprehensive audit and refresh of all README, markdown, and docfx documentation files to reflect 89 commits and 40+ releases of features.

## Changes

### README.md — Complete rewrite
- **14 providers** (was 3): OAuth, API key, local, and AWS SDK providers with grouped table
- **17 tool categories** (was 7): Full table with all categories
- **33+ slash commands** (was basic): Top 20 command reference table
- **18 projects** (was 12): Complete project structure tree
- Updated architecture diagram with Telemetry, Workflows, MCP layers
- New dependency table with all current packages

### CHANGELOG.md — Full history
- 6 milestone sections covering all features from initial release through current
- Keep a Changelog format with PR references
- Covers: multi-provider API keys, dynamic switching, MCP, tools expansion, local models, gateway, channels, etc.

### CONTRIBUTING.md — Developer guidance
- Code quality requirements (analyzers: Meziantou, SonarAnalyzer, xUnit, CA rules)
- Updated project structure (17 projects by layer)
- Test categories (772+ tests across 3 projects)
- CI checks documentation (11 checks)
- Nerdbank.GitVersioning info

### SECURITY.md — Security additions
- Credential store security (DPAPI/AES encryption)
- MCP security (local-only default)
- Local model security (user-specified paths only)
- Session data privacy (local SQLite)

### docs/index.md — Landing page
- Updated all feature counts (14 providers, 17 tools, 33+ commands)
- Added new doc links (observability, local models, channels)
- Fixed API reference link

### docs/articles/overview.md — Architecture overview
- Updated provider/tool/command counts
- Added architecture highlights section (layers, auth methods, ConversationTransformer, AtomicConfigStore)

### docs/articles/getting-started.md — Setup guide
- 10 new API-key provider setup sections
- Credential management section (encrypted store, resolution chain)
- Default configuration section (/default commands, config.json)
- Expanded CLI flags table (6 → 16 flags)

### docs/articles/quickstart.md — First-use walkthrough
- Quick provider setup box
- Model search step
- Provider switching step
- Expanded essential commands table (6 → 14 entries)

## Testing
- DocFX build succeeds
- No broken links (except pre-existing api/ generation link)