### PR TITLE
feat: Model capability indicators (Chat, Tools, Vision, Embeddings)

### DIFF
--- a/src/JD.AI.Core/LocalModels/LocalModelDetector.cs
+++ b/src/JD.AI.Core/LocalModels/LocalModelDetector.cs
@@ -45,7 +45,10 @@ public sealed class LocalModelDetector : IProviderDetector
                 .Select(m => new ProviderModelInfo(
                     m.Id,
                     FormatDisplayName(m),
-                    ProviderName))
+                    ProviderName,
+                    m.Capabilities != ModelCapabilities.None
+                        ? m.Capabilities
+                        : ModelCapabilityHeuristics.InferFromName(m.Id)))
                 .ToList();
 
             if (models.Count == 0)

--- a/src/JD.AI.Core/LocalModels/ModelMetadata.cs
+++ b/src/JD.AI.Core/LocalModels/ModelMetadata.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using JD.AI.Core.Providers;
 
 namespace JD.AI.Core.LocalModels;
 
@@ -83,6 +84,12 @@ public sealed record ModelMetadata
 
     [JsonPropertyName("fileHash")]
     public string? FileHash { get; init; }
+
+    /// <summary>
+    /// Capabilities detected or configured for this model (e.g., Chat, ToolCalling, Vision).
+    /// </summary>
+    [JsonPropertyName("capabilities")]
+    public ModelCapabilities Capabilities { get; init; } = ModelCapabilities.Chat;
 
     /// <summary>
     /// Parses quantization and parameter size from a GGUF filename.

--- a/src/JD.AI.Core/Providers/FoundryLocalDetector.cs
+++ b/src/JD.AI.Core/Providers/FoundryLocalDetector.cs
@@ -33,10 +33,12 @@ public sealed class FoundryLocalDetector : IProviderDetector
                 .ConfigureAwait(false);
 
             var models = (resp?.Data ?? [])
-                .Select(m => new ProviderModelInfo(
-                    m.Id ?? "unknown",
-                    m.Id ?? "unknown",
-                    ProviderName))
+                .Select(m =>
+                {
+                    var name = m.Id ?? "unknown";
+                    var caps = ModelCapabilityHeuristics.InferFromName(name);
+                    return new ProviderModelInfo(name, name, ProviderName, caps);
+                })
                 .ToList();
 
             return new ProviderInfo(

--- a/src/JD.AI.Core/Providers/ModelCapabilities.cs
+++ b/src/JD.AI.Core/Providers/ModelCapabilities.cs
@@ -1,0 +1,72 @@
+namespace JD.AI.Core.Providers;
+
+/// <summary>
+/// Flags describing what a model supports.
+/// A model may support one or more capabilities simultaneously.
+/// </summary>
+[Flags]
+public enum ModelCapabilities
+{
+    /// <summary>No known capabilities (not yet probed).</summary>
+    None = 0,
+
+    /// <summary>Conversational text generation.</summary>
+    Chat = 1 << 0,
+
+    /// <summary>Function/tool calling via structured schemas.</summary>
+    ToolCalling = 1 << 1,
+
+    /// <summary>Image and multi-modal input processing.</summary>
+    Vision = 1 << 2,
+
+    /// <summary>Text embedding generation.</summary>
+    Embeddings = 1 << 3,
+}
+
+/// <summary>
+/// Helpers for <see cref="ModelCapabilities"/> display.
+/// </summary>
+public static class ModelCapabilitiesExtensions
+{
+    /// <summary>
+    /// Returns a compact badge string for display in the TUI.
+    /// Examples: "💬🔧" (chat + tools), "💬" (chat only), "💬👁" (chat + vision).
+    /// </summary>
+    public static string ToBadge(this ModelCapabilities caps)
+    {
+        if (caps == ModelCapabilities.None)
+            return "[dim]?[/]";
+
+        var parts = new System.Text.StringBuilder();
+        if (caps.HasFlag(ModelCapabilities.Chat))
+            parts.Append("💬");
+        if (caps.HasFlag(ModelCapabilities.ToolCalling))
+            parts.Append("🔧");
+        if (caps.HasFlag(ModelCapabilities.Vision))
+            parts.Append("👁");
+        if (caps.HasFlag(ModelCapabilities.Embeddings))
+            parts.Append("📐");
+        return parts.ToString();
+    }
+
+    /// <summary>
+    /// Returns a human-readable label string (no emoji).
+    /// Example: "Chat, Tools" or "Chat".
+    /// </summary>
+    public static string ToLabel(this ModelCapabilities caps)
+    {
+        if (caps == ModelCapabilities.None)
+            return "Unknown";
+
+        var labels = new List<string>(4);
+        if (caps.HasFlag(ModelCapabilities.Chat))
+            labels.Add("Chat");
+        if (caps.HasFlag(ModelCapabilities.ToolCalling))
+            labels.Add("Tools");
+        if (caps.HasFlag(ModelCapabilities.Vision))
+            labels.Add("Vision");
+        if (caps.HasFlag(ModelCapabilities.Embeddings))
+            labels.Add("Embeddings");
+        return string.Join(", ", labels);
+    }
+}

--- a/src/JD.AI.Core/Providers/ModelCapabilityHeuristics.cs
+++ b/src/JD.AI.Core/Providers/ModelCapabilityHeuristics.cs
@@ -1,0 +1,100 @@
+namespace JD.AI.Core.Providers;
+
+/// <summary>
+/// Heuristic rules for inferring model capabilities from model names.
+/// Used for providers that don't expose capability metadata (Foundry Local, GGUF).
+/// </summary>
+internal static class ModelCapabilityHeuristics
+{
+    /// <summary>
+    /// Known model families that support tool/function calling.
+    /// Names are matched case-insensitively against the model ID or display name.
+    /// </summary>
+    private static readonly string[] ToolCapableFamilies =
+    [
+        // Meta Llama 3.1+ and 3.2+ support tools
+        "llama-3.1", "llama-3.2", "llama-3.3", "llama3.1", "llama3.2", "llama3.3",
+        "llama-4", "llama4",
+
+        // Qwen 2.5+ supports tools
+        "qwen2.5", "qwen-2.5", "qwen3", "qwen-3",
+        "qwq",
+
+        // Mistral tool-capable variants
+        "mistral-large", "mistral-small", "mistral-nemo", "pixtral",
+        "mixtral",
+
+        // Google Gemma 2+ with tool support
+        "gemma2", "gemma-2", "gemma3", "gemma-3",
+
+        // Command R+ by Cohere
+        "command-r", "command-r-plus",
+
+        // Microsoft Phi-3/4 with tools
+        "phi-3", "phi3", "phi-4", "phi4",
+
+        // DeepSeek with tool support
+        "deepseek-v2", "deepseek-v3", "deepseek-r1",
+
+        // Nous Hermes (function calling fine-tuned)
+        "hermes-2", "hermes-3",
+
+        // Functionary (purpose-built for tools)
+        "functionary",
+
+        // Firefunction
+        "firefunction",
+
+        // NexusRaven
+        "nexusraven",
+
+        // GLM-4
+        "glm-4", "glm4",
+
+        // Granite
+        "granite",
+    ];
+
+    /// <summary>
+    /// Known model families that support vision/multi-modal input.
+    /// </summary>
+    private static readonly string[] VisionCapableFamilies =
+    [
+        "llava", "bakllava",
+        "moondream",
+        "pixtral",
+        "llama-3.2-vision", "llama3.2-vision",
+        "minicpm-v",
+        "gemma3", "gemma-3",
+    ];
+
+    /// <summary>
+    /// Infer capabilities from a model name/ID using heuristic matching.
+    /// Always returns at least <see cref="ModelCapabilities.Chat"/>.
+    /// </summary>
+    public static ModelCapabilities InferFromName(string modelName)
+    {
+        var caps = ModelCapabilities.Chat;
+        var name = modelName.ToLowerInvariant();
+
+        foreach (var family in ToolCapableFamilies)
+        {
+            if (name.Contains(family, StringComparison.OrdinalIgnoreCase))
+            {
+                caps |= ModelCapabilities.ToolCalling;
+                break;
+            }
+        }
+
+        foreach (var family in VisionCapableFamilies)
+        {
+            if (name.Contains(family, StringComparison.OrdinalIgnoreCase))
+            {
+                caps |= ModelCapabilities.Vision;
+                break;
+            }
+        }
+
+        return caps;
+    }
+}

--- a/src/JD.AI.Core/Providers/ModelSearch/IRemoteModelSearch.cs
+++ b/src/JD.AI.Core/Providers/ModelSearch/IRemoteModelSearch.cs
@@ -19,4 +19,5 @@ public sealed record RemoteModelResult(
     string ProviderName,
     string? Size,
     string Status,
-    string? Description);
+    string? Description,
+    ModelCapabilities Capabilities = ModelCapabilities.Chat | ModelCapabilities.ToolCalling);

--- a/src/JD.AI.Core/Providers/ModelSearch/OllamaModelSearch.cs
+++ b/src/JD.AI.Core/Providers/ModelSearch/OllamaModelSearch.cs
@@ -41,7 +41,8 @@ public sealed class OllamaModelSearch : IRemoteModelSearch
                     ProviderName,
                     FormatBytes(m.Size),
                     "Installed",
-                    null))
+                    null,
+                    ModelCapabilityHeuristics.InferFromName(m.Name ?? "unknown")))
                 .ToList();
 
             return models;

--- a/src/JD.AI.Core/Providers/OllamaDetector.cs
+++ b/src/JD.AI.Core/Providers/OllamaDetector.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using Microsoft.SemanticKernel;
@@ -11,6 +12,7 @@ public sealed class OllamaDetector : IProviderDetector
 {
     private readonly string _endpoint;
     private static readonly HttpClient SharedClient = new();
+    private static readonly ConcurrentDictionary<string, ModelCapabilities> CapabilityCache = new(StringComparer.OrdinalIgnoreCase);
 
     public OllamaDetector(string endpoint = "http://localhost:11434")
     {
@@ -28,17 +30,22 @@ public sealed class OllamaDetector : IProviderDetector
                     $"{_endpoint}/api/tags", ct)
                 .ConfigureAwait(false);
 
-            var models = (resp?.Models ?? [])
-                .Select(m => new ProviderModelInfo(
-                    m.Name ?? "unknown",
-                    m.Name ?? "unknown",
-                    ProviderName))
-                .ToList();
+            var rawModels = resp?.Models ?? [];
+
+            // Probe capabilities in parallel (cached after first call)
+            var tasks = rawModels
+                .Select(async m =>
+                {
+                    var name = m.Name ?? "unknown";
+                    var caps = await ProbeCapabilitiesAsync(name, ct).ConfigureAwait(false);
+                    return new ProviderModelInfo(name, name, ProviderName, caps);
+                });
+            var models = await Task.WhenAll(tasks).ConfigureAwait(false);
 
             return new ProviderInfo(
                 ProviderName,
                 IsAvailable: true,
-                StatusMessage: $"{models.Count} model(s) available",
+                StatusMessage: $"{models.Length} model(s) available",
                 Models: models);
         }
         catch (HttpRequestException)
@@ -49,6 +56,68 @@ public sealed class OllamaDetector : IProviderDetector
                 StatusMessage: "Not running",
                 Models: []);
         }
+    }
+
+    /// <summary>
+    /// Probes a model's capabilities by calling /api/show and inspecting
+    /// the template for tool-calling tokens. Falls back to name heuristics.
+    /// </summary>
+    internal async Task<ModelCapabilities> ProbeCapabilitiesAsync(string modelName, CancellationToken ct)
+    {
+        if (CapabilityCache.TryGetValue(modelName, out var cached))
+            return cached;
+
+        var caps = ModelCapabilities.Chat;
+
+        try
+        {
+            var showResp = await SharedClient
+                .PostAsJsonAsync($"{_endpoint}/api/show", new { name = modelName }, ct)
+                .ConfigureAwait(false);
+
+            if (showResp.IsSuccessStatusCode)
+            {
+                var show = await showResp.Content
+                    .ReadFromJsonAsync<OllamaShowResponse>(ct)
+                    .ConfigureAwait(false);
+
+                if (show != null)
+                {
+                    // Check template for tool-calling tokens
+                    var template = show.Template ?? string.Empty;
+                    if (template.Contains("<tool_call>", StringComparison.OrdinalIgnoreCase)
+                        || template.Contains("{{.ToolCalls}}", StringComparison.OrdinalIgnoreCase)
+                        || template.Contains("<|tool_calls|>", StringComparison.OrdinalIgnoreCase)
+                        || template.Contains("<function_call>", StringComparison.OrdinalIgnoreCase)
+                        || template.Contains("tools", StringComparison.OrdinalIgnoreCase))
+                    {
+                        caps |= ModelCapabilities.ToolCalling;
+                    }
+
+                    // Check for vision projector in model info
+                    var modelInfo = show.ModelInfo ?? string.Empty;
+                    if (modelInfo.Contains("vision", StringComparison.OrdinalIgnoreCase)
+                        || modelInfo.Contains("projector", StringComparison.OrdinalIgnoreCase))
+                    {
+                        caps |= ModelCapabilities.Vision;
+                    }
+                }
+            }
+        }
+        catch (Exception) when (!ct.IsCancellationRequested)
+        {
+            // Fall through to heuristics
+        }
+
+        // If /api/show didn't reveal tools, try name heuristics as fallback
+        if (!caps.HasFlag(ModelCapabilities.ToolCalling))
+        {
+            var heuristic = ModelCapabilityHeuristics.InferFromName(modelName);
+            caps |= heuristic & ~ModelCapabilities.Chat; // Merge non-Chat flags
+        }
+
+        CapabilityCache[modelName] = caps;
+        return caps;
     }
 
     public Kernel BuildKernel(ProviderModelInfo model)
@@ -76,4 +145,10 @@ public sealed class OllamaDetector : IProviderDetector
     private sealed record OllamaModel(
         [property: JsonPropertyName("name")]
         string? Name);
+
+    private sealed record OllamaShowResponse(
+        [property: JsonPropertyName("template")]
+        string? Template,
+        [property: JsonPropertyName("modelinfo")]
+        string? ModelInfo);
 }

--- a/src/JD.AI.Core/Providers/ProviderInfo.cs
+++ b/src/JD.AI.Core/Providers/ProviderInfo.cs
@@ -15,4 +15,5 @@ public sealed record ProviderInfo(
 public sealed record ProviderModelInfo(
     string Id,
     string DisplayName,
-    string ProviderName);
+    string ProviderName,
+    ModelCapabilities Capabilities = ModelCapabilities.Chat | ModelCapabilities.ToolCalling);

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -296,6 +296,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             .Title($"[bold]Search results for '{Markup.Escape(query)}'[/]")
             .AddColumn(new TableColumn("[bold]Provider[/]").NoWrap())
             .AddColumn(new TableColumn("[bold]Model[/]"))
+            .AddColumn(new TableColumn("[bold]Caps[/]").NoWrap())
             .AddColumn(new TableColumn("[bold]Size[/]").RightAligned())
             .AddColumn(new TableColumn("[bold]Status[/]"));
 
@@ -312,6 +313,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             table.AddRow(
                 Markup.Escape(r.ProviderName),
                 Markup.Escape(r.DisplayName),
+                r.Capabilities.ToBadge(),
                 Markup.Escape(r.Size ?? "-"),
                 statusMarkup);
         }
@@ -1177,7 +1179,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         lines.AppendLine($"Local models ({localProvider.Models.Count}):");
         foreach (var m in localProvider.Models)
         {
-            lines.AppendLine($"  • {m.Id} — {m.DisplayName}");
+            lines.AppendLine($"  {m.Capabilities.ToBadge()} {m.Id} — {m.DisplayName}");
         }
 
         return lines.ToString().TrimEnd();

--- a/src/JD.AI/Rendering/ModelPicker.cs
+++ b/src/JD.AI/Rendering/ModelPicker.cs
@@ -35,11 +35,12 @@ internal static class ModelPicker
             .HighlightStyle(new Style(Color.Aqua, decoration: Decoration.Bold))
             .UseConverter(m =>
             {
+                var badge = m.Capabilities.ToBadge();
                 var active = currentModel != null &&
                              string.Equals(m.Id, currentModel.Id, StringComparison.Ordinal)
                     ? " ◄ active"
                     : "";
-                return $"[{m.ProviderName}] {Markup.Escape(m.DisplayName)}{active}";
+                return $"{badge} [{m.ProviderName}] {Markup.Escape(m.DisplayName)}{active}";
             });
 
         // Add choices grouped by provider, placing current model's provider first

--- a/tests/JD.AI.Tests/Providers/ModelCapabilitiesTests.cs
+++ b/tests/JD.AI.Tests/Providers/ModelCapabilitiesTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using JD.AI.Core.Providers;
+
+namespace JD.AI.Tests.Providers;
+
+public sealed class ModelCapabilitiesTests
+{
+    // ── Enum flag combinations ──────────────────────────────────────────
+
+    [Fact]
+    public void Flags_ChatAndToolCalling_CombineCorrectly()
+    {
+        var caps = ModelCapabilities.Chat | ModelCapabilities.ToolCalling;
+
+        caps.HasFlag(ModelCapabilities.Chat).Should().BeTrue();
+        caps.HasFlag(ModelCapabilities.ToolCalling).Should().BeTrue();
+        caps.HasFlag(ModelCapabilities.Vision).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Flags_AllCombined_ContainsEveryFlag()
+    {
+        var all = ModelCapabilities.Chat
+                | ModelCapabilities.ToolCalling
+                | ModelCapabilities.Vision
+                | ModelCapabilities.Embeddings;
+
+        all.HasFlag(ModelCapabilities.Chat).Should().BeTrue();
+        all.HasFlag(ModelCapabilities.ToolCalling).Should().BeTrue();
+        all.HasFlag(ModelCapabilities.Vision).Should().BeTrue();
+        all.HasFlag(ModelCapabilities.Embeddings).Should().BeTrue();
+    }
+
+    // ── ToBadge() ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToBadge_None_ReturnsDimQuestionMark()
+    {
+        ModelCapabilities.None.ToBadge().Should().Be("[dim]?[/]");
+    }
+
+    [Fact]
+    public void ToBadge_ChatOnly_ReturnsChatEmoji()
+    {
+        ModelCapabilities.Chat.ToBadge().Should().Be("💬");
+    }
+
+    [Fact]
+    public void ToBadge_ChatAndToolCalling_ReturnsChatToolEmoji()
+    {
+        (ModelCapabilities.Chat | ModelCapabilities.ToolCalling)
+            .ToBadge().Should().Be("💬🔧");
+    }
+
+    [Fact]
+    public void ToBadge_ChatToolCallingVision_ReturnsThreeEmojis()
+    {
+        (ModelCapabilities.Chat | ModelCapabilities.ToolCalling | ModelCapabilities.Vision)
+            .ToBadge().Should().Be("💬🔧👁");
+    }
+
+    [Fact]
+    public void ToBadge_AllFlags_ReturnsFourEmojis()
+    {
+        (ModelCapabilities.Chat | ModelCapabilities.ToolCalling
+            | ModelCapabilities.Vision | ModelCapabilities.Embeddings)
+            .ToBadge().Should().Be("💬🔧👁📐");
+    }
+
+    // ── ToLabel() ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToLabel_None_ReturnsUnknown()
+    {
+        ModelCapabilities.None.ToLabel().Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void ToLabel_ChatOnly_ReturnsChat()
+    {
+        ModelCapabilities.Chat.ToLabel().Should().Be("Chat");
+    }
+
+    [Fact]
+    public void ToLabel_ChatAndToolCalling_ReturnsChatTools()
+    {
+        (ModelCapabilities.Chat | ModelCapabilities.ToolCalling)
+            .ToLabel().Should().Be("Chat, Tools");
+    }
+
+    [Fact]
+    public void ToLabel_AllFlags_ReturnsAllLabels()
+    {
+        (ModelCapabilities.Chat | ModelCapabilities.ToolCalling
+            | ModelCapabilities.Vision | ModelCapabilities.Embeddings)
+            .ToLabel().Should().Be("Chat, Tools, Vision, Embeddings");
+    }
+
+    // ── ModelCapabilityHeuristics.InferFromName() ───────────────────────
+
+    [Theory]
+    [InlineData("llama3.1:8b")]
+    [InlineData("qwen2.5:7b")]
+    [InlineData("phi-3-mini")]
+    public void InferFromName_ToolCapableModel_ReturnsChatAndToolCalling(string modelName)
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName(modelName);
+
+        caps.Should().HaveFlag(ModelCapabilities.Chat);
+        caps.Should().HaveFlag(ModelCapabilities.ToolCalling);
+    }
+
+    [Fact]
+    public void InferFromName_CodeLlama_ReturnsChatOnly()
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName("codellama:13b");
+
+        caps.Should().HaveFlag(ModelCapabilities.Chat);
+        caps.Should().NotHaveFlag(ModelCapabilities.ToolCalling);
+        caps.Should().NotHaveFlag(ModelCapabilities.Vision);
+    }
+
+    [Fact]
+    public void InferFromName_Llava_ReturnsChatAndVision()
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName("llava:7b");
+
+        caps.Should().HaveFlag(ModelCapabilities.Chat);
+        caps.Should().HaveFlag(ModelCapabilities.Vision);
+    }
+
+    [Fact]
+    public void InferFromName_Llama32Vision_ReturnsChatToolCallingVision()
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName("llama3.2-vision:11b");
+
+        caps.Should().HaveFlag(ModelCapabilities.Chat);
+        caps.Should().HaveFlag(ModelCapabilities.ToolCalling);
+        caps.Should().HaveFlag(ModelCapabilities.Vision);
+    }
+
+    [Fact]
+    public void InferFromName_Gemma3_ReturnsChatToolCallingVision()
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName("gemma-3:4b");
+
+        caps.Should().HaveFlag(ModelCapabilities.Chat);
+        caps.Should().HaveFlag(ModelCapabilities.ToolCalling);
+        caps.Should().HaveFlag(ModelCapabilities.Vision);
+    }
+
+    [Fact]
+    public void InferFromName_UnknownModel_ReturnsChatOnly()
+    {
+        var caps = ModelCapabilityHeuristics.InferFromName("random-model");
+
+        caps.Should().Be(ModelCapabilities.Chat);
+    }
+}


### PR DESCRIPTION
## Summary

Adds visible model capability indicators throughout the model selection and search UIs, making it clear which models support chat-only vs chat+tools, vision, and embeddings.

## Changes

### Core Types
- **\ModelCapabilities\** — \[Flags]\ enum with \Chat\, \ToolCalling\, \Vision\, \Embeddings\ flags
- **\ToBadge()\/\ToLabel()\** — Extension methods for emoji badges (💬🔧👁📐) and text labels
- **\ModelCapabilityHeuristics\** — Static class with known tool-capable/vision-capable model family lists for name-based inference

### Type Updates
- \ProviderModelInfo\ — added \Capabilities\ parameter (defaults to \Chat | ToolCalling\ for cloud providers)
- \RemoteModelResult\ — added \Capabilities\ parameter
- \ModelMetadata\ — added \Capabilities\ property with JSON serialization support

### Provider Detection
- **Cloud/OAuth providers** — default \Chat | ToolCalling\ (always support function calling)
- **Ollama** — probes \/api/show\ endpoint to inspect model template for tool-calling tokens; falls back to name heuristics; results cached
- **Foundry Local** — name-based heuristic from known tool-capable families
- **Local GGUF** — uses \ModelMetadata.Capabilities\ if set, falls back to name heuristic

### UI Updates
- **ModelPicker** — shows capability badges before model name in interactive selection
- **\/model search\** — new \Caps\ column in search results table
- **\/local list\** — shows capability badges per model

### Tests
- 19 unit tests covering enum flags, ToBadge/ToLabel extensions, and InferFromName heuristics

## Build
- 0 errors, 0 warnings
- All 19 new tests pass; pre-existing failures unchanged