### PR TITLE
feat: add Voting, Relay, and Map-Reduce coordination strategies

### DIFF
--- a/src/JD.AI.Core/Agents/Orchestration/Strategies/MapReduceStrategy.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/Strategies/MapReduceStrategy.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+
+namespace JD.AI.Core.Agents.Orchestration.Strategies;
+
+/// <summary>
+/// Map-Reduce strategy — split input into chunks, process in parallel, then reduce.
+/// Good for: bulk file analysis, large codebase scanning, data processing.
+/// </summary>
+public sealed class MapReduceStrategy : IOrchestrationStrategy
+{
+    public string Name => "map-reduce";
+
+    /// <summary>Maximum number of parallel mapper agents.</summary>
+    public int MaxParallelism { get; init; } = 4;
+
+    public async Task<TeamResult> ExecuteAsync(
+        IReadOnlyList<SubagentConfig> agents,
+        TeamContext context,
+        ISubagentExecutor executor,
+        AgentSession parentSession,
+        Action<SubagentProgress>? onProgress = null,
+        CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var results = new Dictionary<string, AgentResult>(StringComparer.Ordinal);
+
+        if (agents.Count == 0)
+        {
+            sw.Stop();
+            return new TeamResult
+            {
+                Output = "No agents configured for map-reduce.",
+                Strategy = Name,
+                AgentResults = results,
+                Duration = sw.Elapsed,
+                Success = false,
+            };
+        }
+
+        // Last agent is the reducer; all others are mappers
+        var mappers = agents.Count > 1 ? agents.Take(agents.Count - 1).ToList() : agents.ToList();
+        var reducerTemplate = agents.Count > 1 ? agents[^1] : null;
+
+        // Execute mappers in parallel with bounded concurrency
+        using var semaphore = new SemaphoreSlim(MaxParallelism);
+        var mapTasks = mappers.Select(async mapper =>
+        {
+            await semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                return await executor.ExecuteAsync(
+                    mapper, parentSession, context, onProgress, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        var mapResults = await Task.WhenAll(mapTasks).ConfigureAwait(false);
+
+        foreach (var result in mapResults)
+        {
+            results[result.AgentName] = result;
+            context.WriteScratchpad($"map:{result.AgentName}", result.Output);
+        }
+
+        // Reduce phase — synthesize mapper outputs
+        string finalOutput;
+        if (reducerTemplate is not null)
+        {
+            var reducePrompt = BuildReducePrompt(context, mapResults);
+            var reducerConfig = new SubagentConfig
+            {
+                Name = reducerTemplate.Name,
+                Type = reducerTemplate.Type,
+                Prompt = reducePrompt,
+                SystemPrompt = reducerTemplate.SystemPrompt ?? """
+                    You are a reducer agent in a map-reduce pipeline.
+                    Multiple mapper agents have independently processed different parts of the input.
+                    Your job is to merge, deduplicate, and synthesize their outputs into a
+                    single coherent result. Resolve conflicts by preferring the most detailed analysis.
+                    Organize the output logically (don't just concatenate).
+                    """,
+                MaxTurns = reducerTemplate.MaxTurns,
+                ModelId = reducerTemplate.ModelId,
+            };
+
+            var reduceResult = await executor.ExecuteAsync(
+                reducerConfig, parentSession, context, onProgress, ct).ConfigureAwait(false);
+
+            results[reducerConfig.Name] = reduceResult;
+            finalOutput = reduceResult.Output;
+        }
+        else
+        {
+            // No separate reducer — concatenate map results
+            finalOutput = string.Join("\n\n---\n\n",
+                mapResults.Select(r => $"## {r.AgentName}\n{r.Output}"));
+        }
+
+        sw.Stop();
+
+        return new TeamResult
+        {
+            Output = finalOutput,
+            Strategy = Name,
+            AgentResults = results,
+            Duration = sw.Elapsed,
+            Success = mapResults.All(r => r.Success),
+        };
+    }
+
+    private static string BuildReducePrompt(TeamContext context, AgentResult[] mapResults)
+    {
+        var parts = new List<string>
+        {
+            $"Team goal: {context.Goal}",
+            "",
+            $"{mapResults.Length} mapper agents have processed different parts of the input:",
+            "",
+        };
+
+        foreach (var result in mapResults)
+        {
+            parts.Add($"--- Mapper: {result.AgentName} (success={result.Success}) ---");
+            parts.Add(result.Output);
+            parts.Add("");
+        }
+
+        parts.Add("Merge and synthesize all mapper outputs into a single unified result.");
+        return string.Join('\n', parts);
+    }
+}

--- a/src/JD.AI.Core/Agents/Orchestration/Strategies/RelayStrategy.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/Strategies/RelayStrategy.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+
+namespace JD.AI.Core.Agents.Orchestration.Strategies;
+
+/// <summary>
+/// Relay strategy — agents process sequentially, each refining the previous output.
+/// Like a relay race where each runner adds their specialized perspective.
+/// Good for: document writing, iterative improvement, multi-perspective analysis.
+/// </summary>
+public sealed class RelayStrategy : IOrchestrationStrategy
+{
+    public string Name => "relay";
+
+    /// <summary>
+    /// Template for prompts passed to each relay agent.
+    /// Supports {previous_output} and {focus_area} placeholders.
+    /// </summary>
+    public string PassPromptTemplate { get; init; } =
+        "Refine and improve this output. Focus on {focus_area}.\n\nPrevious output:\n{previous_output}";
+
+    /// <summary>When true, stop early if an agent reports no changes needed.</summary>
+    public bool StopEarly { get; init; } = true;
+
+    public async Task<TeamResult> ExecuteAsync(
+        IReadOnlyList<SubagentConfig> agents,
+        TeamContext context,
+        ISubagentExecutor executor,
+        AgentSession parentSession,
+        Action<SubagentProgress>? onProgress = null,
+        CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var results = new Dictionary<string, AgentResult>(StringComparer.Ordinal);
+        var currentOutput = context.Goal; // First agent gets the original goal
+
+        for (var i = 0; i < agents.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var agent = agents[i];
+            var focusArea = agent.Perspective ?? agent.Name;
+
+            // Build relay prompt from template
+            var relayPrompt = PassPromptTemplate
+                .Replace("{previous_output}", currentOutput, StringComparison.Ordinal)
+                .Replace("{focus_area}", focusArea, StringComparison.Ordinal);
+
+            var relayConfig = new SubagentConfig
+            {
+                Name = agent.Name,
+                Type = agent.Type,
+                Prompt = relayPrompt,
+                SystemPrompt = agent.SystemPrompt ?? $"""
+                    You are relay agent #{i + 1} of {agents.Count} in a sequential refinement pipeline.
+                    Your focus area is: {focusArea}.
+                    Review the previous output and improve it based on your expertise.
+                    If no changes are needed, respond with exactly "[NO_CHANGES]" and nothing else.
+                    Otherwise, provide the complete improved output.
+                    """,
+                MaxTurns = agent.MaxTurns,
+                ModelId = agent.ModelId,
+                AdditionalTools = agent.AdditionalTools,
+            };
+
+            var result = await executor.ExecuteAsync(
+                relayConfig, parentSession, context, onProgress, ct).ConfigureAwait(false);
+
+            results[agent.Name] = result;
+            context.WriteScratchpad($"relay:{i}:{agent.Name}", result.Output);
+
+            // Check for early stop
+            if (StopEarly && result.Output.Contains("[NO_CHANGES]", StringComparison.OrdinalIgnoreCase))
+            {
+                context.RecordEvent(new AgentEvent(
+                    agent.Name, AgentEventType.Decision,
+                    $"Relay stopped early at agent {i + 1}/{agents.Count}: no changes needed"));
+                break;
+            }
+
+            currentOutput = result.Output;
+        }
+
+        sw.Stop();
+
+        return new TeamResult
+        {
+            Output = currentOutput,
+            Strategy = Name,
+            AgentResults = results,
+            Duration = sw.Elapsed,
+            Success = results.Values.All(r => r.Success),
+        };
+    }
+}

--- a/src/JD.AI.Core/Agents/Orchestration/Strategies/VotingStrategy.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/Strategies/VotingStrategy.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+
+namespace JD.AI.Core.Agents.Orchestration.Strategies;
+
+/// <summary>
+/// Voting strategy — N agents independently process the same input.
+/// Results are aggregated by configurable voting (majority, weighted confidence).
+/// Good for: code review consensus, classification, risk assessment.
+/// </summary>
+public sealed class VotingStrategy : IOrchestrationStrategy
+{
+    public string Name => "voting";
+
+    /// <summary>Voting method to determine the final result.</summary>
+    public VotingMethod Method { get; init; } = VotingMethod.Majority;
+
+    /// <summary>Per-agent weight multipliers (optional). Key = agent name.</summary>
+    public IReadOnlyDictionary<string, double>? Weights { get; init; }
+
+    public async Task<TeamResult> ExecuteAsync(
+        IReadOnlyList<SubagentConfig> agents,
+        TeamContext context,
+        ISubagentExecutor executor,
+        AgentSession parentSession,
+        Action<SubagentProgress>? onProgress = null,
+        CancellationToken ct = default)
+    {
+        var sw = Stopwatch.StartNew();
+        var results = new Dictionary<string, AgentResult>(StringComparer.Ordinal);
+
+        // All agents process the same goal independently (parallel)
+        var tasks = agents.Select(agent =>
+            executor.ExecuteAsync(agent, parentSession, context, onProgress, ct));
+
+        var agentResults = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        foreach (var result in agentResults)
+        {
+            results[result.AgentName] = result;
+            context.WriteScratchpad($"vote:{result.AgentName}", result.Output);
+        }
+
+        // Aggregate using a synthesizer that sees all votes
+        var aggregationPrompt = BuildAggregationPrompt(context, agentResults);
+        var aggregatorConfig = new SubagentConfig
+        {
+            Name = "vote-aggregator",
+            Type = SubagentType.General,
+            Prompt = aggregationPrompt,
+            SystemPrompt = $"""
+                You are a vote aggregation agent. You have received independent analyses from
+                {agentResults.Length} agents on the same input. Your job is to:
+                1. Identify areas of consensus (most agents agree)
+                2. Identify areas of disagreement (agents differ)
+                3. Apply {Method} voting to resolve disagreements
+                4. Produce a final synthesized result that reflects the team consensus
+                5. Note any minority opinions that are worth considering
+                Be precise and attribute conclusions to the consensus level (unanimous, majority, split).
+                """,
+            MaxTurns = 1,
+        };
+
+        var aggregation = await executor.ExecuteAsync(
+            aggregatorConfig, parentSession, context, onProgress, ct).ConfigureAwait(false);
+
+        results["vote-aggregator"] = aggregation;
+        sw.Stop();
+
+        return new TeamResult
+        {
+            Output = aggregation.Output,
+            Strategy = Name,
+            AgentResults = results,
+            Duration = sw.Elapsed,
+            Success = agentResults.All(r => r.Success),
+        };
+    }
+
+    private string BuildAggregationPrompt(TeamContext context, AgentResult[] results)
+    {
+        var parts = new List<string>
+        {
+            $"Team goal: {context.Goal}",
+            $"Voting method: {Method}",
+            "",
+            $"{results.Length} agents have independently analyzed the same input. Their responses:",
+            "",
+        };
+
+        foreach (var result in results)
+        {
+            var weight = Weights is not null &&
+                         Weights.TryGetValue(result.AgentName, out var w) ? w : 1.0;
+            parts.Add($"--- Agent: {result.AgentName} (weight={weight:F1}, success={result.Success}) ---");
+            parts.Add(result.Output);
+            parts.Add("");
+        }
+
+        parts.Add($"Apply {Method} voting to produce a unified result. Attribute confidence levels.");
+        return string.Join('\n', parts);
+    }
+}
+
+/// <summary>Method for aggregating votes.</summary>
+public enum VotingMethod
+{
+    /// <summary>Simple majority wins.</summary>
+    Majority,
+
+    /// <summary>Weighted by agent confidence/weight.</summary>
+    WeightedConfidence,
+
+    /// <summary>All agents must agree.</summary>
+    Unanimous,
+}

--- a/src/JD.AI.Core/Agents/Orchestration/TeamOrchestrator.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/TeamOrchestrator.cs
@@ -34,7 +34,7 @@ public sealed class TeamOrchestrator
         {
             return new TeamResult
             {
-                Output = $"Unknown strategy '{strategyName}'. Valid: sequential, fan-out, supervisor, debate.",
+                Output = $"Unknown strategy '{strategyName}'. Valid: sequential, fan-out, supervisor, debate, voting, relay, map-reduce.",
                 Strategy = strategyName,
                 Success = false,
             };
@@ -128,6 +128,9 @@ public sealed class TeamOrchestrator
             "FAN-OUT" or "FANOUT" or "PARALLEL" => new FanOutStrategy(),
             "SUPERVISOR" or "COORDINATOR" => new SupervisorStrategy(),
             "DEBATE" or "ADVERSARIAL" => new DebateStrategy(),
+            "VOTING" or "VOTE" or "CONSENSUS" => new VotingStrategy(),
+            "RELAY" or "REFINE" or "ITERATIVE" => new RelayStrategy(),
+            "MAP-REDUCE" or "MAPREDUCE" => new MapReduceStrategy(),
             _ => null,
         };
 }

--- a/tests/JD.AI.Tests/Orchestration/CoordinationStrategyTests.cs
+++ b/tests/JD.AI.Tests/Orchestration/CoordinationStrategyTests.cs
@@ -1,0 +1,399 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Agents.Orchestration;
+using JD.AI.Core.Agents.Orchestration.Strategies;
+using JD.AI.Core.Providers;
+using Microsoft.SemanticKernel;
+using NSubstitute;
+using Xunit;
+
+namespace JD.AI.Tests.Orchestration;
+
+public sealed class VotingStrategyTests
+{
+    private readonly ISubagentExecutor _executor = Substitute.For<ISubagentExecutor>();
+    private readonly AgentSession _session;
+
+    public VotingStrategyTests()
+    {
+        var registry = Substitute.For<IProviderRegistry>();
+        var kernel = Kernel.CreateBuilder().Build();
+        var model = new ProviderModelInfo("test", "Test", "TestProvider");
+        _session = new AgentSession(registry, kernel, model);
+    }
+
+    [Fact]
+    public void Name_ReturnsVoting()
+    {
+        var strategy = new VotingStrategy();
+        Assert.Equal("voting", strategy.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RunsAllAgentsInParallel()
+    {
+        var strategy = new VotingStrategy();
+        var context = new TeamContext("Review this code");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "reviewer-1", Prompt = "review" },
+            new() { Name = "reviewer-2", Prompt = "review" },
+            new() { Name = "reviewer-3", Prompt = "review" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Result from {name}",
+                    Success = true,
+                };
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.True(result.Success);
+        Assert.Equal("voting", result.Strategy);
+        // 3 agents + 1 aggregator = 4 results
+        Assert.Equal(4, result.AgentResults.Count);
+        Assert.Contains("reviewer-1", result.AgentResults.Keys);
+        Assert.Contains("reviewer-2", result.AgentResults.Keys);
+        Assert.Contains("reviewer-3", result.AgentResults.Keys);
+        Assert.Contains("vote-aggregator", result.AgentResults.Keys);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesVotesToScratchpad()
+    {
+        var strategy = new VotingStrategy();
+        var context = new TeamContext("Classify this");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "agent-a", Prompt = "classify" },
+            new() { Name = "agent-b", Prompt = "classify" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Vote: {name}",
+                    Success = true,
+                };
+            });
+
+        await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.Equal("Vote: agent-a", context.ReadScratchpad("vote:agent-a"));
+        Assert.Equal("Vote: agent-b", context.ReadScratchpad("vote:agent-b"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReportsFailureWhenAgentFails()
+    {
+        var strategy = new VotingStrategy();
+        var context = new TeamContext("test");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "ok-agent", Prompt = "work" },
+            new() { Name = "fail-agent", Prompt = "work" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Result from {name}",
+                    Success = !string.Equals(name, "fail-agent", StringComparison.Ordinal),
+                };
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public void DefaultVotingMethod_IsMajority()
+    {
+        var strategy = new VotingStrategy();
+        Assert.Equal(VotingMethod.Majority, strategy.Method);
+    }
+
+    [Fact]
+    public void Weights_DefaultsToNull()
+    {
+        var strategy = new VotingStrategy();
+        Assert.Null(strategy.Weights);
+    }
+}
+
+public sealed class RelayStrategyTests
+{
+    private readonly ISubagentExecutor _executor = Substitute.For<ISubagentExecutor>();
+    private readonly AgentSession _session;
+
+    public RelayStrategyTests()
+    {
+        var registry = Substitute.For<IProviderRegistry>();
+        var kernel = Kernel.CreateBuilder().Build();
+        var model = new ProviderModelInfo("test", "Test", "TestProvider");
+        _session = new AgentSession(registry, kernel, model);
+    }
+
+    [Fact]
+    public void Name_ReturnsRelay()
+    {
+        var strategy = new RelayStrategy();
+        Assert.Equal("relay", strategy.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ChainsOutputBetweenAgents()
+    {
+        var strategy = new RelayStrategy();
+        var context = new TeamContext("Write a report");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "drafter", Prompt = "draft", Perspective = "content completeness" },
+            new() { Name = "editor", Prompt = "edit", Perspective = "clarity" },
+            new() { Name = "reviewer", Prompt = "review", Perspective = "accuracy" },
+        };
+
+        var callOrder = new List<string>();
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                callOrder.Add(name);
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Refined by {name}",
+                    Success = true,
+                };
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.Equal("relay", result.Strategy);
+        Assert.True(result.Success);
+        // Output should be from the last agent
+        Assert.Equal("Refined by reviewer", result.Output);
+        // Agents should execute in order
+        Assert.Equal(["drafter", "editor", "reviewer"], callOrder);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StopsEarlyOnNoChanges()
+    {
+        var strategy = new RelayStrategy { StopEarly = true };
+        var context = new TeamContext("Perfect this");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "first", Prompt = "improve" },
+            new() { Name = "second", Prompt = "improve" },
+            new() { Name = "third", Prompt = "improve" },
+        };
+
+        var callCount = 0;
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callCount++;
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                var output = callCount == 2 ? "[NO_CHANGES]" : $"Improved by {name}";
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = output,
+                    Success = true,
+                };
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        // Should have stopped after agent 2 returned [NO_CHANGES]
+        Assert.Equal(2, callCount);
+        Assert.Equal(2, result.AgentResults.Count);
+        Assert.DoesNotContain("third", result.AgentResults.Keys);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesRelayResultsToScratchpad()
+    {
+        var strategy = new RelayStrategy();
+        var context = new TeamContext("Build it");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "builder", Prompt = "build" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(new AgentResult
+            {
+                AgentName = "builder",
+                Output = "Built result",
+                Success = true,
+            });
+
+        await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.Equal("Built result", context.ReadScratchpad("relay:0:builder"));
+    }
+}
+
+public sealed class MapReduceStrategyTests
+{
+    private readonly ISubagentExecutor _executor = Substitute.For<ISubagentExecutor>();
+    private readonly AgentSession _session;
+
+    public MapReduceStrategyTests()
+    {
+        var registry = Substitute.For<IProviderRegistry>();
+        var kernel = Kernel.CreateBuilder().Build();
+        var model = new ProviderModelInfo("test", "Test", "TestProvider");
+        _session = new AgentSession(registry, kernel, model);
+    }
+
+    [Fact]
+    public void Name_ReturnsMapReduce()
+    {
+        var strategy = new MapReduceStrategy();
+        Assert.Equal("map-reduce", strategy.Name);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RunsMappersAndReducer()
+    {
+        var strategy = new MapReduceStrategy();
+        var context = new TeamContext("Analyze files");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "mapper-1", Prompt = "analyze src/" },
+            new() { Name = "mapper-2", Prompt = "analyze tests/" },
+            new() { Name = "reducer", Prompt = "merge results" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Output from {name}",
+                    Success = true,
+                };
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.True(result.Success);
+        Assert.Equal("map-reduce", result.Strategy);
+        Assert.Equal(3, result.AgentResults.Count);
+        Assert.Contains("mapper-1", result.AgentResults.Keys);
+        Assert.Contains("mapper-2", result.AgentResults.Keys);
+        Assert.Contains("reducer", result.AgentResults.Keys);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoAgents_ReturnsFailed()
+    {
+        var strategy = new MapReduceStrategy();
+        var context = new TeamContext("nothing to do");
+
+        var result = await strategy.ExecuteAsync([], context, _executor, _session);
+
+        Assert.False(result.Success);
+        Assert.Contains("No agents", result.Output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SingleAgent_ActsAsMapper()
+    {
+        var strategy = new MapReduceStrategy();
+        var context = new TeamContext("Quick scan");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "solo", Prompt = "scan" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(new AgentResult
+            {
+                AgentName = "solo",
+                Output = "Scanned everything",
+                Success = true,
+            });
+
+        var result = await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.True(result.Success);
+        // Single agent = mapper only, output is concatenation
+        Assert.Contains("solo", result.Output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WritesMapResultsToScratchpad()
+    {
+        var strategy = new MapReduceStrategy();
+        var context = new TeamContext("Analyze");
+
+        var agents = new List<SubagentConfig>
+        {
+            new() { Name = "m1", Prompt = "analyze chunk 1" },
+            new() { Name = "reducer", Prompt = "merge" },
+        };
+
+        _executor.ExecuteAsync(Arg.Any<SubagentConfig>(), Arg.Any<AgentSession>(),
+                Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var name = callInfo.Arg<SubagentConfig>().Name;
+                return new AgentResult
+                {
+                    AgentName = name,
+                    Output = $"Result from {name}",
+                    Success = true,
+                };
+            });
+
+        await strategy.ExecuteAsync(agents, context, _executor, _session);
+
+        Assert.Equal("Result from m1", context.ReadScratchpad("map:m1"));
+    }
+
+    [Fact]
+    public void MaxParallelism_DefaultsToFour()
+    {
+        var strategy = new MapReduceStrategy();
+        Assert.Equal(4, strategy.MaxParallelism);
+    }
+}


### PR DESCRIPTION
## Summary

Adds three new coordination strategies to the multi-agent orchestration framework. Partial implementation of #28.

### New Strategies

#### 1. Voting Strategy (\oting\, \ote\, \consensus\)
N agents independently process the same input in parallel. A vote-aggregator synthesizes results using configurable voting methods:
- **Majority** (default): consensus wins
- **WeightedConfidence**: per-agent weight multipliers
- **Unanimous**: all must agree

**Use cases**: Code review consensus, risk assessment, classification

#### 2. Relay Strategy (\elay\, \efine\, \iterative\)
Sequential refinement pipeline — each agent receives the previous agent's output and improves it:
- Configurable prompt template with \{previous_output}\ and \{focus_area}\ placeholders
- Early stopping when agent returns \[NO_CHANGES]\
- Agent \Perspective\ field used as focus area

**Use cases**: Document writing, iterative code improvement, multi-perspective analysis

#### 3. Map-Reduce Strategy (\map-reduce\, \mapreduce\)
Parallel mappers with bounded concurrency, followed by a reducer:
- Configurable \MaxParallelism\ (default 4) via \SemaphoreSlim\
- Last agent in list acts as reducer; all others are mappers
- Single agent mode concatenates mapper outputs

**Use cases**: Bulk file analysis, large codebase scanning, data processing

### Strategy Registration
All three registered in \TeamOrchestrator.ResolveStrategy\ with aliases.

### Tests
16 new unit tests with mocked \ISubagentExecutor\ covering:
- Parallel execution, vote scratchpad writes, failure propagation
- Sequential chaining, early stop on [NO_CHANGES], scratchpad writes
- Mapper/reducer split, empty agents, single agent, scratchpad writes

All 1083 tests pass.

Partial #28