### PR TITLE
feat: AI-powered workflow refinement and history extraction

### DIFF
--- a/src/JD.AI.Workflows/WorkflowGenerator.cs
+++ b/src/JD.AI.Workflows/WorkflowGenerator.cs
@@ -1,3 +1,7 @@
+using System.Text.Json;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
 namespace JD.AI.Workflows;
 
 /// <summary>
@@ -141,6 +145,260 @@ public sealed class WorkflowGenerator
         }
 
         return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Refines an existing workflow using AI-powered analysis. Applies the user's
+    /// natural language feedback to add, remove, reorder, or modify steps.
+    /// Returns a new version of the workflow with the refinements applied.
+    /// </summary>
+    public async Task<WorkflowRefinementResult> RefineAsync(
+        AgentWorkflowDefinition workflow,
+        string feedback,
+        Kernel kernel,
+        CancellationToken ct = default)
+    {
+        var chat = kernel.GetRequiredService<IChatCompletionService>();
+        var history = new ChatHistory();
+
+        var emitter = new WorkflowEmitter();
+        var currentJson = emitter.Emit(workflow, WorkflowExportFormat.Json).Content;
+
+        history.AddSystemMessage(
+            """
+            You are a workflow refinement assistant. You will be given a workflow definition in JSON
+            and user feedback about changes they want. Apply the changes and return ONLY a valid JSON
+            object with this exact schema:
+            {
+              "name": "string",
+              "version": "string",
+              "description": "string",
+              "tags": ["string"],
+              "steps": [
+                {
+                  "name": "string",
+                  "kind": "Tool|Skill|Nested|Loop|Conditional",
+                  "target": "string or null",
+                  "condition": "string or null",
+                  "subSteps": []
+                }
+              ],
+              "changelog": "Brief description of what changed"
+            }
+            Increment the minor version number. Return ONLY the JSON, no markdown fences.
+            """);
+
+        history.AddUserMessage(
+            $"Current workflow:\n{currentJson}\n\nRequested changes:\n{feedback}");
+
+        var result = await chat.GetChatMessageContentAsync(history, cancellationToken: ct)
+            .ConfigureAwait(false);
+
+        var responseText = result.Content?.Trim() ?? "";
+
+        // Strip markdown code fences if present
+        if (responseText.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstNewline = responseText.IndexOf('\n');
+            var lastFence = responseText.LastIndexOf("```", StringComparison.Ordinal);
+            if (firstNewline >= 0 && lastFence > firstNewline)
+                responseText = responseText[(firstNewline + 1)..lastFence].Trim();
+        }
+
+        try
+        {
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            using var doc = JsonDocument.Parse(responseText);
+            var root = doc.RootElement;
+
+            var refined = new AgentWorkflowDefinition
+            {
+                Name = root.TryGetProperty("name", out var n) ? n.GetString() ?? workflow.Name : workflow.Name,
+                Version = root.TryGetProperty("version", out var v) ? v.GetString() ?? workflow.Version : workflow.Version,
+                Description = root.TryGetProperty("description", out var d)
+                    ? d.GetString() ?? workflow.Description
+                    : workflow.Description,
+                Tags = root.TryGetProperty("tags", out var t)
+                    ? [.. t.EnumerateArray().Select(e => e.GetString() ?? "")]
+                    : [.. workflow.Tags],
+                Steps = root.TryGetProperty("steps", out var s)
+                    ? [.. ParseSteps(s)]
+                    : [.. workflow.Steps],
+                UpdatedAt = DateTime.UtcNow,
+            };
+
+            var changelog = root.TryGetProperty("changelog", out var cl)
+                ? cl.GetString() ?? "Refined"
+                : "Refined";
+
+            return new WorkflowRefinementResult
+            {
+                Success = true,
+                Workflow = refined,
+                Changelog = changelog,
+            };
+        }
+        catch (JsonException ex)
+        {
+            return new WorkflowRefinementResult
+            {
+                Success = false,
+                Workflow = workflow,
+                Changelog = $"Failed to parse AI response: {ex.Message}",
+                RawResponse = responseText,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Extracts a workflow definition from conversation history by analyzing
+    /// the tool calls and user/assistant interactions from the last N turns.
+    /// </summary>
+    public AgentWorkflowDefinition ExtractFromHistory(
+        IReadOnlyList<ChatMessageContent> messages,
+        int turnCount = 10,
+        string? name = null)
+    {
+        var steps = new List<AgentStepDefinition>();
+        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Take the last N user messages and their responses
+        var userMessages = messages
+            .Where(m => m.Role == AuthorRole.User)
+            .TakeLast(turnCount)
+            .ToList();
+
+        var toolCalls = new List<(string Tool, string? Args)>();
+
+        // Walk through all messages in the window to find tool calls
+        var startIndex = messages.Count > 0 && userMessages.Count > 0
+            ? messages.ToList().IndexOf(userMessages[0])
+            : Math.Max(0, messages.Count - turnCount * 3);
+
+        if (startIndex < 0) startIndex = 0;
+
+        for (var i = startIndex; i < messages.Count; i++)
+        {
+            var msg = messages[i];
+
+            // Check for function call content items
+            foreach (var item in msg.Items)
+            {
+                if (item is FunctionCallContent fcc)
+                {
+                    var toolName = string.IsNullOrEmpty(fcc.PluginName)
+                        ? fcc.FunctionName
+                        : $"{fcc.PluginName}-{fcc.FunctionName}";
+                    var argsStr = fcc.Arguments is not null
+                        ? string.Join(", ", fcc.Arguments.Select(kv => $"{kv.Key}={kv.Value}"))
+                        : null;
+                    toolCalls.Add((toolName, argsStr));
+                }
+            }
+        }
+
+        // Deduplicate consecutive identical tool calls (e.g., repeated read_file)
+        string? lastTool = null;
+        var mergedCalls = new List<(string Tool, string? Args, int Count)>();
+        foreach (var (tool, args) in toolCalls)
+        {
+            if (string.Equals(tool, lastTool, StringComparison.Ordinal) && mergedCalls.Count > 0)
+            {
+                var last = mergedCalls[^1];
+                mergedCalls[^1] = (last.Tool, last.Args, last.Count + 1);
+            }
+            else
+            {
+                mergedCalls.Add((tool, args, 1));
+            }
+            lastTool = tool;
+        }
+
+        // Convert to workflow steps
+        foreach (var (tool, args, count) in mergedCalls)
+        {
+            if (count > 2)
+            {
+                // Repeated tool calls become a loop
+                var bodyStep = AgentStepDefinition.InvokeTool(
+                    DeriveToolStepName(tool),
+                    tool);
+                steps.Add(AgentStepDefinition.LoopUntil(
+                    $"Repeat {DeriveToolStepName(tool)}",
+                    "items_exhausted",
+                    [bodyStep]));
+            }
+            else
+            {
+                steps.Add(AgentStepDefinition.InvokeTool(
+                    DeriveToolStepName(tool),
+                    tool));
+            }
+
+            // Extract tags from tool names
+            if (tool.Contains("git", StringComparison.OrdinalIgnoreCase)) tags.Add("git");
+            if (tool.Contains("test", StringComparison.OrdinalIgnoreCase) ||
+                tool.Contains("build", StringComparison.OrdinalIgnoreCase)) tags.Add("build");
+            if (tool.Contains("grep", StringComparison.OrdinalIgnoreCase) ||
+                tool.Contains("glob", StringComparison.OrdinalIgnoreCase)) tags.Add("search");
+            if (tool.Contains("file", StringComparison.OrdinalIgnoreCase)) tags.Add("files");
+        }
+
+        // Build description from first user message
+        var firstUserMsg = userMessages.FirstOrDefault()?.Content ?? "Extracted workflow";
+        var description = firstUserMsg.Length > 200 ? firstUserMsg[..200] + "..." : firstUserMsg;
+
+        var workflowName = name ?? $"Extracted {DateTime.UtcNow:yyyyMMdd-HHmm}";
+
+        return new AgentWorkflowDefinition
+        {
+            Name = workflowName,
+            Version = "1.0",
+            Description = description,
+            Tags = [.. tags],
+            Steps = steps,
+        };
+    }
+
+    private static IEnumerable<AgentStepDefinition> ParseSteps(JsonElement stepsArray)
+    {
+        foreach (var stepEl in stepsArray.EnumerateArray())
+        {
+            var stepName = stepEl.TryGetProperty("name", out var sn) ? sn.GetString() ?? "" : "";
+            var kindStr = stepEl.TryGetProperty("kind", out var sk) ? sk.GetString() ?? "Tool" : "Tool";
+            var target = stepEl.TryGetProperty("target", out var st) ? st.GetString() : null;
+            var condition = stepEl.TryGetProperty("condition", out var sc) ? sc.GetString() : null;
+
+            var kind = kindStr.ToUpperInvariant() switch
+            {
+                "SKILL" => AgentStepKind.Skill,
+                "NESTED" => AgentStepKind.Nested,
+                "LOOP" => AgentStepKind.Loop,
+                "CONDITIONAL" => AgentStepKind.Conditional,
+                _ => AgentStepKind.Tool,
+            };
+
+            var subSteps = stepEl.TryGetProperty("subSteps", out var ss) && ss.ValueKind == JsonValueKind.Array
+                ? [.. ParseSteps(ss)]
+                : new List<AgentStepDefinition>();
+
+            yield return new AgentStepDefinition
+            {
+                Name = stepName,
+                Kind = kind,
+                Target = target,
+                Condition = condition,
+                SubSteps = subSteps,
+            };
+        }
+    }
+
+    private static string DeriveToolStepName(string tool)
+    {
+        // Convert "plugin-function_name" to "Function Name"
+        var parts = tool.Split('-', '_', '.');
+        return string.Join(' ', parts.Select(p =>
+            p.Length > 0 ? char.ToUpperInvariant(p[0]) + p[1..] : p));
     }
 
     private static List<AgentStepDefinition> DecomposeIntoSteps(string description)
@@ -307,4 +565,13 @@ public sealed record DryRunStep
     public string? ToolOrTarget { get; init; }
     public string Description { get; init; } = "";
     public IList<DryRunStep> SubSteps { get; init; } = new List<DryRunStep>();
+}
+
+/// <summary>Result of an AI-powered workflow refinement.</summary>
+public sealed record WorkflowRefinementResult
+{
+    public bool Success { get; init; }
+    public AgentWorkflowDefinition Workflow { get; init; } = new();
+    public string Changelog { get; init; } = "";
+    public string? RawResponse { get; init; }
 }

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -1378,8 +1378,9 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             "EXPORT" => "Usage: /workflow export <name> [json|csharp|mermaid]",
             "REPLAY" when param is not null => await ReplayWorkflowAsync(param, ct).ConfigureAwait(false),
             "REPLAY" => "Usage: /workflow replay <name> [version]",
-            "REFINE" when param is not null => RefineWorkflowInfo(param),
-            "REFINE" => "Usage: /workflow refine <name>",
+            "REFINE" when param is not null => await RefineWorkflowAsync(param, ct).ConfigureAwait(false),
+            "REFINE" => "Usage: /workflow refine <name> <feedback>  — e.g. /workflow refine my-workflow Add a validation step after step 2",
+            "FROM-HISTORY" or "FROMHISTORY" => await ExtractWorkflowFromHistoryAsync(param, ct).ConfigureAwait(false),
             "CATALOG" => await CatalogSharedWorkflowsAsync(param, ct).ConfigureAwait(false),
             "PUBLISH" when param is not null => await PublishWorkflowAsync(param, ct).ConfigureAwait(false),
             "PUBLISH" => "Usage: /workflow publish <name>",
@@ -1389,7 +1390,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             "SEARCH" => "Usage: /workflow search <query>",
             "VERSIONS" when param is not null => await ShowWorkflowVersionsAsync(param, ct).ConfigureAwait(false),
             "VERSIONS" => "Usage: /workflow versions <name>",
-            _ => "Usage: /workflow [list|show|create|compose|dry-run|export|replay|refine|catalog|publish|install|search|versions]",
+            _ => "Usage: /workflow [list|show|create|compose|dry-run|export|replay|refine|from-history|catalog|publish|install|search|versions]",
         };
     }
 
@@ -1455,9 +1456,95 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                "(Dry-run mode — pass the prompt to the agent to execute live.)";
     }
 
-    private static string RefineWorkflowInfo(string name) =>
-        $"To refine '{name}', export it (e.g. /workflow export {name} csharp), " +
-        "edit the steps, then save a new version via the agent.";
+    private async Task<string> RefineWorkflowAsync(string param, CancellationToken ct)
+    {
+        // Parse: /workflow refine <name> <feedback>
+        var parts = param.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        var name = parts[0];
+        var feedback = parts.Length > 1 ? parts[1] : null;
+
+        if (string.IsNullOrWhiteSpace(feedback))
+            return $"Usage: /workflow refine {name} <describe what to change>\n" +
+                   "Example: /workflow refine my-workflow Add a validation step after cloning";
+
+        var workflow = await _workflowCatalog!.GetAsync(name, ct: ct).ConfigureAwait(false);
+        if (workflow is null)
+            return $"Workflow '{name}' not found. Use '/workflow list' to see available workflows.";
+
+        if (_session?.Kernel is null)
+            return "No active model/kernel. Select a model first with /model.";
+
+        var generator = new WorkflowGenerator();
+        var result = await generator.RefineAsync(workflow, feedback, _session.Kernel, ct)
+            .ConfigureAwait(false);
+
+        if (!result.Success)
+        {
+            return $"⚠️ Refinement failed: {result.Changelog}\n" +
+                   (result.RawResponse is not null ? $"Raw response:\n{result.RawResponse[..Math.Min(500, result.RawResponse.Length)]}" : "");
+        }
+
+        // Save refined version
+        await _workflowCatalog.SaveAsync(result.Workflow, ct).ConfigureAwait(false);
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"✅ Refined '{result.Workflow.Name}' → v{result.Workflow.Version}");
+        sb.AppendLine($"   Changes: {result.Changelog}");
+        sb.AppendLine();
+        sb.AppendLine("Updated steps:");
+        sb.Append(FlattenSteps(result.Workflow.Steps, 1));
+        sb.AppendLine();
+        sb.AppendLine($"Use '/workflow show {result.Workflow.Name}' to view JSON, '/workflow dry-run {result.Workflow.Name}' to preview.");
+        return sb.ToString().TrimEnd();
+    }
+
+    private async Task<string> ExtractWorkflowFromHistoryAsync(string? param, CancellationToken ct)
+    {
+        // Parse: /workflow from-history [N] [--name <name>]
+        var turnCount = 10;
+        string? name = null;
+
+        if (param is not null)
+        {
+            var parts = param.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var i in Enumerable.Range(0, parts.Length))
+            {
+                if (int.TryParse(parts[i], out var n))
+                    turnCount = n;
+                else if (parts[i].Equals("--name", StringComparison.OrdinalIgnoreCase) && i + 1 < parts.Length)
+                    name = parts[i + 1];
+            }
+        }
+
+        if (_session?.History is null || _session.History.Count == 0)
+            return "No conversation history to extract from.";
+
+        var messages = _session.History.ToList().AsReadOnly();
+        var generator = new WorkflowGenerator();
+        var workflow = generator.ExtractFromHistory(messages, turnCount, name);
+
+        if (workflow.Steps.Count == 0)
+            return $"No tool calls found in the last {turnCount} turns. Try a larger number.";
+
+        await _workflowCatalog!.SaveAsync(workflow, ct).ConfigureAwait(false);
+
+        var emitter = _workflowEmitter;
+        var mermaid = emitter.Emit(workflow, WorkflowExportFormat.Mermaid);
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"✅ Extracted workflow '{workflow.Name}' ({workflow.Steps.Count} steps) from last {turnCount} turns");
+        if (workflow.Tags.Count > 0)
+            sb.AppendLine($"   Tags: {string.Join(", ", workflow.Tags)}");
+        sb.AppendLine();
+        sb.AppendLine("Steps:");
+        sb.Append(FlattenSteps(workflow.Steps, 1));
+        sb.AppendLine();
+        sb.AppendLine("Diagram:");
+        sb.AppendLine(mermaid.Content);
+        sb.AppendLine();
+        sb.AppendLine($"Use '/workflow refine {workflow.Name} <feedback>' to adjust, '/workflow dry-run {workflow.Name}' to preview.");
+        return sb.ToString().TrimEnd();
+    }
 
     // ── Shared workflow store commands ────────────────────────
 

--- a/tests/JD.AI.Tests/Workflows/WorkflowGeneratorRefinementTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowGeneratorRefinementTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+using JD.AI.Workflows;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace JD.AI.Tests.Workflows;
+
+public class WorkflowGeneratorRefinementTests
+{
+    private readonly WorkflowGenerator _generator = new();
+
+    [Fact]
+    public void Generate_ReturnsWorkflow_WithSteps()
+    {
+        var workflow = _generator.Generate("Clone the repo, run tests, deploy to staging");
+
+        workflow.Should().NotBeNull();
+        workflow.Steps.Should().NotBeEmpty();
+        workflow.Version.Should().Be("1.0");
+        workflow.Tags.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Generate_DetectsLoopPatterns()
+    {
+        var workflow = _generator.Generate("For each file in the directory, read it and analyze it");
+
+        workflow.Steps.Should().Contain(s => s.Kind == AgentStepKind.Loop);
+    }
+
+    [Fact]
+    public void Generate_DetectsConditionalPatterns()
+    {
+        var workflow = _generator.Generate("Check if tests pass, then deploy");
+
+        workflow.Steps.Should().Contain(s => s.Kind == AgentStepKind.Conditional);
+    }
+
+    [Fact]
+    public void Generate_WithCustomName_UsesProvidedName()
+    {
+        var workflow = _generator.Generate("Build and test", "my-pipeline");
+
+        workflow.Name.Should().Be("my-pipeline");
+    }
+
+    [Fact]
+    public void ExtractFromHistory_EmptyHistory_ReturnsEmptySteps()
+    {
+        var messages = new List<ChatMessageContent>().AsReadOnly();
+
+        var workflow = _generator.ExtractFromHistory(messages, 10, "test-workflow");
+
+        workflow.Name.Should().Be("test-workflow");
+        workflow.Steps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExtractFromHistory_WithToolCalls_ExtractsSteps()
+    {
+        var messages = new List<ChatMessageContent>();
+
+        // Add user message
+        messages.Add(new ChatMessageContent(AuthorRole.User, "Fix the bug"));
+
+        // Add assistant message with tool call
+        var assistantMsg = new ChatMessageContent(AuthorRole.Assistant, [
+            new FunctionCallContent("read_file", "file", "call1",
+                new KernelArguments { ["path"] = "src/Program.cs" }),
+        ]);
+        messages.Add(assistantMsg);
+
+        // Add another tool call
+        var assistantMsg2 = new ChatMessageContent(AuthorRole.Assistant, [
+            new FunctionCallContent("edit_file", "file", "call2",
+                new KernelArguments { ["path"] = "src/Program.cs" }),
+        ]);
+        messages.Add(assistantMsg2);
+
+        var workflow = _generator.ExtractFromHistory(messages.AsReadOnly(), 10, "bug-fix");
+
+        workflow.Steps.Should().HaveCountGreaterThanOrEqualTo(2);
+        workflow.Tags.Should().Contain("files");
+    }
+
+    [Fact]
+    public void ExtractFromHistory_RepeatedToolCalls_CreatesLoop()
+    {
+        var messages = new List<ChatMessageContent>();
+        messages.Add(new ChatMessageContent(AuthorRole.User, "Process all files"));
+
+        // 4 consecutive read_file calls
+        for (var i = 0; i < 4; i++)
+        {
+            messages.Add(new ChatMessageContent(AuthorRole.Assistant, [
+                new FunctionCallContent("read_file", "file", $"call{i}",
+                    new KernelArguments { ["path"] = $"file{i}.cs" }),
+            ]));
+        }
+
+        var workflow = _generator.ExtractFromHistory(messages.AsReadOnly(), 10, "batch-read");
+
+        workflow.Steps.Should().Contain(s => s.Kind == AgentStepKind.Loop);
+    }
+
+    [Fact]
+    public void ExtractFromHistory_WithName_UsesCustomName()
+    {
+        var messages = new List<ChatMessageContent>
+        {
+            new(AuthorRole.User, "Hello"),
+        };
+
+        var workflow = _generator.ExtractFromHistory(messages.AsReadOnly(), 10, "custom-name");
+
+        workflow.Name.Should().Be("custom-name");
+    }
+
+    [Fact]
+    public void ExtractFromHistory_WithoutName_GeneratesTimestampName()
+    {
+        var messages = new List<ChatMessageContent>
+        {
+            new(AuthorRole.User, "Hello"),
+        };
+
+        var workflow = _generator.ExtractFromHistory(messages.AsReadOnly(), 10);
+
+        workflow.Name.Should().StartWith("Extracted ");
+    }
+
+    [Fact]
+    public void Compose_CombinesWorkflows_IntoNested()
+    {
+        var wf1 = _generator.Generate("Build the project", "build");
+        var wf2 = _generator.Generate("Run the tests", "test");
+
+        var composite = _generator.Compose("ci-pipeline", [wf1, wf2]);
+
+        composite.Name.Should().Be("ci-pipeline");
+        composite.Steps.Should().HaveCount(2);
+        composite.Steps.Should().OnlyContain(s => s.Kind == AgentStepKind.Nested);
+    }
+
+    [Fact]
+    public void DryRun_ValidatesToolAvailability()
+    {
+        var workflow = _generator.Generate("Read the file and grep for patterns");
+        var availableTools = new HashSet<string>(StringComparer.Ordinal) { "file-read_file" };
+
+        var result = _generator.DryRun(workflow, availableTools);
+
+        result.WorkflowName.Should().NotBeEmpty();
+        result.TotalSteps.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void DryRun_WithNoTools_StillWorks()
+    {
+        var workflow = _generator.Generate("Think about the problem");
+
+        var result = _generator.DryRun(workflow);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FormatDryRun_ProducesReadableOutput()
+    {
+        var workflow = _generator.Generate("Clone, test, deploy");
+        var result = _generator.DryRun(workflow);
+
+        var output = WorkflowGenerator.FormatDryRun(result);
+
+        output.Should().Contain("Dry Run");
+        output.Should().Contain("Steps:");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining features for #27 (Enhanced /workflow — generation, refinement, and marketplace):

### New Commands
- **\/workflow refine <name> <feedback>\** — AI-powered iterative refinement. Sends current workflow JSON + natural language feedback to the LLM, parses structured JSON response, auto-increments version, saves refined workflow to catalog.
- **\/workflow from-history [N] [--name <name>]\** — Extracts workflow definitions from conversation history by analyzing tool call patterns. Detects repeated calls and creates loop steps.

### New Methods on WorkflowGenerator
- \RefineAsync(workflow, feedback, kernel)\ — LLM-powered refinement with JSON parsing
- \ExtractFromHistory(messages, turnCount, name)\ — Pattern-based extraction from ChatHistory
- \WorkflowRefinementResult\ record for structured outcomes

### Tests
13 new tests covering generation, history extraction, loop detection, conditional detection, composition, dry-run, and formatting.

### Already Implemented (prior PRs)
- \/workflow create\, \show\, \list\, \compose\, \dry-run\, \xport\, \eplay\
- \/workflow catalog\, \publish\, \install\, \search\, \ersions\ (Git-backed marketplace)

Closes #27