### PR TITLE
feat: native GitHub connector tools (issues, PRs, actions, releases)

### DIFF
--- a/src/JD.AI.Core/Tools/GitHubTools.cs
+++ b/src/JD.AI.Core/Tools/GitHubTools.cs
@@ -1,0 +1,328 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// Native GitHub tools for issue, PR, and repository workflows.
+/// Uses the gh CLI for authentication and API access.
+/// </summary>
+public sealed class GitHubTools
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    // ── Issues ──────────────────────────────────────────────
+
+    [KernelFunction("github_list_issues")]
+    [Description("List issues in a GitHub repository. Returns issue number, title, state, labels, and assignees.")]
+    public static async Task<string> ListIssuesAsync(
+        [Description("Repository in owner/repo format (e.g. 'JerrettDavis/JD.AI'). Omit to use current repo.")] string? repo = null,
+        [Description("Filter by state: open, closed, all (default: open)")] string state = "open",
+        [Description("Filter by labels (comma-separated)")] string? labels = null,
+        [Description("Maximum number of results (default: 30)")] int limit = 30)
+    {
+        var args = new StringBuilder("issue list");
+        args.Append($" --state {state}");
+        args.Append($" --limit {limit}");
+        if (!string.IsNullOrEmpty(labels)) args.Append($" --label \"{labels}\"");
+        if (!string.IsNullOrEmpty(repo)) args.Append($" --repo {repo}");
+        args.Append(" --json number,title,state,labels,assignees,createdAt,updatedAt");
+
+        return await RunGhAsync(args.ToString());
+    }
+
+    [KernelFunction("github_get_issue")]
+    [Description("Get details of a specific GitHub issue including body, comments, and metadata.")]
+    public static async Task<string> GetIssueAsync(
+        [Description("Issue number")] int number,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Include comments (default: false)")] bool includeComments = false)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        var result = await RunGhAsync(
+            $"issue view {number}{repoArg} --json number,title,body,state,labels,assignees,comments,createdAt,updatedAt,milestone,author");
+
+        if (includeComments)
+        {
+            var comments = await RunGhAsync(
+                $"issue view {number}{repoArg} --json comments --jq '.comments[] | \"---\\n**\" + .author.login + \"** (\" + .createdAt + \"):\\n\" + .body'");
+            if (!string.IsNullOrEmpty(comments) && !comments.StartsWith("Error", StringComparison.Ordinal))
+                result += "\n\n## Comments\n" + comments;
+        }
+
+        return result;
+    }
+
+    [KernelFunction("github_create_issue")]
+    [Description("Create a new GitHub issue with title, body, and optional labels/assignees.")]
+    public static async Task<string> CreateIssueAsync(
+        [Description("Issue title")] string title,
+        [Description("Issue body (markdown)")] string body,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Labels (comma-separated)")] string? labels = null,
+        [Description("Assignees (comma-separated GitHub usernames)")] string? assignees = null)
+    {
+        var args = new StringBuilder($"issue create --title \"{EscapeQuotes(title)}\" --body \"{EscapeQuotes(body)}\"");
+        if (!string.IsNullOrEmpty(labels)) args.Append($" --label \"{labels}\"");
+        if (!string.IsNullOrEmpty(assignees)) args.Append($" --assignee \"{assignees}\"");
+        if (!string.IsNullOrEmpty(repo)) args.Append($" --repo {repo}");
+
+        return await RunGhAsync(args.ToString());
+    }
+
+    [KernelFunction("github_close_issue")]
+    [Description("Close a GitHub issue with an optional comment.")]
+    public static async Task<string> CloseIssueAsync(
+        [Description("Issue number")] int number,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Optional closing comment")] string? comment = null)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        if (!string.IsNullOrEmpty(comment))
+            await RunGhAsync($"issue comment {number}{repoArg} --body \"{EscapeQuotes(comment)}\"");
+
+        return await RunGhAsync($"issue close {number}{repoArg}");
+    }
+
+    // ── Pull Requests ───────────────────────────────────────
+
+    [KernelFunction("github_list_prs")]
+    [Description("List pull requests in a GitHub repository.")]
+    public static async Task<string> ListPullRequestsAsync(
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Filter by state: open, closed, merged, all (default: open)")] string state = "open",
+        [Description("Maximum number of results (default: 30)")] int limit = 30)
+    {
+        var args = new StringBuilder("pr list");
+        args.Append($" --state {state}");
+        args.Append($" --limit {limit}");
+        if (!string.IsNullOrEmpty(repo)) args.Append($" --repo {repo}");
+        args.Append(" --json number,title,state,author,baseRefName,headRefName,labels,reviewDecision,createdAt,updatedAt");
+
+        return await RunGhAsync(args.ToString());
+    }
+
+    [KernelFunction("github_get_pr")]
+    [Description("Get details of a specific pull request including diff stats, review status, and checks.")]
+    public static async Task<string> GetPullRequestAsync(
+        [Description("Pull request number")] int number,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Include diff (default: false — can be large)")] bool includeDiff = false)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+
+        var sb = new StringBuilder();
+        var detail = await RunGhAsync(
+            $"pr view {number}{repoArg} --json number,title,body,state,author,baseRefName,headRefName,additions,deletions,changedFiles,labels,reviewDecision,reviews,statusCheckRollup,createdAt,updatedAt,mergedAt,mergedBy");
+        sb.Append(detail);
+
+        if (includeDiff)
+        {
+            var diff = await RunGhAsync($"pr diff {number}{repoArg} --name-only");
+            if (!string.IsNullOrEmpty(diff) && !diff.StartsWith("Error", StringComparison.Ordinal))
+                sb.Append("\n\n## Changed Files\n").Append(diff);
+        }
+
+        return sb.ToString();
+    }
+
+    [KernelFunction("github_create_pr")]
+    [Description("Create a new pull request from the current branch.")]
+    public static async Task<string> CreatePullRequestAsync(
+        [Description("PR title")] string title,
+        [Description("PR body (markdown)")] string body,
+        [Description("Base branch to merge into (default: main)")] string baseBranch = "main",
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Labels (comma-separated)")] string? labels = null,
+        [Description("Mark as draft (default: false)")] bool draft = false)
+    {
+        var args = new StringBuilder($"pr create --title \"{EscapeQuotes(title)}\" --body \"{EscapeQuotes(body)}\" --base {baseBranch}");
+        if (!string.IsNullOrEmpty(labels)) args.Append($" --label \"{labels}\"");
+        if (draft) args.Append(" --draft");
+        if (!string.IsNullOrEmpty(repo)) args.Append($" --repo {repo}");
+
+        return await RunGhAsync(args.ToString());
+    }
+
+    [KernelFunction("github_pr_checks")]
+    [Description("Get CI check status for a pull request.")]
+    public static async Task<string> GetPrChecksAsync(
+        [Description("Pull request number")] int number,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        return await RunGhAsync($"pr checks {number}{repoArg}");
+    }
+
+    [KernelFunction("github_merge_pr")]
+    [Description("Merge a pull request. Requires all checks to pass and review approval.")]
+    public static async Task<string> MergePullRequestAsync(
+        [Description("Pull request number")] int number,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Merge method: merge, squash, rebase (default: squash)")] string method = "squash",
+        [Description("Delete branch after merge (default: true)")] bool deleteBranch = true)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        var deleteArg = deleteBranch ? " --delete-branch" : "";
+        return await RunGhAsync($"pr merge {number}{repoArg} --{method}{deleteArg} --auto");
+    }
+
+    [KernelFunction("github_pr_review")]
+    [Description("Submit a review on a pull request (approve, request changes, or comment).")]
+    public static async Task<string> ReviewPullRequestAsync(
+        [Description("Pull request number")] int number,
+        [Description("Review action: approve, request-changes, comment")] string action,
+        [Description("Review body/comment")] string body,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        return await RunGhAsync($"pr review {number}{repoArg} --{action} --body \"{EscapeQuotes(body)}\"");
+    }
+
+    // ── Repository ──────────────────────────────────────────
+
+    [KernelFunction("github_repo_info")]
+    [Description("Get information about a GitHub repository (description, stars, language, topics).")]
+    public static async Task<string> GetRepoInfoAsync(
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        return await RunGhAsync(
+            $"repo view{repoArg} --json name,description,defaultBranchRef,stargazerCount,forkCount,primaryLanguage,repositoryTopics,isPrivate,url,createdAt,pushedAt");
+    }
+
+    [KernelFunction("github_search_issues")]
+    [Description("Search GitHub issues and PRs across repositories using query syntax.")]
+    public static async Task<string> SearchIssuesAsync(
+        [Description("Search query (GitHub search syntax, e.g. 'bug label:critical is:open')")] string query,
+        [Description("Repository in owner/repo format. Omit to search all accessible repos.")] string? repo = null,
+        [Description("Maximum results (default: 20)")] int limit = 20)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        return await RunGhAsync(
+            $"search issues \"{EscapeQuotes(query)}\"{repoArg} --limit {limit} --json repository,number,title,state,author,labels,createdAt,updatedAt");
+    }
+
+    // ── Workflows / Actions ─────────────────────────────────
+
+    [KernelFunction("github_list_runs")]
+    [Description("List recent GitHub Actions workflow runs for a repository.")]
+    public static async Task<string> ListWorkflowRunsAsync(
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Filter by branch name")] string? branch = null,
+        [Description("Filter by workflow name or filename")] string? workflow = null,
+        [Description("Maximum results (default: 10)")] int limit = 10)
+    {
+        var args = new StringBuilder("run list");
+        args.Append($" --limit {limit}");
+        if (!string.IsNullOrEmpty(branch)) args.Append($" --branch {branch}");
+        if (!string.IsNullOrEmpty(workflow)) args.Append($" --workflow \"{workflow}\"");
+        if (!string.IsNullOrEmpty(repo)) args.Append($" --repo {repo}");
+        args.Append(" --json databaseId,displayTitle,status,conclusion,headBranch,event,createdAt,updatedAt,url");
+
+        return await RunGhAsync(args.ToString());
+    }
+
+    [KernelFunction("github_run_details")]
+    [Description("Get details and job logs for a specific GitHub Actions run.")]
+    public static async Task<string> GetRunDetailsAsync(
+        [Description("Workflow run ID")] long runId,
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Show failed job logs (default: true)")] bool showLogs = true)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        var sb = new StringBuilder();
+
+        var detail = await RunGhAsync($"run view {runId}{repoArg} --json databaseId,displayTitle,status,conclusion,jobs,headBranch,event,createdAt,updatedAt,url");
+        sb.Append(detail);
+
+        if (showLogs)
+        {
+            var logs = await RunGhAsync($"run view {runId}{repoArg} --log-failed");
+            if (!string.IsNullOrEmpty(logs) && !logs.StartsWith("Error", StringComparison.Ordinal))
+            {
+                // Truncate logs to avoid overwhelming the context
+                const int maxLogLength = 8000;
+                if (logs.Length > maxLogLength)
+                    logs = logs[..maxLogLength] + $"\n\n... (truncated, {logs.Length - maxLogLength} chars omitted)";
+                sb.Append("\n\n## Failed Job Logs\n```\n").Append(logs).Append("\n```");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    // ── Releases ────────────────────────────────────────────
+
+    [KernelFunction("github_list_releases")]
+    [Description("List releases for a GitHub repository.")]
+    public static async Task<string> ListReleasesAsync(
+        [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
+        [Description("Maximum results (default: 10)")] int limit = 10)
+    {
+        var repoArg = !string.IsNullOrEmpty(repo) ? $" --repo {repo}" : "";
+        return await RunGhAsync($"release list{repoArg} --limit {limit}");
+    }
+
+    // ── Auth Status ─────────────────────────────────────────
+
+    [KernelFunction("github_auth_status")]
+    [Description("Check GitHub CLI authentication status and available scopes.")]
+    public static async Task<string> GetAuthStatusAsync()
+    {
+        return await RunGhAsync("auth status");
+    }
+
+    // ── Internal helpers ────────────────────────────────────
+
+    private static async Task<string> RunGhAsync(string arguments)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null)
+                return "Error: Failed to start gh CLI. Ensure GitHub CLI is installed.";
+
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+
+            var completed = process.WaitForExit((int)DefaultTimeout.TotalMilliseconds);
+            if (!completed)
+            {
+                process.Kill(entireProcessTree: true);
+                return "Error: Command timed out after 30 seconds.";
+            }
+
+            var output = await outputTask;
+            var error = await errorTask;
+
+            if (process.ExitCode != 0)
+            {
+                return !string.IsNullOrEmpty(error)
+                    ? $"Error (exit {process.ExitCode}): {error.Trim()}"
+                    : $"Error (exit {process.ExitCode}): {output.Trim()}";
+            }
+
+            return string.IsNullOrWhiteSpace(output) ? "(no output)" : output.Trim();
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    private static string EscapeQuotes(string input)
+        => input.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/JD.AI/Agent/ToolConfirmationFilter.cs
+++ b/src/JD.AI/Agent/ToolConfirmationFilter.cs
@@ -51,6 +51,19 @@ public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
             ["session_status"] = SafetyTier.AutoApprove,
             ["agents_list"] = SafetyTier.AutoApprove,
 
+            // GitHub tools — read-only ops auto-approve
+            ["github_list_issues"] = SafetyTier.AutoApprove,
+            ["github_get_issue"] = SafetyTier.AutoApprove,
+            ["github_list_prs"] = SafetyTier.AutoApprove,
+            ["github_get_pr"] = SafetyTier.AutoApprove,
+            ["github_pr_checks"] = SafetyTier.AutoApprove,
+            ["github_repo_info"] = SafetyTier.AutoApprove,
+            ["github_search_issues"] = SafetyTier.AutoApprove,
+            ["github_list_runs"] = SafetyTier.AutoApprove,
+            ["github_run_details"] = SafetyTier.AutoApprove,
+            ["github_list_releases"] = SafetyTier.AutoApprove,
+            ["github_auth_status"] = SafetyTier.AutoApprove,
+
             // Write ops — confirm once per session
             ["write_file"] = SafetyTier.ConfirmOnce,
             ["edit_file"] = SafetyTier.ConfirmOnce,
@@ -72,6 +85,13 @@ public sealed class ToolConfirmationFilter : IAutoFunctionInvocationFilter
             ["apply_patch"] = SafetyTier.ConfirmOnce,
             ["batch_edit_files"] = SafetyTier.ConfirmOnce,
             ["reset_usage"] = SafetyTier.ConfirmOnce,
+
+            // GitHub tools — write ops confirm once
+            ["github_create_issue"] = SafetyTier.ConfirmOnce,
+            ["github_close_issue"] = SafetyTier.ConfirmOnce,
+            ["github_create_pr"] = SafetyTier.ConfirmOnce,
+            ["github_merge_pr"] = SafetyTier.ConfirmOnce,
+            ["github_pr_review"] = SafetyTier.ConfirmOnce,
 
             // Dangerous — always confirm
             ["run_command"] = SafetyTier.AlwaysConfirm,

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -540,6 +540,7 @@ kernel.Plugins.AddFromType<FileTools>("file");
 kernel.Plugins.AddFromType<SearchTools>("search");
 kernel.Plugins.AddFromType<ShellTools>("shell");
 kernel.Plugins.AddFromType<GitTools>("git");
+kernel.Plugins.AddFromType<GitHubTools>("github");
 kernel.Plugins.AddFromType<WebTools>("web");
 kernel.Plugins.AddFromType<ThinkTools>("think");
 kernel.Plugins.AddFromType<EnvironmentTools>("environment");

--- a/tests/JD.AI.Tests/GitHubToolsTests.cs
+++ b/tests/JD.AI.Tests/GitHubToolsTests.cs
@@ -1,0 +1,196 @@
+using FluentAssertions;
+using JD.AI.Core.Tools;
+using Xunit;
+
+namespace JD.AI.Tests;
+
+/// <summary>
+/// Tests for GitHubTools — focuses on argument construction and error handling.
+/// Actual gh CLI calls are integration tests (require auth).
+/// </summary>
+public sealed class GitHubToolsTests
+{
+    // ── Issues ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListIssues_NoGhCli_ReturnsError()
+    {
+        // If gh is not installed or auth fails, we get an error message
+        var result = await GitHubTools.ListIssuesAsync("nonexistent-owner/nonexistent-repo");
+
+        // Either returns data (if gh is installed) or an error
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetIssue_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.GetIssueAsync(999999, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        // Should contain "Error" since repo doesn't exist
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task CreateIssue_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.CreateIssueAsync(
+            "Test Issue", "Test body", "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task CloseIssue_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.CloseIssueAsync(999999, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    // ── Pull Requests ───────────────────────────────────────
+
+    [Fact]
+    public async Task ListPrs_NoGhCli_ReturnsResult()
+    {
+        var result = await GitHubTools.ListPullRequestsAsync("nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetPr_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.GetPullRequestAsync(999999, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task PrChecks_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.GetPrChecksAsync(999999, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task MergePr_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.MergePullRequestAsync(999999, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task ReviewPr_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.ReviewPullRequestAsync(
+            999999, "approve", "Looks good", "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    // ── Repository ──────────────────────────────────────────
+
+    [Fact]
+    public async Task RepoInfo_InvalidRepo_ReturnsError()
+    {
+        var result = await GitHubTools.GetRepoInfoAsync("nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    [Fact]
+    public async Task SearchIssues_ReturnsResult()
+    {
+        var result = await GitHubTools.SearchIssuesAsync("test", "nonexistent-owner/nonexistent-repo");
+
+        // May return empty results or error — both valid
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    // ── Workflows ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ListRuns_InvalidRepo_ReturnsResult()
+    {
+        var result = await GitHubTools.ListWorkflowRunsAsync("nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task RunDetails_InvalidId_ReturnsError()
+    {
+        var result = await GitHubTools.GetRunDetailsAsync(0, "nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("Error");
+    }
+
+    // ── Releases ────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListReleases_InvalidRepo_ReturnsResult()
+    {
+        var result = await GitHubTools.ListReleasesAsync("nonexistent-owner/nonexistent-repo");
+
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    // ── Auth ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AuthStatus_ReturnsResult()
+    {
+        var result = await GitHubTools.GetAuthStatusAsync();
+
+        // Returns auth info or error if not authenticated
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    // ── Integration Tests (real repo — only when gh is authenticated) ───
+
+    [Fact]
+    public async Task ListIssues_RealRepo_ReturnsJson()
+    {
+        var result = await GitHubTools.ListIssuesAsync("JerrettDavis/JD.AI");
+
+        // If gh is authenticated, we should get JSON array
+        if (!result.StartsWith("Error", StringComparison.Ordinal))
+        {
+            result.Should().StartWith("[");
+        }
+    }
+
+    [Fact]
+    public async Task ListPrs_RealRepo_ReturnsJson()
+    {
+        var result = await GitHubTools.ListPullRequestsAsync("JerrettDavis/JD.AI");
+
+        if (!result.StartsWith("Error", StringComparison.Ordinal))
+        {
+            result.Should().StartWith("[");
+        }
+    }
+
+    [Fact]
+    public async Task RepoInfo_RealRepo_ReturnsInfo()
+    {
+        var result = await GitHubTools.GetRepoInfoAsync("JerrettDavis/JD.AI");
+
+        if (!result.StartsWith("Error", StringComparison.Ordinal))
+        {
+            result.Should().Contain("JD.AI");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds 16 native KernelFunction tools for GitHub workflows, replacing the need for MCP-backed GitHub integrations.

### Tools Added

| Category | Tool | Description | Safety |
|----------|------|-------------|--------|
| Issues | \github_list_issues\ | List repo issues with filters | AutoApprove |
| Issues | \github_get_issue\ | Get issue details + comments | AutoApprove |
| Issues | \github_create_issue\ | Create new issue | ConfirmOnce |
| Issues | \github_close_issue\ | Close issue with optional comment | ConfirmOnce |
| PRs | \github_list_prs\ | List pull requests | AutoApprove |
| PRs | \github_get_pr\ | Get PR details + diff stats | AutoApprove |
| PRs | \github_create_pr\ | Create PR from current branch | ConfirmOnce |
| PRs | \github_merge_pr\ | Merge PR (squash/merge/rebase) | ConfirmOnce |
| PRs | \github_pr_review\ | Submit review (approve/request changes) | ConfirmOnce |
| PRs | \github_pr_checks\ | Get CI check status | AutoApprove |
| Repo | \github_repo_info\ | Get repo metadata | AutoApprove |
| Search | \github_search_issues\ | Search across repos | AutoApprove |
| CI | \github_list_runs\ | List workflow runs | AutoApprove |
| CI | \github_run_details\ | Get run details + failed logs | AutoApprove |
| Releases | \github_list_releases\ | List releases | AutoApprove |
| Auth | \github_auth_status\ | Check gh auth status | AutoApprove |

### Architecture
- Uses \gh\ CLI for authentication (no token management needed)
- 30s timeout with process tree kill on timeout
- Failed log output truncated to 8k chars to protect context window
- All tools return structured JSON where available

### Tests
18 unit/integration tests covering error handling and real-repo queries.

Refs #78