### PR TITLE
fix: add /output as alias for /output-style command

### DIFF
--- a/src/JD.AI/Commands/SlashCommandCatalog.cs
+++ b/src/JD.AI/Commands/SlashCommandCatalog.cs
@@ -54,6 +54,7 @@ public static class SlashCommandCatalog
         new("/agents", "Manage local agent profiles"),
         new("/hooks", "Manage local hook profiles"),
         new("/memory", "View/edit JDAI.md project memory"),
+        new("/output", "Set output rendering style (alias: /output-style)"),
         new("/output-style", "Set output rendering style"),
         new("/default", "Manage default provider/model settings"),
         new("/default provider", "Set global default provider"),

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -141,7 +141,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             "/AGENTS" or "/JDAI-AGENTS" => await HandleAgentsAsync(arg, ct).ConfigureAwait(false),
             "/HOOKS" or "/JDAI-HOOKS" => await HandleHooksAsync(arg, ct).ConfigureAwait(false),
             "/MEMORY" or "/JDAI-MEMORY" => await HandleMemoryAsync(arg, ct).ConfigureAwait(false),
-            "/OUTPUT-STYLE" or "/JDAI-OUTPUT-STYLE" => HandleOutputStyle(arg),
+            "/OUTPUT" or "/OUTPUT-STYLE" or "/JDAI-OUTPUT-STYLE" => HandleOutputStyle(arg),
             "/DEFAULT" or "/JDAI-DEFAULT" => await HandleDefaultAsync(arg, ct).ConfigureAwait(false),
             "/QUIT" or "/EXIT" or "/JDAI-QUIT" or "/JDAI-EXIT" => null, // Signal exit
             _ => $"Unknown command: {parts[0]}. Type /help for available commands.",

--- a/tests/JD.AI.Tests/SlashCommandRouterTests.cs
+++ b/tests/JD.AI.Tests/SlashCommandRouterTests.cs
@@ -505,6 +505,22 @@ public sealed class SlashCommandRouterTests
     }
 
     [Fact]
+    public async Task Output_Alias_SetsStyle()
+    {
+        var style = OutputStyle.Json;
+        var router = new SlashCommandRouter(
+            _session, _registry,
+            getOutputStyle: () => style,
+            onOutputStyleChanged: s => style = s);
+
+        var result = await router.ExecuteAsync("/output rich");
+
+        Assert.NotNull(result);
+        Assert.Contains("rich", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(OutputStyle.Rich, style);
+    }
+
+    [Fact]
     public async Task Config_List_IncludesTheme()
     {
         var result = await _router.ExecuteAsync("/config");


### PR DESCRIPTION
## Summary

Users naturally type \/output rich\ instead of \/output-style rich\. This adds \/output\ as a recognized alias.

### Changes
- **SlashCommandRouter.cs** — Added \/OUTPUT\ to the switch case alongside \/OUTPUT-STYLE\
- **SlashCommandCatalog.cs** — Added \/output\ entry for autocompletion
- **SlashCommandRouterTests.cs** — Added test verifying the alias works

### Testing
- All 57 slash command tests pass
- Full solution builds with 0 warnings/errors