### PR TITLE
fix(foundry): normalize JSON Schema type arrays for Foundry Local compatibility

### DIFF
--- a/src/JD.AI.Core/Providers/FoundryLocalDetector.cs
+++ b/src/JD.AI.Core/Providers/FoundryLocalDetector.cs
@@ -47,8 +47,23 @@ public sealed partial class FoundryLocalDetector : IProviderDetector
                 .Select(m =>
                 {
                     var name = m.Id ?? "unknown";
-                    var caps = ModelCapabilityHeuristics.InferFromName(name);
-                    return new ProviderModelInfo(name, name, ProviderName, Capabilities: caps);
+
+                    // Prefer metadata from Foundry's /v1/models response over heuristics
+                    var caps = ModelCapabilities.Chat;
+                    if (m.ToolCalling == true)
+                        caps |= ModelCapabilities.ToolCalling;
+                    if (m.Vision == true)
+                        caps |= ModelCapabilities.Vision;
+
+                    // Fall back to heuristics only when Foundry doesn't report capabilities
+                    if (m.ToolCalling is null && m.Vision is null)
+                        caps = ModelCapabilityHeuristics.InferFromName(name);
+
+                    return new ProviderModelInfo(
+                        name, name, ProviderName,
+                        Capabilities: caps,
+                        ContextWindowTokens: m.MaxInputTokens ?? 128_000,
+                        MaxOutputTokens: m.MaxOutputTokens ?? 4_096);
                 })
                 .ToList();
 
@@ -74,18 +89,100 @@ public sealed partial class FoundryLocalDetector : IProviderDetector
 
         var builder = Kernel.CreateBuilder();
 
+        // Foundry Local rejects JSON Schema type arrays (e.g. ["string","null"])
+        // that SK emits for nullable C# parameters. The handler normalizes them
+        // to simple strings before forwarding the request.
+        var handler = new FoundrySchemaFixupHandler();
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri($"{endpoint}/v1/"),
+            Timeout = TimeSpan.FromMinutes(10),
+        };
+
 #pragma warning disable SKEXP0010 // OpenAI connector experimental
         builder.AddOpenAIChatCompletion(
             modelId: model.Id,
             apiKey: "foundry",
-            httpClient: new HttpClient
-            {
-                BaseAddress = new Uri($"{endpoint}/v1/"),
-                Timeout = TimeSpan.FromMinutes(10),
-            });
+            httpClient: httpClient);
 #pragma warning restore SKEXP0010
 
         return builder.Build();
+    }
+
+    /// <summary>
+    /// Normalizes tool parameter schemas so Foundry Local can parse them.
+    /// Foundry Local expects <c>"type": "string"</c> but SK emits
+    /// <c>"type": ["string", "null"]</c> for nullable parameters.
+    /// </summary>
+    internal sealed class FoundrySchemaFixupHandler : DelegatingHandler
+    {
+        public FoundrySchemaFixupHandler() : base(new HttpClientHandler()) { }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.Content != null &&
+                request.RequestUri?.AbsolutePath.EndsWith("chat/completions", StringComparison.Ordinal) == true)
+            {
+                var body = await request.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+                using var doc = System.Text.Json.JsonDocument.Parse(body);
+                if (doc.RootElement.TryGetProperty("tools", out _))
+                {
+                    var node = System.Text.Json.Nodes.JsonNode.Parse(body)!;
+                    if (node["tools"] is System.Text.Json.Nodes.JsonArray tools)
+                    {
+                        foreach (var tool in tools)
+                        {
+                            var parameters = tool?["function"]?["parameters"];
+                            if (parameters != null)
+                                NormalizeTypeArrays(parameters);
+                        }
+                    }
+
+                    var fixedBody = node.ToJsonString();
+                    request.Content = new StringContent(
+                        fixedBody, System.Text.Encoding.UTF8, "application/json");
+                }
+            }
+
+            return await base.SendAsync(request, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Recursively finds <c>"type": ["string", "null"]</c> and replaces with
+        /// <c>"type": "string"</c> (first non-null element).
+        /// </summary>
+        internal static void NormalizeTypeArrays(System.Text.Json.Nodes.JsonNode node)
+        {
+            if (node is not System.Text.Json.Nodes.JsonObject obj)
+                return;
+
+            if (obj["type"] is System.Text.Json.Nodes.JsonArray typeArr && typeArr.Count > 0)
+            {
+                // Pick the first non-null type
+                var primary = typeArr
+                    .Select(t => t?.GetValue<string>())
+                    .FirstOrDefault(t => !string.Equals(t, "null", StringComparison.Ordinal));
+                obj["type"] = primary ?? "string";
+            }
+
+            // Recurse into properties
+            if (obj["properties"] is System.Text.Json.Nodes.JsonObject props)
+            {
+                foreach (var (_, value) in props)
+                {
+                    if (value != null)
+                        NormalizeTypeArrays(value);
+                }
+            }
+
+            // Recurse into items (for array types)
+            if (obj["items"] is System.Text.Json.Nodes.JsonObject items)
+            {
+                NormalizeTypeArrays(items);
+            }
+        }
     }
 
     /// <summary>
@@ -253,5 +350,13 @@ public sealed partial class FoundryLocalDetector : IProviderDetector
 
     private sealed record FoundryModel(
         [property: JsonPropertyName("id")]
-        string? Id);
+        string? Id,
+        [property: JsonPropertyName("toolCalling")]
+        bool? ToolCalling = null,
+        [property: JsonPropertyName("vision")]
+        bool? Vision = null,
+        [property: JsonPropertyName("maxInputTokens")]
+        int? MaxInputTokens = null,
+        [property: JsonPropertyName("maxOutputTokens")]
+        int? MaxOutputTokens = null);
 }

--- a/tests/JD.AI.Tests/FoundryLocalDetectorTests.cs
+++ b/tests/JD.AI.Tests/FoundryLocalDetectorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using JD.AI.Core.Providers;
 using Xunit;
 
@@ -24,5 +25,67 @@ public sealed class FoundryLocalDetectorTests
         // but the call should always succeed without throwing
         Assert.NotNull(result);
         Assert.Equal("Foundry Local", result.Name);
+    }
+
+    // ── Schema fixup (Foundry Local rejects type arrays) ─────────
+
+    [Fact]
+    public void NormalizeTypeArrays_ConvertsArrayToString()
+    {
+        // Foundry Local rejects ["integer", "null"] — must become "integer"
+        var node = JsonNode.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "startLine": { "type": ["integer", "null"] },
+                    "path": { "type": "string" }
+                }
+            }
+            """)!;
+
+        FoundryLocalDetector.FoundrySchemaFixupHandler.NormalizeTypeArrays(node);
+
+        Assert.Equal("integer", node["properties"]!["startLine"]!["type"]!.GetValue<string>());
+        Assert.Equal("string", node["properties"]!["path"]!["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void NormalizeTypeArrays_HandlesNestedItems()
+    {
+        var node = JsonNode.Parse("""
+            {
+                "type": "object",
+                "properties": {
+                    "tags": {
+                        "type": "array",
+                        "items": { "type": ["string", "null"] }
+                    }
+                }
+            }
+            """)!;
+
+        FoundryLocalDetector.FoundrySchemaFixupHandler.NormalizeTypeArrays(node);
+
+        Assert.Equal("string", node["properties"]!["tags"]!["items"]!["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void NormalizeTypeArrays_LeavesPlainTypesAlone()
+    {
+        var node = JsonNode.Parse("""{ "type": "string" }""")!;
+
+        FoundryLocalDetector.FoundrySchemaFixupHandler.NormalizeTypeArrays(node);
+
+        Assert.Equal("string", node["type"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void NormalizeTypeArrays_NullOnlyArrayDefaultsToString()
+    {
+        var node = JsonNode.Parse("""{ "type": ["null"] }""")!;
+
+        FoundryLocalDetector.FoundrySchemaFixupHandler.NormalizeTypeArrays(node);
+
+        Assert.Equal("string", node["type"]!.GetValue<string>());
     }
 }


### PR DESCRIPTION
Foundry Local rejects type arrays like ["string", "null"] that SK emits for nullable C# parameters, returning a 500 with:
  [json.exception.type_error.302] type must be string, but is array

Add FoundrySchemaFixupHandler that normalizes type arrays to simple strings before forwarding requests. Also parse rich model metadata (toolCalling, vision, maxInputTokens, maxOutputTokens) from Foundry's /v1/models endpoint instead of relying solely on name heuristics.
