### PR TITLE
feat: OpenTelemetry tool and session instrumentation

### DIFF
--- a/src/JD.AI.Core/Sessions/SessionStore.cs
+++ b/src/JD.AI.Core/Sessions/SessionStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Text.Json;
 using JD.AI.Core.Agents;
 using Microsoft.Data.Sqlite;
@@ -10,6 +11,8 @@ namespace JD.AI.Core.Sessions;
 /// </summary>
 public sealed class SessionStore : IDisposable
 {
+    private static readonly ActivitySource SessionActivity = new("JD.AI.Sessions");
+
     private readonly string _connectionString;
     private SqliteConnection? _connection;
 
@@ -128,6 +131,10 @@ public sealed class SessionStore : IDisposable
 
     public async Task CreateSessionAsync(SessionInfo session)
     {
+        using var activity = SessionActivity.StartActivity("jdai.session.create");
+        activity?.SetTag("jdai.session.id", session.Id);
+        activity?.SetTag("jdai.session.project_hash", session.ProjectHash);
+
         var conn = await GetConnectionAsync().ConfigureAwait(false);
         using var cmd = conn.CreateCommand();
         cmd.CommandText = """
@@ -175,6 +182,11 @@ public sealed class SessionStore : IDisposable
 
     public async Task SaveTurnAsync(TurnRecord turn)
     {
+        using var activity = SessionActivity.StartActivity("jdai.session.save_turn");
+        activity?.SetTag("jdai.session.id", turn.SessionId);
+        activity?.SetTag("jdai.turn.index", turn.TurnIndex);
+        activity?.SetTag("jdai.turn.role", turn.Role);
+
         var conn = await GetConnectionAsync().ConfigureAwait(false);
         using var tx = conn.BeginTransaction();
 
@@ -241,6 +253,9 @@ public sealed class SessionStore : IDisposable
 
     public async Task<SessionInfo?> GetSessionAsync(string id)
     {
+        using var activity = SessionActivity.StartActivity("jdai.session.load");
+        activity?.SetTag("jdai.session.id", id);
+
         var conn = await GetConnectionAsync().ConfigureAwait(false);
         SessionInfo? session = null;
 

--- a/src/JD.AI/Agent/ToolConfirmationFilter.cs
+++ b/src/JD.AI/Agent/ToolConfirmationFilter.cs
@@ -13,6 +13,8 @@ namespace JD.AI.Agent;
 /// </summary>
 public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
 {
+    private static readonly ActivitySource ToolActivity = new("JD.AI.Tools");
+
     private readonly AgentSession _session;
     private readonly IPolicyEvaluator? _policyEvaluator;
     private readonly AuditService? _auditService;
@@ -174,7 +176,22 @@ public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
             output.RenderInfo($"  ▸ {functionName}({args})");
         }
 
+        // ── Tool execution with OTel tracing ─────────────────
+        using var activity = ToolActivity.StartActivity("jdai.tool.invoke");
+        activity?.SetTag("jdai.tool.name", functionName);
+        activity?.SetTag("jdai.tool.safety_tier", tier.ToString());
+        activity?.SetTag("jdai.tool.permission_mode", _session.PermissionMode.ToString());
+        var sw = Stopwatch.StartNew();
+
         await next(context).ConfigureAwait(false);
+
+        sw.Stop();
+        activity?.SetTag("jdai.tool.duration_ms", sw.ElapsedMilliseconds);
+        activity?.SetStatus(ActivityStatusCode.Ok);
+
+        // Record metric
+        JD.AI.Telemetry.Meters.ToolCalls.Add(1,
+            new KeyValuePair<string, object?>("jdai.tool.name", functionName));
 
         // Render tool result
         var result = context.Result.GetValue<string>() ?? context.Result.ToString() ?? "";

--- a/src/JD.AI/JD.AI.csproj
+++ b/src/JD.AI/JD.AI.csproj
@@ -39,6 +39,7 @@
   <!-- Core library (agents, orchestration, checkpointing) -->
   <ItemGroup>
     <ProjectReference Include="..\JD.AI.Core\JD.AI.Core.csproj" />
+    <ProjectReference Include="..\JD.AI.Telemetry\JD.AI.Telemetry.csproj" />
     <ProjectReference Include="..\JD.AI.Workflows\JD.AI.Workflows.csproj" />
   </ItemGroup>
 

--- a/tests/JD.AI.Tests/Telemetry/OtelInstrumentationTests.cs
+++ b/tests/JD.AI.Tests/Telemetry/OtelInstrumentationTests.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace JD.AI.Tests.Telemetry;
+
+public sealed class OtelInstrumentationTests
+{
+    [Fact]
+    public void ToolActivitySource_HasCorrectName()
+    {
+        // The ToolConfirmationFilter creates ActivitySource("JD.AI.Tools")
+        // Verify it can be listened to
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "JD.AI.Tools", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("JD.AI.Tools");
+        using var activity = source.StartActivity("test.span");
+
+        Assert.NotNull(activity);
+        Assert.Equal("test.span", activity.OperationName);
+    }
+
+    [Fact]
+    public void SessionActivitySource_HasCorrectName()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => string.Equals(source.Name, "JD.AI.Sessions", StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("JD.AI.Sessions");
+        using var activity = source.StartActivity("test.span");
+
+        Assert.NotNull(activity);
+        Assert.Equal("test.span", activity.OperationName);
+    }
+
+    [Fact]
+    public void Meters_ToolCalls_CanRecord()
+    {
+        // Verify the counter exists and doesn't throw
+        JD.AI.Telemetry.Meters.ToolCalls.Add(1,
+            new KeyValuePair<string, object?>("jdai.tool.name", "test_tool"));
+    }
+
+    [Fact]
+    public void Meters_TurnCount_CanRecord()
+    {
+        JD.AI.Telemetry.Meters.TurnCount.Add(1);
+    }
+
+    [Fact]
+    public void Meters_ProviderErrors_CanRecord()
+    {
+        JD.AI.Telemetry.Meters.ProviderErrors.Add(1,
+            new KeyValuePair<string, object?>("provider", "test"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds distributed tracing and metrics instrumentation to tool invocations and session operations, completing issue #25.

## Changes

### Tool Invocation Tracing (ToolConfirmationFilter)
- Wraps every tool execution in an \Activity\ span (\jdai.tool.invoke\)
- Tags: \jdai.tool.name\, \jdai.tool.safety_tier\, \jdai.tool.permission_mode\, \jdai.tool.duration_ms\
- Records \Meters.ToolCalls\ counter with tool name dimension

### Session Operation Tracing (SessionStore)
- \jdai.session.create\ — spans session creation with session ID and project hash
- \jdai.session.load\ — spans session retrieval
- \jdai.session.save_turn\ — spans turn persistence with turn index and role

### Infrastructure
- Added \JD.AI.Telemetry\ project reference to TUI project
- ActivitySource names match \ActivitySources.ToolsSourceName\ and \SessionsSourceName\

### Tests
- 5 new tests verifying ActivitySource creation and metric recording

## How It Works
Uses \System.Diagnostics.ActivitySource\ (BCL) directly — no heavy OTel SDK dependency in TUI. When the Gateway runs with OTel configured, it picks up these activities via matching source names.

Closes #25