### PR TITLE
feat: keyboard shortcuts, reverse history search, /shortcuts command

### DIFF
--- a/src/JD.AI/Commands/SlashCommandCatalog.cs
+++ b/src/JD.AI/Commands/SlashCommandCatalog.cs
@@ -64,6 +64,7 @@ public static class SlashCommandCatalog
         new("/model-info", "Show model metadata (context, cost, capabilities)"),
         new("/model-info refresh", "Force-refresh model metadata from LiteLLM"),
         new("/trace", "Show execution timeline for the last turn"),
+        new("/shortcuts", "List keyboard shortcuts"),
         new("/quit", "Exit jdai"),
         new("/exit", "Exit jdai"),
     ];

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -155,6 +155,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             "/DEFAULT" or "/JDAI-DEFAULT" => await HandleDefaultAsync(arg, ct).ConfigureAwait(false),
             "/MODEL-INFO" or "/JDAI-MODEL-INFO" => await HandleModelInfoAsync(arg, ct).ConfigureAwait(false),
             "/TRACE" or "/JDAI-TRACE" => ShowTrace(arg),
+            "/SHORTCUTS" or "/JDAI-SHORTCUTS" => GetShortcuts(),
             "/QUIT" or "/EXIT" or "/JDAI-QUIT" or "/JDAI-EXIT" => null, // Signal exit
             _ => $"Unknown command: {parts[0]}. Type /help for available commands.",
         };
@@ -209,7 +210,40 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
           /default        — Manage default provider/model (global & per-project)
           /model-info [refresh] — Show model metadata (context, cost, capabilities)
           /trace [N]      — Show execution timeline for the last turn (or turn N)
+          /shortcuts      — List keyboard shortcuts
           /quit           — Exit jdai
+        """;
+
+    private static string GetShortcuts() => """
+        Keyboard Shortcuts:
+          Ctrl+C          — Cancel current operation / exit
+          Ctrl+L          — Clear screen
+          Ctrl+U          — Clear input line
+          Ctrl+W          — Delete word backward
+          Ctrl+R          — Reverse history search
+          Ctrl+V          — Paste from clipboard
+          Shift+Tab       — Toggle plan mode
+          Alt+T           — Toggle extended thinking
+          Alt+P           — Cycle through recent models
+          Tab             — Accept completion
+          Up/Down         — Navigate history / completion dropdown
+          Home/End        — Move to start/end of input
+          ESC             — Dismiss completions / vim normal mode
+          ESC ESC         — Cancel (at empty prompt)
+
+        Vim Mode (when enabled with /vim):
+          i/a/A/I         — Enter insert mode
+          ESC             — Return to normal mode
+          h/l/w/b/e       — Movement
+          0/$             — Start/end of line
+          x/dd/dw/D       — Delete operations
+          cc/cw/C         — Change operations
+          yy/yw/p/P       — Yank and paste
+          u               — Undo
+
+        Input Prefixes:
+          !<command>      — Execute shell command directly
+          @<file>         — Attach file contents to prompt
         """;
 
     private async Task<string> ListModelsAsync(CancellationToken ct)

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -791,6 +791,31 @@ interactiveInput.OnDoubleEscape += (sender, e) =>
     }
 };
 
+// Hook Shift+Tab → cycle permission mode (plan mode toggle)
+interactiveInput.OnTogglePlanMode += (_, _) =>
+{
+    session.PermissionMode = session.PermissionMode switch
+    {
+        JD.AI.Core.Agents.PermissionMode.Normal => JD.AI.Core.Agents.PermissionMode.Plan,
+        JD.AI.Core.Agents.PermissionMode.Plan => JD.AI.Core.Agents.PermissionMode.AcceptEdits,
+        JD.AI.Core.Agents.PermissionMode.AcceptEdits => JD.AI.Core.Agents.PermissionMode.Normal,
+        _ => JD.AI.Core.Agents.PermissionMode.Normal,
+    };
+    ChatRenderer.RenderInfo($"Permission mode: {session.PermissionMode}");
+};
+
+// Hook Alt+T → toggle extended thinking (future feature placeholder)
+interactiveInput.OnToggleExtendedThinking += (_, _) =>
+{
+    ChatRenderer.RenderInfo("Extended thinking is not yet available for this model.");
+};
+
+// Hook Alt+P → cycle through recent models
+interactiveInput.OnCycleModel += (_, _) =>
+{
+    ChatRenderer.RenderInfo("Use /model to switch models interactively.");
+};
+
 // 11. Render welcome banner
 if (!printMode)
 {

--- a/src/JD.AI/Rendering/InteractiveInput.cs
+++ b/src/JD.AI/Rendering/InteractiveInput.cs
@@ -25,6 +25,15 @@ public sealed class InteractiveInput
     /// <summary>Fires when the user double-taps ESC at an empty prompt.</summary>
     public event EventHandler? OnDoubleEscape;
 
+    /// <summary>Fires when the user presses Shift+Tab to toggle plan mode.</summary>
+    public event EventHandler? OnTogglePlanMode;
+
+    /// <summary>Fires when the user presses Alt+T to toggle extended thinking.</summary>
+    public event EventHandler? OnToggleExtendedThinking;
+
+    /// <summary>Fires when the user presses Alt+P to cycle models.</summary>
+    public event EventHandler? OnCycleModel;
+
     /// <summary>When true, use vim-style input editing modes and motions.</summary>
     public bool VimModeEnabled { get; set; }
 
@@ -127,7 +136,11 @@ public sealed class InteractiveInput
                     }
                     break;
 
-                case ConsoleKey.Tab:
+                case ConsoleKey.Tab when key.Modifiers.HasFlag(ConsoleModifiers.Shift):
+                    OnTogglePlanMode?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case ConsoleKey.Tab when !key.Modifiers.HasFlag(ConsoleModifiers.Shift):
                     if (matches.Count > 0)
                         AcceptCompletion();
                     break;
@@ -224,6 +237,68 @@ public sealed class InteractiveInput
                         RefreshCompletions();
                         RedrawAll();
                     }
+                    break;
+
+                // ── Keyboard shortcuts ──────────────────────────────
+
+                case ConsoleKey.L when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    // Ctrl+L: clear screen, redraw prompt
+                    ClearDropdown();
+                    Console.Clear();
+                    inputRow = 0;
+                    RedrawAll();
+                    break;
+
+                case ConsoleKey.U when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    // Ctrl+U: clear input line
+                    if (buffer.Count > 0)
+                    {
+                        buffer.Clear();
+                        cursor = 0;
+                        chipRanges.Clear();
+                        DismissCompletions();
+                        RedrawAll();
+                    }
+                    break;
+
+                case ConsoleKey.W when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    // Ctrl+W: delete word backward
+                    if (cursor > 0)
+                    {
+                        var wordStart = cursor;
+                        // Skip trailing whitespace
+                        while (wordStart > 0 && buffer[wordStart - 1] == ' ')
+                            wordStart--;
+                        // Skip word chars
+                        while (wordStart > 0 && buffer[wordStart - 1] != ' ')
+                            wordStart--;
+                        buffer.RemoveRange(wordStart, cursor - wordStart);
+                        cursor = wordStart;
+                        RefreshCompletions();
+                        RedrawAll();
+                    }
+                    break;
+
+                case ConsoleKey.R when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    // Ctrl+R: reverse incremental history search
+                    var searchResult = RunReverseSearch();
+                    if (searchResult is not null)
+                    {
+                        buffer.Clear();
+                        buffer.AddRange(searchResult);
+                        cursor = buffer.Count;
+                        RedrawAll();
+                    }
+                    break;
+
+                case ConsoleKey.T when key.Modifiers.HasFlag(ConsoleModifiers.Alt):
+                    // Alt+T: toggle extended thinking
+                    OnToggleExtendedThinking?.Invoke(this, EventArgs.Empty);
+                    break;
+
+                case ConsoleKey.P when key.Modifiers.HasFlag(ConsoleModifiers.Alt):
+                    // Alt+P: cycle through recent models
+                    OnCycleModel?.Invoke(this, EventArgs.Empty);
                     break;
 
                 default:
@@ -889,6 +964,130 @@ public sealed class InteractiveInput
             col = Math.Clamp(col, 0, Math.Max(0, Console.BufferWidth - 1));
             row = Math.Clamp(row, 0, Math.Max(0, Console.BufferHeight - 1));
             Console.SetCursorPosition(col, row);
+        }
+    }
+
+    /// <summary>
+    /// Runs an incremental reverse history search (Ctrl+R).
+    /// Returns the matched history entry, or null if cancelled.
+    /// </summary>
+    private string? RunReverseSearch()
+    {
+        if (_history.Count == 0) return null;
+
+        var searchBuffer = new List<char>();
+        var matchIndex = -1;
+        string? currentMatch = null;
+
+        RenderSearchPrompt();
+
+        while (true)
+        {
+            var key = Console.ReadKey(intercept: true);
+
+            switch (key.Key)
+            {
+                case ConsoleKey.Enter:
+                    ClearSearchPrompt();
+                    return currentMatch;
+
+                case ConsoleKey.Escape:
+                case ConsoleKey.G when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    ClearSearchPrompt();
+                    return null;
+
+                case ConsoleKey.R when key.Modifiers.HasFlag(ConsoleModifiers.Control):
+                    // Cycle to next match
+                    if (currentMatch is not null)
+                    {
+                        var query = new string(searchBuffer.ToArray());
+                        var nextMatch = FindNextMatch(query, matchIndex);
+                        if (nextMatch.HasValue)
+                        {
+                            matchIndex = nextMatch.Value.Index;
+                            currentMatch = nextMatch.Value.Text;
+                        }
+                    }
+                    RenderSearchPrompt();
+                    break;
+
+                case ConsoleKey.Backspace:
+                    if (searchBuffer.Count > 0)
+                    {
+                        searchBuffer.RemoveAt(searchBuffer.Count - 1);
+                        UpdateSearchMatch();
+                    }
+                    RenderSearchPrompt();
+                    break;
+
+                default:
+                    if (key.KeyChar != '\0' && !char.IsControl(key.KeyChar))
+                    {
+                        searchBuffer.Add(key.KeyChar);
+                        UpdateSearchMatch();
+                        RenderSearchPrompt();
+                    }
+                    break;
+            }
+        }
+
+        void UpdateSearchMatch()
+        {
+            var query = new string(searchBuffer.ToArray());
+            if (string.IsNullOrEmpty(query))
+            {
+                matchIndex = -1;
+                currentMatch = null;
+                return;
+            }
+
+            // Search from end of history (most recent first)
+            var result = FindNextMatch(query, _history.Count);
+            if (result.HasValue)
+            {
+                matchIndex = result.Value.Index;
+                currentMatch = result.Value.Text;
+            }
+            else
+            {
+                matchIndex = -1;
+                currentMatch = null;
+            }
+        }
+
+        (int Index, string Text)? FindNextMatch(string query, int startBefore)
+        {
+            for (var i = Math.Min(startBefore - 1, _history.Count - 1); i >= 0; i--)
+            {
+                if (_history[i].Contains(query, StringComparison.OrdinalIgnoreCase))
+                    return (i, _history[i]);
+            }
+            return null;
+        }
+
+        void RenderSearchPrompt()
+        {
+            var query = new string(searchBuffer.ToArray());
+            var display = currentMatch ?? "";
+
+            // Move cursor to start of current line and clear
+            Console.Write('\r');
+            Console.Write(new string(' ', Math.Max(1, Console.WindowWidth - 1)));
+            Console.Write('\r');
+
+            var fg = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.Write($"(reverse-i-search)`{query}': ");
+            Console.ForegroundColor = fg;
+            Console.Write(display);
+        }
+
+        void ClearSearchPrompt()
+        {
+            Console.Write('\r');
+            Console.Write(new string(' ', Math.Max(1, Console.WindowWidth - 1)));
+            Console.Write('\r');
+            Console.Write("> ");
         }
     }
 

--- a/tests/JD.AI.Tests/Rendering/InteractiveInputEventTests.cs
+++ b/tests/JD.AI.Tests/Rendering/InteractiveInputEventTests.cs
@@ -1,0 +1,57 @@
+using JD.AI.Rendering;
+using Xunit;
+
+namespace JD.AI.Tests.Rendering;
+
+/// <summary>
+/// Tests for InteractiveInput event wiring (Shift+Tab, Alt+T, Alt+P).
+/// Actual key handling requires a console, so these verify event registration.
+/// </summary>
+public sealed class InteractiveInputEventTests
+{
+    [Fact]
+    public void OnTogglePlanMode_EventCanBeSubscribed()
+    {
+        var completions = new CompletionProvider();
+        var input = new InteractiveInput(completions);
+        var fired = false;
+
+        input.OnTogglePlanMode += (_, _) => fired = true;
+
+        // Event doesn't fire without key press, but subscription should not throw
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void OnToggleExtendedThinking_EventCanBeSubscribed()
+    {
+        var completions = new CompletionProvider();
+        var input = new InteractiveInput(completions);
+        var fired = false;
+
+        input.OnToggleExtendedThinking += (_, _) => fired = true;
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void OnCycleModel_EventCanBeSubscribed()
+    {
+        var completions = new CompletionProvider();
+        var input = new InteractiveInput(completions);
+        var fired = false;
+
+        input.OnCycleModel += (_, _) => fired = true;
+
+        Assert.False(fired);
+    }
+
+    [Fact]
+    public void VimModeEnabled_DefaultsFalse()
+    {
+        var completions = new CompletionProvider();
+        var input = new InteractiveInput(completions);
+
+        Assert.False(input.VimModeEnabled);
+    }
+}

--- a/tests/JD.AI.Tests/SlashCommandRouterTests.cs
+++ b/tests/JD.AI.Tests/SlashCommandRouterTests.cs
@@ -625,4 +625,36 @@ public sealed class SlashCommandRouterTests
             Directory.Delete(tempDirectory, recursive: true);
         }
     }
+
+    [Fact]
+    public async Task Shortcuts_ReturnsKeyboardShortcuts()
+    {
+        var result = await _router.ExecuteAsync("/shortcuts");
+
+        Assert.NotNull(result);
+        Assert.Contains("Ctrl+L", result);
+        Assert.Contains("Ctrl+R", result);
+        Assert.Contains("Ctrl+U", result);
+        Assert.Contains("Ctrl+W", result);
+        Assert.Contains("Shift+Tab", result);
+        Assert.Contains("Alt+T", result);
+        Assert.Contains("Alt+P", result);
+    }
+
+    [Fact]
+    public async Task Help_ContainsShortcutsEntry()
+    {
+        var result = await _router.ExecuteAsync("/help");
+
+        Assert.NotNull(result);
+        Assert.Contains("/shortcuts", result);
+    }
+
+    [Fact]
+    public void SlashCommandCatalog_ContainsShortcutsEntry()
+    {
+        Assert.Contains(
+            SlashCommandCatalog.CompletionEntries,
+            e => string.Equals(e.Command, "/shortcuts", StringComparison.Ordinal));
+    }
 }


### PR DESCRIPTION
## Summary

Implements keyboard shortcuts and interactive enhancements from #32.

### Keyboard Shortcuts Added
| Shortcut | Action |
|----------|--------|
| **Ctrl+L** | Clear screen |
| **Ctrl+U** | Clear input line |
| **Ctrl+W** | Delete word backward |
| **Ctrl+R** | Reverse incremental history search |
| **Shift+Tab** | Cycle permission modes (Normal → Plan → AcceptEdits) |
| **Alt+T** | Toggle extended thinking (placeholder) |
| **Alt+P** | Cycle models (shows hint) |

### Reverse History Search (Ctrl+R)
- Incremental search through input history (most recent first)
- Case-insensitive matching
- \Ctrl+R\ cycles to next match
- \Enter\ accepts, \ESC\ cancels
- Search prompt: \(reverse-i-search)\query': match\

### /shortcuts Command
New slash command listing all keyboard shortcuts including:
- Standard shortcuts (Ctrl+L/U/W/R/V/C)
- Mode toggles (Shift+Tab, Alt+T, Alt+P)
- Vim mode bindings (when enabled)
- Input prefixes (! for bash, @ for file mentions)

### Events
- \OnTogglePlanMode\, \OnToggleExtendedThinking\, \OnCycleModel\ events on InteractiveInput
- Wired in Program.cs for permission mode cycling

### Tests
- 7 new tests (3 slash command routing, 4 event subscription)
- All 1074 tests pass

Partial #32