### PR TITLE
refactor: attribute-driven tool registration (Tier 3d)

### DIFF
--- a/src/JD.AI.Core/Tools/BatchEditTools.cs
+++ b/src/JD.AI.Core/Tools/BatchEditTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,9 +9,11 @@ namespace JD.AI.Core.Tools;
 /// Tool for applying multiple edits to one or more files in a single atomic operation.
 /// If any edit fails validation, no files are modified.
 /// </summary>
+[ToolPlugin("batchEdit")]
 public sealed class BatchEditTools
 {
     [KernelFunction("batch_edit_files")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description(
         "Apply multiple text replacements across one or more files atomically. " +
         "All edits are validated first — if any oldText is not found, no files are modified. " +

--- a/src/JD.AI.Core/Tools/BenchmarkTools.cs
+++ b/src/JD.AI.Core/Tools/BenchmarkTools.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -11,6 +12,7 @@ namespace JD.AI.Core.Tools;
 /// Parity benchmark harness for evaluating JD.AI capability coverage
 /// against target surfaces (OpenClaw, Claude Code, Copilot CLI, Codex CLI).
 /// </summary>
+[ToolPlugin("benchmark", RequiresInjection = true)]
 public sealed class BenchmarkTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -116,6 +118,7 @@ public sealed class BenchmarkTools
     // ── Benchmark Tools ─────────────────────────────────────
 
     [KernelFunction("benchmark_scorecard")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a parity scorecard comparing current JD.AI capabilities against the canonical registry. Shows coverage percentage and gaps.")]
     public string GenerateScorecard()
     {
@@ -179,6 +182,7 @@ public sealed class BenchmarkTools
     }
 
     [KernelFunction("benchmark_run")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Run a quick smoke test of available tools by invoking read-only tools and measuring response times.")]
     public async Task<string> RunSmokeBenchmark()
     {
@@ -245,6 +249,7 @@ public sealed class BenchmarkTools
     }
 
     [KernelFunction("benchmark_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export the full capability registry as JSON for CI integration. Includes coverage status for each canonical capability.")]
     public string ExportRegistry()
     {
@@ -275,6 +280,7 @@ public sealed class BenchmarkTools
     }
 
     [KernelFunction("benchmark_regression")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check for capability regressions by comparing current state against a baseline JSON. Returns any capabilities that were covered but are now missing.")]
     public static string CheckRegression(
         [Description("Baseline JSON from a previous benchmark_export")] string baselineJson)

--- a/src/JD.AI.Core/Tools/BrowserTools.cs
+++ b/src/JD.AI.Core/Tools/BrowserTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Browser automation tools for web interaction, navigation, and capture.
 /// Uses system browser for simple ops and headless Chrome/Edge for advanced ops.
 /// </summary>
+[ToolPlugin("browser")]
 public sealed class BrowserTools
 {
     private static readonly string[] BrowserPaths = OperatingSystem.IsWindows()
@@ -23,6 +25,7 @@ public sealed class BrowserTools
     // ── Status ──────────────────────────────────────────────
 
     [KernelFunction("browser_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check browser availability and capabilities. Reports which browsers are installed and headless support.")]
     public static string GetBrowserStatus()
     {
@@ -60,6 +63,7 @@ public sealed class BrowserTools
     // ── Open ────────────────────────────────────────────────
 
     [KernelFunction("browser_open")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Open a URL in the user's default browser. Returns immediately after launching.")]
     public static string OpenInBrowser(
         [Description("The URL to open (e.g. https://github.com)")] string url)
@@ -89,6 +93,7 @@ public sealed class BrowserTools
     // ── Screenshot ──────────────────────────────────────────
 
     [KernelFunction("browser_screenshot")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Take a headless screenshot of a web page. Returns the path to the saved PNG file.")]
     public static async Task<string> ScreenshotAsync(
         [Description("URL to capture")] string url,
@@ -126,6 +131,7 @@ public sealed class BrowserTools
     // ── PDF ─────────────────────────────────────────────────
 
     [KernelFunction("browser_pdf")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Capture a web page as PDF using headless browser. Returns the path to the saved PDF.")]
     public static async Task<string> CapturePdfAsync(
         [Description("URL to capture")] string url,
@@ -160,6 +166,7 @@ public sealed class BrowserTools
     // ── Content extraction ──────────────────────────────────
 
     [KernelFunction("browser_content")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Extract text content from a web page using headless browser and dump-dom. Returns the HTML.")]
     public static async Task<string> GetContentAsync(
         [Description("URL to extract content from")] string url,
@@ -191,6 +198,7 @@ public sealed class BrowserTools
     // ── Console output ──────────────────────────────────────
 
     [KernelFunction("browser_console")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Run a URL in headless mode and capture JavaScript console output for debugging.")]
     public static async Task<string> GetConsoleOutputAsync(
         [Description("URL to load")] string url,

--- a/src/JD.AI.Core/Tools/CapabilityTools.cs
+++ b/src/JD.AI.Core/Tools/CapabilityTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,6 +10,7 @@ namespace JD.AI.Core.Tools;
 /// Self-introspection and capability discovery tools.
 /// Enables the agent to understand its own tools, analyze usage, and suggest improvements.
 /// </summary>
+[ToolPlugin("capabilities", RequiresInjection = true)]
 public sealed class CapabilityTools
 {
     private readonly Kernel _kernel;
@@ -32,6 +34,7 @@ public sealed class CapabilityTools
     // ── Discovery ───────────────────────────────────────────
 
     [KernelFunction("capability_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all registered tools grouped by plugin with descriptions. Use this to understand what tools are available.")]
     public string ListCapabilities(
         [Description("Optional plugin name to filter (e.g. 'file', 'git'). Omit for all.")] string? plugin = null)
@@ -67,6 +70,7 @@ public sealed class CapabilityTools
     }
 
     [KernelFunction("capability_detail")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get detailed information about a specific tool including parameters, descriptions, and return type.")]
     public string GetToolDetail(
         [Description("Tool name (e.g. 'read_file', 'git_commit')")] string toolName)
@@ -125,6 +129,7 @@ public sealed class CapabilityTools
     // ── Usage Analysis ──────────────────────────────────────
 
     [KernelFunction("capability_usage")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Analyze tool usage patterns in the current session. Shows which tools are used most and which are unused.")]
     public string AnalyzeUsage()
     {
@@ -186,6 +191,7 @@ public sealed class CapabilityTools
     // ── Gap Analysis ────────────────────────────────────────
 
     [KernelFunction("capability_gaps")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Identify missing capability categories compared to common AI agent patterns. Suggests areas for improvement.")]
     public string AnalyzeGaps()
     {
@@ -253,6 +259,7 @@ public sealed class CapabilityTools
     // ── Scaffold ────────────────────────────────────────────
 
     [KernelFunction("capability_scaffold")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a code template for a new JD.AI tool. Produces a .cs file with KernelFunction stubs.")]
     public static string ScaffoldTool(
         [Description("Tool class name (e.g. 'WeatherTools')")] string className,

--- a/src/JD.AI.Core/Tools/ChannelOpsTools.cs
+++ b/src/JD.AI.Core/Tools/ChannelOpsTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Channels;
 using Microsoft.SemanticKernel;
 
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Operational tools for messaging channels — list, status, send, and read.
 /// Requires an <see cref="IChannelRegistry"/> for channel access.
 /// </summary>
+[ToolPlugin("channels", RequiresInjection = true)]
 public sealed class ChannelOpsTools
 {
     private readonly IChannelRegistry _registry;
@@ -20,6 +22,7 @@ public sealed class ChannelOpsTools
     }
 
     [KernelFunction("channel_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all registered messaging channels and their connection status.")]
     public string ListChannels()
     {
@@ -43,6 +46,7 @@ public sealed class ChannelOpsTools
     }
 
     [KernelFunction("channel_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get detailed status of a specific messaging channel.")]
     public string GetChannelStatus(
         [Description("Channel type identifier (e.g. 'discord', 'slack', 'signal', 'web')")] string channelType)
@@ -61,6 +65,7 @@ public sealed class ChannelOpsTools
     }
 
     [KernelFunction("channel_send")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Send a message through a specific channel to a conversation or thread.")]
     public async Task<string> SendMessageAsync(
         [Description("Channel type (e.g. 'discord', 'slack', 'signal', 'web')")] string channelType,
@@ -89,6 +94,7 @@ public sealed class ChannelOpsTools
     }
 
     [KernelFunction("channel_connect")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Connect a disconnected channel adapter.")]
     public async Task<string> ConnectChannelAsync(
         [Description("Channel type to connect (e.g. 'discord', 'slack')")] string channelType)
@@ -112,6 +118,7 @@ public sealed class ChannelOpsTools
     }
 
     [KernelFunction("channel_disconnect")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Disconnect a channel adapter gracefully.")]
     public async Task<string> DisconnectChannelAsync(
         [Description("Channel type to disconnect")] string channelType)

--- a/src/JD.AI.Core/Tools/ClipboardTools.cs
+++ b/src/JD.AI.Core/Tools/ClipboardTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,9 +10,11 @@ namespace JD.AI.Core.Tools;
 /// Tools for reading from and writing to the system clipboard.
 /// Uses platform-specific commands (pbcopy/pbpaste, xclip, clip.exe/PowerShell).
 /// </summary>
+[ToolPlugin("clipboard")]
 public sealed class ClipboardTools
 {
     [KernelFunction("read_clipboard")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Read the current text content from the system clipboard.")]
     public static async Task<string> ReadClipboardAsync()
     {
@@ -36,6 +39,7 @@ public sealed class ClipboardTools
     }
 
     [KernelFunction("write_clipboard")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Write text to the system clipboard.")]
     public static async Task<string> WriteClipboardAsync(
         [Description("Text to write to the clipboard")] string text)

--- a/src/JD.AI.Core/Tools/DiffTools.cs
+++ b/src/JD.AI.Core/Tools/DiffTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,9 +9,11 @@ namespace JD.AI.Core.Tools;
 /// Tools for creating and applying unified diff patches.
 /// Enables structured multi-location file edits via standard patch format.
 /// </summary>
+[ToolPlugin("diff")]
 public sealed class DiffTools
 {
     [KernelFunction("create_patch")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description(
         "Create a unified diff patch from a list of file edits. Each edit specifies " +
         "a file path, the old text to find, and the new text to replace it with. " +
@@ -59,6 +62,7 @@ public sealed class DiffTools
     }
 
     [KernelFunction("apply_patch")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description(
         "Apply a set of text replacements to files. Each edit specifies a file path, " +
         "old text to find, and new text to replace it with. All edits are applied atomically — " +

--- a/src/JD.AI.Core/Tools/EncodingCryptoTools.cs
+++ b/src/JD.AI.Core/Tools/EncodingCryptoTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -11,6 +12,7 @@ namespace JD.AI.Core.Tools;
 /// Encoding, decoding, hashing, and cryptographic utility tools
 /// for common developer operations.
 /// </summary>
+[ToolPlugin("encoding")]
 public sealed class EncodingCryptoTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -18,6 +20,7 @@ public sealed class EncodingCryptoTools
     // ── Base64 ──────────────────────────────────────────────
 
     [KernelFunction("encode_base64")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Encode text to Base64. Useful for encoding credentials, binary data, or payloads.")]
     public static string EncodeBase64(
         [Description("The text to encode")] string text,
@@ -38,6 +41,7 @@ public sealed class EncodingCryptoTools
     }
 
     [KernelFunction("decode_base64")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Decode a Base64-encoded string back to plain text.")]
     public static string DecodeBase64(
         [Description("The Base64 string to decode")] string encoded)
@@ -67,6 +71,7 @@ public sealed class EncodingCryptoTools
     // ── URL Encoding ────────────────────────────────────────
 
     [KernelFunction("encode_url")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("URL-encode a string for safe use in URLs and query parameters.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Returns markdown-formatted text, not a URI")]
     public static string EncodeUrl(
@@ -77,6 +82,7 @@ public sealed class EncodingCryptoTools
     }
 
     [KernelFunction("decode_url")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Decode a URL-encoded string back to plain text.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "Returns markdown-formatted text, not a URI")]
     public static string DecodeUrl(
@@ -96,6 +102,7 @@ public sealed class EncodingCryptoTools
     // ── JWT Decode ──────────────────────────────────────────
 
     [KernelFunction("decode_jwt")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Decode a JWT token to inspect its header and payload. WARNING: This does NOT verify the signature — use only for inspection/debugging.")]
     public static string DecodeJwt(
         [Description("The JWT token string")] string token)
@@ -183,6 +190,7 @@ public sealed class EncodingCryptoTools
     // ── Hashing ─────────────────────────────────────────────
 
     [KernelFunction("hash_compute")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Compute a cryptographic hash of the input text. Supports SHA256 (default), SHA512, SHA384, SHA1, and MD5.")]
     public static string ComputeHash(
         [Description("The text to hash")] string text,
@@ -236,6 +244,7 @@ public sealed class EncodingCryptoTools
     // ── GUID Generator ──────────────────────────────────────
 
     [KernelFunction("generate_guid")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate one or more GUIDs/UUIDs (v4). Useful for creating unique identifiers, correlation IDs, or test data.")]
     public static string GenerateGuid(
         [Description("Number of GUIDs to generate (default: 1, max: 20)")] int count = 1)

--- a/src/JD.AI.Core/Tools/EnvironmentTools.cs
+++ b/src/JD.AI.Core/Tools/EnvironmentTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,9 +10,11 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Tools for inspecting the runtime environment, OS, and system information.
 /// </summary>
+[ToolPlugin("environment")]
 public sealed class EnvironmentTools
 {
     [KernelFunction("get_environment")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description(
         "Get information about the current environment: OS, architecture, .NET runtime, " +
         "working directory, git version, available disk space, and environment variables.")]

--- a/src/JD.AI.Core/Tools/ExecProcessTools.cs
+++ b/src/JD.AI.Core/Tools/ExecProcessTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Tracing;
 using Microsoft.SemanticKernel;
 
@@ -8,6 +9,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Native exec/process tool surface for background session lifecycle management.
 /// </summary>
+[ToolPlugin("runtime", RequiresInjection = true)]
 public sealed class ExecProcessTools
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
@@ -20,6 +22,7 @@ public sealed class ExecProcessTools
     }
 
     [KernelFunction("exec")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("Execute a command with optional background mode, PTY emulation flag, timeout, and yield window. Returns a process session id for polling/logging.")]
     public async Task<string> ExecAsync(
         [Description("Command to execute")] string command,
@@ -68,6 +71,7 @@ public sealed class ExecProcessTools
     }
 
     [KernelFunction("process")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("Manage process sessions. Actions: list, poll, log, write, kill, clear, remove.")]
     public async Task<string> ProcessAsync(
         [Description("Action: list, poll, log, write, kill, clear, remove")] string action,

--- a/src/JD.AI.Core/Tools/FileTools.cs
+++ b/src/JD.AI.Core/Tools/FileTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -7,9 +8,11 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// File system tools for the AI agent.
 /// </summary>
+[ToolPlugin("file")]
 public sealed class FileTools
 {
     [KernelFunction("read_file")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Read the contents of a file. Returns the text content with line numbers.")]
     public static string ReadFile(
         [Description("Absolute or relative file path")] string path,
@@ -35,6 +38,7 @@ public sealed class FileTools
     }
 
     [KernelFunction("write_file")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Write content to a file, creating it if it doesn't exist.")]
     public static string WriteFile(
         [Description("Absolute or relative file path")] string path,
@@ -51,6 +55,7 @@ public sealed class FileTools
     }
 
     [KernelFunction("edit_file")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Replace exactly one occurrence of old_str with new_str in a file.")]
     public static string EditFile(
         [Description("Absolute or relative file path")] string path,
@@ -82,6 +87,7 @@ public sealed class FileTools
     }
 
     [KernelFunction("list_directory")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List files and directories. Returns a tree-like listing.")]
     public static string ListDirectory(
         [Description("Directory path (defaults to current directory)")] string? path = null,

--- a/src/JD.AI.Core/Tools/GatewayOpsTools.cs
+++ b/src/JD.AI.Core/Tools/GatewayOpsTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Gateway lifecycle and configuration tools — status, config, restart controls.
 /// Operates against the local gateway process or a configured remote endpoint.
 /// </summary>
+[ToolPlugin("gateway", RequiresInjection = true)]
 public sealed class GatewayOpsTools
 {
     private readonly string? _gatewayEndpoint;
@@ -23,6 +25,7 @@ public sealed class GatewayOpsTools
     }
 
     [KernelFunction("gateway_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check the gateway's health and connection status.")]
     public async Task<string> GetStatusAsync()
     {
@@ -87,6 +90,7 @@ public sealed class GatewayOpsTools
     }
 
     [KernelFunction("gateway_config")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Retrieve the current gateway configuration (secrets redacted).")]
     public async Task<string> GetConfigAsync()
     {
@@ -115,6 +119,7 @@ public sealed class GatewayOpsTools
     }
 
     [KernelFunction("gateway_channels")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List channels registered in the gateway with their connection status.")]
     public async Task<string> ListGatewayChannelsAsync()
     {
@@ -143,6 +148,7 @@ public sealed class GatewayOpsTools
     }
 
     [KernelFunction("gateway_agents")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List agents managed by the gateway.")]
     public async Task<string> ListGatewayAgentsAsync()
     {
@@ -171,6 +177,7 @@ public sealed class GatewayOpsTools
     }
 
     [KernelFunction("gateway_sessions")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List active sessions in the gateway.")]
     public async Task<string> ListGatewaySessionsAsync()
     {

--- a/src/JD.AI.Core/Tools/GitHubTools.cs
+++ b/src/JD.AI.Core/Tools/GitHubTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,6 +10,7 @@ namespace JD.AI.Core.Tools;
 /// Native GitHub tools for issue, PR, and repository workflows.
 /// Uses the gh CLI for authentication and API access.
 /// </summary>
+[ToolPlugin("github")]
 public sealed class GitHubTools
 {
     private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
@@ -16,6 +18,7 @@ public sealed class GitHubTools
     // ── Issues ──────────────────────────────────────────────
 
     [KernelFunction("github_list_issues")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List issues in a GitHub repository. Returns issue number, title, state, labels, and assignees.")]
     public static async Task<string> ListIssuesAsync(
         [Description("Repository in owner/repo format (e.g. 'JerrettDavis/JD.AI'). Omit to use current repo.")] string? repo = null,
@@ -34,6 +37,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_get_issue")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get details of a specific GitHub issue including body, comments, and metadata.")]
     public static async Task<string> GetIssueAsync(
         [Description("Issue number")] int number,
@@ -56,6 +60,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_create_issue")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Create a new GitHub issue with title, body, and optional labels/assignees.")]
     public static async Task<string> CreateIssueAsync(
         [Description("Issue title")] string title,
@@ -73,6 +78,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_close_issue")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Close a GitHub issue with an optional comment.")]
     public static async Task<string> CloseIssueAsync(
         [Description("Issue number")] int number,
@@ -89,6 +95,7 @@ public sealed class GitHubTools
     // ── Pull Requests ───────────────────────────────────────
 
     [KernelFunction("github_list_prs")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List pull requests in a GitHub repository.")]
     public static async Task<string> ListPullRequestsAsync(
         [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
@@ -105,6 +112,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_get_pr")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get details of a specific pull request including diff stats, review status, and checks.")]
     public static async Task<string> GetPullRequestAsync(
         [Description("Pull request number")] int number,
@@ -129,6 +137,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_create_pr")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Create a new pull request from the current branch.")]
     public static async Task<string> CreatePullRequestAsync(
         [Description("PR title")] string title,
@@ -147,6 +156,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_pr_checks")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get CI check status for a pull request.")]
     public static async Task<string> GetPrChecksAsync(
         [Description("Pull request number")] int number,
@@ -157,6 +167,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_merge_pr")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Merge a pull request. Requires all checks to pass and review approval.")]
     public static async Task<string> MergePullRequestAsync(
         [Description("Pull request number")] int number,
@@ -170,6 +181,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_pr_review")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Submit a review on a pull request (approve, request changes, or comment).")]
     public static async Task<string> ReviewPullRequestAsync(
         [Description("Pull request number")] int number,
@@ -184,6 +196,7 @@ public sealed class GitHubTools
     // ── Repository ──────────────────────────────────────────
 
     [KernelFunction("github_repo_info")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get information about a GitHub repository (description, stars, language, topics).")]
     public static async Task<string> GetRepoInfoAsync(
         [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null)
@@ -194,6 +207,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_search_issues")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Search GitHub issues and PRs across repositories using query syntax.")]
     public static async Task<string> SearchIssuesAsync(
         [Description("Search query (GitHub search syntax, e.g. 'bug label:critical is:open')")] string query,
@@ -208,6 +222,7 @@ public sealed class GitHubTools
     // ── Workflows / Actions ─────────────────────────────────
 
     [KernelFunction("github_list_runs")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List recent GitHub Actions workflow runs for a repository.")]
     public static async Task<string> ListWorkflowRunsAsync(
         [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
@@ -226,6 +241,7 @@ public sealed class GitHubTools
     }
 
     [KernelFunction("github_run_details")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get details and job logs for a specific GitHub Actions run.")]
     public static async Task<string> GetRunDetailsAsync(
         [Description("Workflow run ID")] long runId,
@@ -257,6 +273,7 @@ public sealed class GitHubTools
     // ── Releases ────────────────────────────────────────────
 
     [KernelFunction("github_list_releases")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List releases for a GitHub repository.")]
     public static async Task<string> ListReleasesAsync(
         [Description("Repository in owner/repo format. Omit to use current repo.")] string? repo = null,
@@ -269,6 +286,7 @@ public sealed class GitHubTools
     // ── Auth Status ─────────────────────────────────────────
 
     [KernelFunction("github_auth_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check GitHub CLI authentication status and available scopes.")]
     public static async Task<string> GetAuthStatusAsync()
     {

--- a/src/JD.AI.Core/Tools/GitTools.cs
+++ b/src/JD.AI.Core/Tools/GitTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,9 +9,11 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Git tools for the AI agent.
 /// </summary>
+[ToolPlugin("git")]
 public sealed class GitTools
 {
     [KernelFunction("git_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Show the working tree status (modified, staged, untracked files).")]
     public static async Task<string> GitStatusAsync(
         [Description("Repository path (defaults to cwd)")] string? path = null)
@@ -19,6 +22,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_diff")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Show differences. Use target to compare branches (e.g. 'main').")]
     public static async Task<string> GitDiffAsync(
         [Description("Diff target (e.g. 'main', '--staged', or empty for unstaged)")] string? target = null,
@@ -29,6 +33,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_log")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Show recent commit history.")]
     public static async Task<string> GitLogAsync(
         [Description("Number of commits to show (default 10)")] int count = 10,
@@ -39,6 +44,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_commit")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Stage all changes and commit with the given message.")]
     public static async Task<string> GitCommitAsync(
         [Description("Commit message")] string message,
@@ -50,6 +56,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_push")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Push commits to the remote repository.")]
     public static async Task<string> GitPushAsync(
         [Description("Remote name (default 'origin')")] string remote = "origin",
@@ -61,6 +68,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_pull")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Pull changes from the remote repository.")]
     public static async Task<string> GitPullAsync(
         [Description("Remote name (default 'origin')")] string remote = "origin",
@@ -72,6 +80,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_branch")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List, create, or delete branches.")]
     public static async Task<string> GitBranchAsync(
         [Description("Branch name to create (omit to list branches)")] string? name = null,
@@ -88,6 +97,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_checkout")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Switch branches or restore working tree files.")]
     public static async Task<string> GitCheckoutAsync(
         [Description("Branch name, commit SHA, or file path to checkout")] string target,
@@ -99,6 +109,7 @@ public sealed class GitTools
     }
 
     [KernelFunction("git_stash")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Stash or restore uncommitted changes.")]
     public static async Task<string> GitStashAsync(
         [Description("Stash action: 'push' (default), 'pop', 'list', 'drop'")] string action = "push",

--- a/src/JD.AI.Core/Tools/McpEcosystemTools.cs
+++ b/src/JD.AI.Core/Tools/McpEcosystemTools.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,11 +9,13 @@ namespace JD.AI.Core.Tools;
 /// MCP ecosystem import, sync, and drift detection tools.
 /// Handles bidirectional config reconciliation across Claude, OpenClaw, and JD.AI.
 /// </summary>
+[ToolPlugin("mcpEcosystem")]
 public sealed class McpEcosystemTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
 
     [KernelFunction("mcp_import_scan")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [System.ComponentModel.Description(
         "Scan ecosystem configs (Claude, OpenClaw, JD.AI) for MCP server definitions and report importable servers.")]
     public static string ImportScan(
@@ -83,6 +86,7 @@ public sealed class McpEcosystemTools
     }
 
     [KernelFunction("mcp_sync")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [System.ComponentModel.Description(
         "Sync MCP server definitions from an ecosystem (Claude, OpenClaw) into JD.AI config. " +
         "Use dry_run=true to preview changes without writing.")]
@@ -214,6 +218,7 @@ public sealed class McpEcosystemTools
     }
 
     [KernelFunction("mcp_drift")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [System.ComponentModel.Description(
         "Detect drift between MCP server definitions across ecosystems. " +
         "Shows added, removed, and changed servers with remediation guidance.")]
@@ -352,6 +357,7 @@ public sealed class McpEcosystemTools
     }
 
     [KernelFunction("mcp_quarantine")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [System.ComponentModel.Description(
         "List quarantined MCP servers pending trust approval. " +
         "Imported servers with unknown executables are quarantined until explicitly approved.")]
@@ -417,6 +423,7 @@ public sealed class McpEcosystemTools
     }
 
     [KernelFunction("mcp_ecosystem_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [System.ComponentModel.Description(
         "Export the full MCP ecosystem state as JSON for CI/CD or auditing. " +
         "Includes all sources, servers, drift status, and quarantine state.")]

--- a/src/JD.AI.Core/Tools/McpTransportTools.cs
+++ b/src/JD.AI.Core/Tools/McpTransportTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Tools for managing MCP (Model Context Protocol) server connections,
 /// transport configuration, credential management, and diagnostics.
 /// </summary>
+[ToolPlugin("mcp")]
 public sealed class McpTransportTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -17,6 +19,7 @@ public sealed class McpTransportTools
     // ── List Servers ────────────────────────────────────────
 
     [KernelFunction("mcp_list_servers")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all configured MCP servers with their transport type, status, and available tools.")]
     public static string ListServers(
         [Description("Optional config directory (default: ~/.jdai)")] string? configDir = null)
@@ -76,6 +79,7 @@ public sealed class McpTransportTools
     // ── Transport Matrix ────────────────────────────────────
 
     [KernelFunction("mcp_transport_matrix")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Show the MCP transport support matrix with security characteristics and status.")]
     public static string GetTransportMatrix()
     {
@@ -132,6 +136,7 @@ public sealed class McpTransportTools
     // ── Diagnose Server ─────────────────────────────────────
 
     [KernelFunction("mcp_diagnose")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Run diagnostics on a specific MCP server connection: config validation, connectivity, auth status, and available tools.")]
     public static string DiagnoseServer(
         [Description("MCP server name to diagnose")] string serverName,
@@ -184,6 +189,7 @@ public sealed class McpTransportTools
     // ── Credential Status ───────────────────────────────────
 
     [KernelFunction("mcp_credential_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check the credential/authentication status for all configured MCP servers.")]
     public static string GetCredentialStatus(
         [Description("Optional config directory (default: ~/.jdai)")] string? configDir = null)
@@ -243,6 +249,7 @@ public sealed class McpTransportTools
     // ── Export Config ────────────────────────────────────────
 
     [KernelFunction("mcp_export_config")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export MCP server configuration and diagnostics as JSON for CI and automation.")]
     public static string ExportConfig(
         [Description("Optional config directory (default: ~/.jdai)")] string? configDir = null)

--- a/src/JD.AI.Core/Tools/MemoryTools.cs
+++ b/src/JD.AI.Core/Tools/MemoryTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using JD.AI.Core.Attributes;
 using JD.SemanticKernel.Extensions.Memory;
 using Microsoft.SemanticKernel;
 
@@ -7,6 +8,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Semantic memory tools — store, search, and forget.
 /// </summary>
+[ToolPlugin("memory", RequiresInjection = true)]
 public sealed class MemoryTools
 {
     private readonly ISemanticMemory? _memory;
@@ -17,6 +19,7 @@ public sealed class MemoryTools
     }
 
     [KernelFunction("memory_store")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Store text in semantic memory for future recall.")]
     public async Task<string> MemoryStoreAsync(
         [Description("Text to store")] string text,
@@ -38,6 +41,7 @@ public sealed class MemoryTools
     }
 
     [KernelFunction("memory_search")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Search semantic memory for relevant information.")]
     public async Task<string> MemorySearchAsync(
         [Description("Search query")] string query,
@@ -68,6 +72,7 @@ public sealed class MemoryTools
     }
 
     [KernelFunction("memory_forget")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Remove a memory entry by its ID.")]
     public async Task<string> MemoryForgetAsync(
         [Description("Memory ID to remove")] string id)

--- a/src/JD.AI.Core/Tools/MigrationTools.cs
+++ b/src/JD.AI.Core/Tools/MigrationTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Migration tools for importing Claude Code skills, plugins, and hooks
 /// into JD.AI-native capabilities.
 /// </summary>
+[ToolPlugin("migration")]
 public sealed class MigrationTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -17,6 +19,7 @@ public sealed class MigrationTools
     // ── Scan ────────────────────────────────────────────────
 
     [KernelFunction("migration_scan")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Scan a Claude Code installation directory for skills, plugins, and hooks that can be migrated to JD.AI. Defaults to ~/.claude.")]
     public static string ScanClaudeInstallation(
         [Description("Path to Claude Code config directory (default: ~/.claude)")] string? claudePath = null)
@@ -88,6 +91,7 @@ public sealed class MigrationTools
     // ── Analyze ─────────────────────────────────────────────
 
     [KernelFunction("migration_analyze")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Analyze a specific Claude skill or plugin and generate migration recommendations for JD.AI.")]
     public static string AnalyzeSkill(
         [Description("Name of the skill/plugin to analyze")] string name,
@@ -215,6 +219,7 @@ public sealed class MigrationTools
     // ── Convert ─────────────────────────────────────────────
 
     [KernelFunction("migration_convert")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Convert a Claude CLAUDE.md file to JD.AI JDAI.md format.")]
     public static string ConvertInstructions(
         [Description("Path to CLAUDE.md file, or content directly")] string input)
@@ -248,6 +253,7 @@ public sealed class MigrationTools
     // ── Parity Matrix ───────────────────────────────────────
 
     [KernelFunction("migration_parity")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a parity matrix showing Claude skill equivalents in JD.AI. Shows what's native, planned, or not applicable.")]
     public static string GenerateParityMatrix()
     {
@@ -289,6 +295,7 @@ public sealed class MigrationTools
     // ── Export ───────────────────────────────────────────────
 
     [KernelFunction("migration_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export migration scan results as JSON for CI/automation integration.")]
     public static string ExportScanResults(
         [Description("Path to Claude config directory (default: ~/.claude)")] string? claudePath = null)

--- a/src/JD.AI.Core/Tools/MultimodalTools.cs
+++ b/src/JD.AI.Core/Tools/MultimodalTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Net.Http.Headers;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
@@ -12,6 +13,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Multimodal analysis tools — image metadata, PDF text extraction, and media inspection.
 /// </summary>
+[ToolPlugin("multimodal")]
 public sealed class MultimodalTools
 {
     private static readonly HashSet<string> AllowedImageExtensions = new(StringComparer.OrdinalIgnoreCase)
@@ -30,6 +32,7 @@ public sealed class MultimodalTools
     // ── Image analysis ───────────────────────────────────
 
     [KernelFunction("image_analyze")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Analyze an image file and return metadata (dimensions, format, file size). " +
                  "For vision-capable models, returns base64 data for further inspection. " +
                  "Supports PNG, JPG, GIF, BMP, WebP, TIFF, SVG.")]
@@ -58,6 +61,7 @@ public sealed class MultimodalTools
     // ── PDF analysis ─────────────────────────────────────
 
     [KernelFunction("pdf_analyze")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Extract text and metadata from a PDF file. Returns page count, text content, " +
                  "and document metadata. Supports local files and HTTP(S) URLs.")]
     public static async Task<string> AnalyzePdfAsync(
@@ -86,6 +90,7 @@ public sealed class MultimodalTools
     // ── Media view (unified inspection) ──────────────────
 
     [KernelFunction("media_view")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Inspect a media file and return its type, metadata, and a brief summary. " +
                  "Auto-detects whether the file is an image, PDF, or other document type.")]
     public static async Task<string> MediaViewAsync(

--- a/src/JD.AI.Core/Tools/NotebookTools.cs
+++ b/src/JD.AI.Core/Tools/NotebookTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,10 +9,12 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Code execution (REPL) tools for running snippets in various languages.
 /// </summary>
+[ToolPlugin("notebook")]
 public sealed class NotebookTools
 {
 
     [KernelFunction("execute_code")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description(
         "Execute a code snippet in the specified language and return the output. " +
         "Supported languages: csharp (dotnet-script), python, node (JavaScript), bash/powershell.")]

--- a/src/JD.AI.Core/Tools/OpenClawCompatibilityTools.cs
+++ b/src/JD.AI.Core/Tools/OpenClawCompatibilityTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -6,6 +7,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// OpenClaw-compatible tool aliases and shared envelope parameters.
 /// </summary>
+[ToolPlugin("openclaw", RequiresInjection = true)]
 public sealed class OpenClawCompatibilityTools
 {
     private readonly TaskTools _tasks;
@@ -18,6 +20,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("bash")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for run_command.")]
     public async Task<string> BashAsync(
         [Description("The command to execute")] string command,
@@ -37,6 +40,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("read")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for read_file.")]
     public string Read(
         [Description("Absolute or relative file path")] string path,
@@ -52,6 +56,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("write")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for write_file.")]
     public string Write(
         [Description("Absolute or relative file path")] string path,
@@ -66,6 +71,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("edit")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for edit_file.")]
     public string Edit(
         [Description("Absolute or relative file path")] string path,
@@ -81,6 +87,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("ls")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for list_directory.")]
     public string Ls(
         [Description("Directory path (optional)")] string? path = null,
@@ -95,6 +102,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("webfetch")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for web_fetch.")]
     public async Task<string> WebFetchAsync(
         [Description("The URL to fetch")] string url,
@@ -109,6 +117,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("websearch")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for web_search.")]
     public async Task<string> WebSearchAsync(
         [Description("Search query")] string query,
@@ -142,6 +151,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("todo_read")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible alias for list_tasks.")]
     public string TodoRead(
         [Description("Optional status filter: pending, in_progress, done, blocked")] string? status = null,
@@ -155,6 +165,7 @@ public sealed class OpenClawCompatibilityTools
     }
 
     [KernelFunction("todo_write")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("OpenClaw-compatible todo mutator. Supports create, update, and complete actions.")]
     public string TodoWrite(
         [Description("Action: create, update, complete")] string action,

--- a/src/JD.AI.Core/Tools/ParityDocsTools.cs
+++ b/src/JD.AI.Core/Tools/ParityDocsTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Tools for generating competitive parity documentation, compatibility matrices,
 /// migration guides, and governance runbooks from source metadata.
 /// </summary>
+[ToolPlugin("parityDocs")]
 public sealed class ParityDocsTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -17,6 +19,7 @@ public sealed class ParityDocsTools
     // ── Compatibility Matrix ────────────────────────────────
 
     [KernelFunction("parity_compatibility_matrix")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a versioned compatibility matrix comparing JD.AI features against Claude Code, OpenClaw, GitHub Copilot, and Codex CLI.")]
     public static string GenerateCompatibilityMatrix(
         [Description("Optional category filter: 'tools', 'skills', 'mcp', 'governance', 'runtime', or 'all' (default)")] string? category = null)
@@ -48,6 +51,7 @@ public sealed class ParityDocsTools
     // ── Migration Guide ─────────────────────────────────────
 
     [KernelFunction("parity_migration_guide")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a migration guide for users switching from a specific competitor to JD.AI.")]
     public static string GenerateMigrationGuide(
         [Description("Source platform: 'claude', 'openclaw', 'copilot', or 'codex'")] string source)
@@ -150,6 +154,7 @@ public sealed class ParityDocsTools
     // ── Governance Runbook ──────────────────────────────────
 
     [KernelFunction("parity_governance_runbook")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a governance runbook covering security, policy, and operational guidelines for a specific feature area.")]
     public static string GenerateGovernanceRunbook(
         [Description("Feature area: 'tools', 'skills', 'mcp', 'providers', or 'channels'")] string area)
@@ -186,6 +191,7 @@ public sealed class ParityDocsTools
     // ── Threat Model ────────────────────────────────────────
 
     [KernelFunction("parity_threat_model")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate a threat model summary for a JD.AI feature, including attack vectors and mitigations.")]
     public static string GenerateThreatModel(
         [Description("Feature to model: 'tool-execution', 'skill-loading', 'mcp-transport', 'provider-auth', 'session-data', or 'gateway'")] string feature)
@@ -224,6 +230,7 @@ public sealed class ParityDocsTools
     // ── Export ───────────────────────────────────────────────
 
     [KernelFunction("parity_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export the full parity data (compatibility matrix, migration mappings, governance status) as JSON.")]
     public static string ExportParityData()
     {

--- a/src/JD.AI.Core/Tools/PolicyTools.cs
+++ b/src/JD.AI.Core/Tools/PolicyTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Governance;
 using JD.AI.Core.Governance.Audit;
 using Microsoft.SemanticKernel;
@@ -12,6 +13,7 @@ namespace JD.AI.Core.Tools;
 /// Policy-as-code tools for governance, audit, and trust evaluation.
 /// Exposes the governance infrastructure as agent-callable functions.
 /// </summary>
+[ToolPlugin("policy", RequiresInjection = true)]
 public sealed class PolicyTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -28,6 +30,7 @@ public sealed class PolicyTools
     // ── Policy Evaluation ───────────────────────────────────
 
     [KernelFunction("policy_evaluate")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Evaluate whether a specific tool, provider, or model is allowed by the current policy. Returns the policy decision (Allow/Deny/RequireApproval) with reason.")]
     public string EvaluatePolicy(
         [Description("Type of evaluation: 'tool', 'provider', or 'model'")] string type,
@@ -86,6 +89,7 @@ public sealed class PolicyTools
     // ── Policy Listing ──────────────────────────────────────
 
     [KernelFunction("policy_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List the currently resolved policy rules including tool/provider/model restrictions, budget limits, and data policies.")]
     public string ListPolicies()
     {
@@ -208,6 +212,7 @@ public sealed class PolicyTools
     // ── Audit ───────────────────────────────────────────────
 
     [KernelFunction("audit_query")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Query the audit log for recent events. Shows who did what and when, including policy decisions.")]
     public async Task<string> QueryAudit(
         [Description("Number of recent events to show (default 10, max 50)")] int count = 10)
@@ -247,6 +252,7 @@ public sealed class PolicyTools
     // ── RBAC ────────────────────────────────────────────────
 
     [KernelFunction("rbac_check")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check current user's effective permissions based on policies. Shows what tools, providers, and models are accessible.")]
     public string CheckRbac(
         [Description("Optional user ID to check (defaults to current user)")] string? userId = null)
@@ -324,6 +330,7 @@ public sealed class PolicyTools
     // ── Policy Validation ───────────────────────────────────
 
     [KernelFunction("policy_validate")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Validate a policy YAML document for syntax and semantic correctness. Returns validation results.")]
     public static string ValidatePolicy(
         [Description("Policy YAML content to validate")] string yamlContent)
@@ -424,6 +431,7 @@ public sealed class PolicyTools
     // ── Policy Export ───────────────────────────────────────
 
     [KernelFunction("policy_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export the current resolved policy as JSON for backup, comparison, or CI integration.")]
     public string ExportPolicy()
     {

--- a/src/JD.AI.Core/Tools/QuestionTools.cs
+++ b/src/JD.AI.Core/Tools/QuestionTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Questions;
 using Microsoft.SemanticKernel;
 
@@ -8,6 +9,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Tool for presenting structured questions to the user and collecting validated answers.
 /// </summary>
+[ToolPlugin("questions", RequiresInjection = true)]
 public sealed class QuestionTools
 {
     private readonly Func<AskQuestionsRequest, AskQuestionsResult> _runQuestionnaire;
@@ -22,6 +24,7 @@ public sealed class QuestionTools
     }
 
     [KernelFunction("ask_questions")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description(
         "Present a structured set of questions to the user and collect their answers. " +
         "Use this when you need specific information from the user before proceeding — " +

--- a/src/JD.AI.Core/Tools/SchedulerTools.cs
+++ b/src/JD.AI.Core/Tools/SchedulerTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,6 +10,7 @@ namespace JD.AI.Core.Tools;
 /// Scheduled task management tools — create, list, update, and remove recurring or one-shot tasks.
 /// Tasks are stored in-memory for the current session; persistence is optional via SessionStore.
 /// </summary>
+[ToolPlugin("scheduler", RequiresInjection = true)]
 public sealed class SchedulerTools
 {
     private readonly Lock _lock = new();
@@ -16,6 +18,7 @@ public sealed class SchedulerTools
     private int _nextId = 1;
 
     [KernelFunction("cron_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all scheduled tasks and their status.")]
     public string ListTasks()
     {
@@ -44,6 +47,7 @@ public sealed class SchedulerTools
     }
 
     [KernelFunction("cron_add")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Add a new scheduled task. Schedule can be a cron expression (e.g. '*/5 * * * *') " +
                  "or a simple interval like '5m', '1h', '30s'.")]
     public string AddTask(
@@ -78,6 +82,7 @@ public sealed class SchedulerTools
     }
 
     [KernelFunction("cron_remove")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Remove a scheduled task by ID.")]
     public string RemoveTask(
         [Description("Task ID to remove")] int taskId)
@@ -95,6 +100,7 @@ public sealed class SchedulerTools
     }
 
     [KernelFunction("cron_update")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Update an existing scheduled task's schedule, command, or status.")]
     public string UpdateTask(
         [Description("Task ID to update")] int taskId,
@@ -128,6 +134,7 @@ public sealed class SchedulerTools
     }
 
     [KernelFunction("cron_run")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Manually trigger a scheduled task immediately.")]
     public string RunTask(
         [Description("Task ID to run now")] int taskId)
@@ -145,6 +152,7 @@ public sealed class SchedulerTools
     }
 
     [KernelFunction("cron_history")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get execution history for a specific scheduled task.")]
     public string GetTaskHistory(
         [Description("Task ID")] int taskId)

--- a/src/JD.AI.Core/Tools/SearchTools.cs
+++ b/src/JD.AI.Core/Tools/SearchTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,9 +9,11 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Code search tools — grep and glob — for the AI agent.
 /// </summary>
+[ToolPlugin("search")]
 public sealed class SearchTools
 {
     [KernelFunction("grep")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Search file contents for a regex pattern. Returns matching lines with file paths and line numbers.")]
     public static string Grep(
         [Description("Regex pattern to search for")] string pattern,
@@ -96,6 +99,7 @@ public sealed class SearchTools
     }
 
     [KernelFunction("glob")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Find files matching a glob pattern. Returns file paths.")]
     public static string Glob(
         [Description("Glob pattern (e.g. **/*.cs, src/**/*.json)")] string pattern,

--- a/src/JD.AI.Core/Tools/ShellTools.cs
+++ b/src/JD.AI.Core/Tools/ShellTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,9 +9,11 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Shell execution tool for the AI agent.
 /// </summary>
+[ToolPlugin("shell")]
 public sealed class ShellTools
 {
     [KernelFunction("run_command")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("Execute a shell command and return its output. Use for builds, tests, git operations, etc.")]
     public static async Task<string> RunCommandAsync(
         [Description("The command to execute")] string command,

--- a/src/JD.AI.Core/Tools/SkillParityTools.cs
+++ b/src/JD.AI.Core/Tools/SkillParityTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -10,6 +11,7 @@ namespace JD.AI.Core.Tools;
 /// Tools for tracking and managing OpenClaw bundled-skill parity in JD.AI.
 /// Provides a canonical parity matrix, pack grouping, and gap analysis.
 /// </summary>
+[ToolPlugin("skillParity")]
 public sealed class SkillParityTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -17,6 +19,7 @@ public sealed class SkillParityTools
     // ── Parity Matrix ───────────────────────────────────────
 
     [KernelFunction("skills_parity_matrix")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Generate the complete OpenClaw→JD.AI skills parity matrix showing status for every bundled skill.")]
     public static string GenerateParityMatrix(
         [Description("Optional filter: 'native', 'planned', 'superseded', 'not-applicable', or 'all' (default)")] string? filter = null)
@@ -50,6 +53,7 @@ public sealed class SkillParityTools
     // ── Pack Overview ───────────────────────────────────────
 
     [KernelFunction("skills_pack_overview")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Show skills grouped by pack (Productivity, Dev/Coding, Media, Device/OS, Platform, Communication) with coverage percentages.")]
     public static string GetPackOverview()
     {
@@ -89,6 +93,7 @@ public sealed class SkillParityTools
     // ── Gap Analysis ────────────────────────────────────────
 
     [KernelFunction("skills_gap_analysis")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Identify skill gaps — planned skills not yet implemented, ranked by priority tier.")]
     public static string GetGapAnalysis()
     {
@@ -131,6 +136,7 @@ public sealed class SkillParityTools
     // ── Skill Detail ────────────────────────────────────────
 
     [KernelFunction("skills_detail")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get detailed information about a specific skill's parity status, including migration notes and security requirements.")]
     public static string GetSkillDetail(
         [Description("OpenClaw skill name to look up")] string name)
@@ -171,6 +177,7 @@ public sealed class SkillParityTools
     // ── Export ───────────────────────────────────────────────
 
     [KernelFunction("skills_parity_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export the full skills parity data as JSON for CI dashboards and automation.")]
     public static string ExportParity()
     {

--- a/src/JD.AI.Core/Tools/TailscaleTools.cs
+++ b/src/JD.AI.Core/Tools/TailscaleTools.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -11,6 +12,7 @@ namespace JD.AI.Core.Tools;
 /// Tools for Tailscale integration: status detection, Tailnet machine discovery,
 /// remote orchestration, and credential configuration.
 /// </summary>
+[ToolPlugin("tailscale")]
 public sealed class TailscaleTools
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
@@ -18,6 +20,7 @@ public sealed class TailscaleTools
     // ── Status ──────────────────────────────────────────────
 
     [KernelFunction("tailscale_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check Tailscale installation, authentication status, current Tailnet, and local node identity.")]
     public static string GetStatus(
         [Description("Optional config directory for stored credentials (default: ~/.jdai)")] string? configDir = null)
@@ -74,6 +77,7 @@ public sealed class TailscaleTools
     // ── Machine Discovery ───────────────────────────────────
 
     [KernelFunction("tailscale_machines")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all machines on the Tailnet with name, OS, online status, and addresses. Requires Tailscale CLI or API credentials.")]
     public static string ListMachines(
         [Description("Optional filter: 'online', 'offline', or 'all' (default: all)")] string? filter = null,
@@ -152,6 +156,7 @@ public sealed class TailscaleTools
     // ── Configure Credentials ───────────────────────────────
 
     [KernelFunction("tailscale_configure")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Configure Tailscale API credentials for machine discovery and remote orchestration. Stores in ~/.jdai/tailscale.json.")]
     public static string Configure(
         [Description("Tailnet name (e.g., 'example.com' or org name)")] string tailnet,
@@ -223,6 +228,7 @@ public sealed class TailscaleTools
     // ── Runner Probe ────────────────────────────────────────
 
     [KernelFunction("tailscale_runner_probe")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Check if a jdai-runner service is available on a specific Tailnet machine. Returns runner version, status, and capabilities.")]
     public static string ProbeRunner(
         [Description("Machine hostname or Tailscale IP to probe")] string target,
@@ -297,6 +303,7 @@ public sealed class TailscaleTools
     // ── Export ───────────────────────────────────────────────
 
     [KernelFunction("tailscale_export")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export Tailscale configuration, discovered machines, and runner status as JSON for CI and automation.")]
     public static string Export(
         [Description("Optional config directory (default: ~/.jdai)")] string? configDir = null)

--- a/src/JD.AI.Core/Tools/TaskTools.cs
+++ b/src/JD.AI.Core/Tools/TaskTools.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,6 +10,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Task/todo management tools for the agent to track work items within a session.
 /// </summary>
+[ToolPlugin("tasks", RequiresInjection = true)]
 public sealed class TaskTools
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -21,6 +23,7 @@ public sealed class TaskTools
     private int _nextId;
 
     [KernelFunction("create_task")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Create a new task/todo item to track work. Returns the task ID.")]
     public string CreateTask(
         [Description("Short title for the task")] string title,
@@ -42,6 +45,7 @@ public sealed class TaskTools
     }
 
     [KernelFunction("list_tasks")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List all tasks, optionally filtered by status.")]
     public string ListTasks(
         [Description("Filter by status: pending, in_progress, done, blocked (optional)")] string? status = null)
@@ -76,6 +80,7 @@ public sealed class TaskTools
     }
 
     [KernelFunction("update_task")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Update a task's status or details.")]
     public string UpdateTask(
         [Description("Task ID (e.g. 'task-1')")] string id,
@@ -108,6 +113,7 @@ public sealed class TaskTools
     }
 
     [KernelFunction("complete_task")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Mark a task as done.")]
     public string CompleteTask(
         [Description("Task ID (e.g. 'task-1')")] string id)
@@ -116,6 +122,7 @@ public sealed class TaskTools
     }
 
     [KernelFunction("export_tasks")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Export all tasks as JSON for persistence or sharing.")]
     public string ExportTasks()
     {

--- a/src/JD.AI.Core/Tools/ThinkTools.cs
+++ b/src/JD.AI.Core/Tools/ThinkTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -7,9 +8,11 @@ namespace JD.AI.Core.Tools;
 /// A scratchpad/thinking tool that lets the agent reason out loud without side effects.
 /// The agent can use this to organize thoughts, plan steps, or reason through complex logic.
 /// </summary>
+[ToolPlugin("think")]
 public sealed class ThinkTools
 {
     [KernelFunction("think")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description(
         "Use this tool to think through complex problems, plan multi-step approaches, " +
         "or reason about trade-offs. This has no side effects — it simply returns your " +

--- a/src/JD.AI.Core/Tools/UsageTools.cs
+++ b/src/JD.AI.Core/Tools/UsageTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Providers;
 using Microsoft.SemanticKernel;
 
@@ -8,6 +9,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Tools for tracking token usage and costs across the session.
 /// </summary>
+[ToolPlugin("usage", RequiresInjection = true)]
 public sealed class UsageTools
 {
     private long _promptTokens;
@@ -33,6 +35,7 @@ public sealed class UsageTools
     }
 
     [KernelFunction("get_usage")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description(
         "Get token usage and cost statistics for the current session. " +
         "Shows prompt tokens, completion tokens, total tokens, tool calls, " +
@@ -88,6 +91,7 @@ public sealed class UsageTools
     }
 
     [KernelFunction("reset_usage")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Reset session usage counters to zero.")]
     public string ResetUsage()
     {

--- a/src/JD.AI.Core/Tools/WebSearchTools.cs
+++ b/src/JD.AI.Core/Tools/WebSearchTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Net.Http.Json;
 using System.Text.Json;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -8,6 +9,7 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Web search tool using Bing Search API (via Copilot connector auth or direct API key).
 /// </summary>
+[ToolPlugin("WebSearchTools", RequiresInjection = true)]
 public sealed class WebSearchTools : IDisposable
 {
     private readonly HttpClient _httpClient;
@@ -20,6 +22,7 @@ public sealed class WebSearchTools : IDisposable
     }
 
     [KernelFunction("web_search")]
+    [ToolSafetyTier(SafetyTier.AlwaysConfirm)]
     [Description("Search the web for current information. Returns top results with snippets and URLs.")]
     public async Task<string> SearchAsync(
         [Description("Search query")] string query,

--- a/src/JD.AI.Core/Tools/WebTools.cs
+++ b/src/JD.AI.Core/Tools/WebTools.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Net.Http.Headers;
 using System.Text;
 using HtmlAgilityPack;
+using JD.AI.Core.Attributes;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Core.Tools;
@@ -9,11 +10,13 @@ namespace JD.AI.Core.Tools;
 /// <summary>
 /// Web tools — fetch URLs and convert HTML to readable text.
 /// </summary>
+[ToolPlugin("web")]
 public sealed class WebTools
 {
     private static readonly HttpClient SharedClient = new();
 
     [KernelFunction("web_fetch")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Fetch a URL and return its content as readable text (HTML converted to plain text).")]
     public static async Task<string> WebFetchAsync(
         [Description("The URL to fetch")] string url,

--- a/src/JD.AI/Tools/SessionOrchestrationTools.cs
+++ b/src/JD.AI/Tools/SessionOrchestrationTools.cs
@@ -2,7 +2,9 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using JD.AI.Core.Agents;
+using JD.AI.Core.Attributes;
 using JD.AI.Core.Sessions;
+using JD.AI.Core.Tools;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Tools;
@@ -12,6 +14,7 @@ namespace JD.AI.Tools;
 /// existing <see cref="AgentSession"/> and <see cref="SessionStore"/> infrastructure.
 /// Provides explicit session inventory, history, spawning, and agent listing.
 /// </summary>
+[ToolPlugin("sessions", RequiresInjection = true)]
 public sealed class SessionOrchestrationTools
 {
     private readonly AgentSession _session;
@@ -23,6 +26,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("sessions_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List sessions for this project. Returns session IDs, names, dates, token counts, and status.")]
     public async Task<string> ListSessionsAsync(
         [Description("Maximum number of sessions to return (default 20)")] int limit = 20,
@@ -64,6 +68,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("sessions_history")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get turn history for a session. Returns user/assistant messages with token counts and tool calls. Defaults to the current session.")]
     public async Task<string> GetSessionHistoryAsync(
         [Description("Session ID (default: current session)")] string? sessionId = null,
@@ -127,6 +132,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("sessions_spawn")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Create a new session or fork the current session. Use mode='fork' to clone history, or mode='new' for a fresh session.")]
     public async Task<string> SpawnSessionAsync(
         [Description("Spawn mode: 'new' (fresh session) or 'fork' (clone current)")] string mode = "new",
@@ -162,6 +168,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("session_status")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Get the current session's status: ID, project, model, turn count, tokens, spend, and timing.")]
     public string GetSessionStatus()
     {
@@ -195,6 +202,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("agents_list")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("List available agent types and any active team agents from the current orchestration context.")]
     public string ListAgents()
     {
@@ -225,6 +233,7 @@ public sealed class SessionOrchestrationTools
     }
 
     [KernelFunction("sessions_send")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Send a message to the current session's history for context injection. The message is recorded as a system note visible to subsequent turns.")]
     public async Task<string> SendMessageAsync(
         [Description("The message content to inject")] string message,

--- a/src/JD.AI/Tools/SubagentTools.cs
+++ b/src/JD.AI/Tools/SubagentTools.cs
@@ -2,6 +2,8 @@ using System.ComponentModel;
 using System.Text.Json;
 using JD.AI.Agent;
 using JD.AI.Core.Agents.Orchestration;
+using JD.AI.Core.Attributes;
+using JD.AI.Core.Tools;
 using Microsoft.SemanticKernel;
 
 namespace JD.AI.Tools;
@@ -9,6 +11,7 @@ namespace JD.AI.Tools;
 /// <summary>
 /// Kernel functions for spawning subagents and teams from the parent agent loop.
 /// </summary>
+[ToolPlugin("subagents", RequiresInjection = true)]
 public sealed class SubagentTools
 {
     private readonly TeamOrchestrator _orchestrator;
@@ -19,6 +22,7 @@ public sealed class SubagentTools
     }
 
     [KernelFunction("spawn_agent")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("Spawn a specialized subagent to handle a task. Types: explore (fast codebase Q&A), task (run commands), plan (create implementation plans), review (code review), general (full capability). Modes: single (default, one-shot), multi (multi-turn with tool calling loop).")]
     public async Task<string> SpawnAgentAsync(
         [Description("Subagent type: explore, task, plan, review, or general")] string type,
@@ -45,6 +49,7 @@ public sealed class SubagentTools
     }
 
     [KernelFunction("spawn_team")]
+    [ToolSafetyTier(SafetyTier.ConfirmOnce)]
     [Description("""
         Spawn an orchestrated team of agents. Strategies:
         - 'sequential': Agents run in order, each gets previous output (pipeline)
@@ -89,6 +94,7 @@ public sealed class SubagentTools
     }
 
     [KernelFunction("query_team_context")]
+    [ToolSafetyTier(SafetyTier.AutoApprove)]
     [Description("Query the current team's shared scratchpad or event log. Use key to read a specific scratchpad entry, or 'events' to get the event log, or 'results' to see completed agent outputs.")]
     public string QueryTeamContext(
         [Description("What to query: a scratchpad key, 'events', or 'results'")] string key)


### PR DESCRIPTION
## Summary

Adds [ToolPlugin] and [ToolSafetyTier] attributes to all 36 tool classes, completing Tier 3d of the code cleanup plan.

## Changes

- **34 tool files** in \src/JD.AI.Core/Tools/\ annotated with \[ToolPlugin]\ (name, description, RequiresInjection) and \[ToolSafetyTier]\ on every \[KernelFunction]\ method
- **2 tool files** in \src/JD.AI/Tools/\ (SessionOrchestrationTools, SubagentTools) annotated
- Safety tiers mapped 1:1 from the existing \ToolConfirmationFilter.ToolTiers\ dictionary

## Validation

- Build: **0 warnings, 0 errors** (Release config)
- Tests: **2,157 passed**, 0 failed
- Format: \dotnet format --verify-no-changes\ clean

## Next Steps

- PR 3: Replace manual registrations in \Program.cs\ with \ToolAssemblyScanner\
- PR 4: Replace \ToolTiers\ dictionary in \ToolConfirmationFilter\ with \BuildSafetyTierMap\ output