### PR TITLE
Fix OpenAI Codex connector model lookup

### DIFF
--- a/src/JD.AI.Core/Providers/OpenAICodexDetector.cs
+++ b/src/JD.AI.Core/Providers/OpenAICodexDetector.cs
@@ -145,7 +145,7 @@ public sealed class OpenAICodexDetector : IProviderDetector
                     continue;
 
                 var supportedInApi = !entry.TryGetProperty("supported_in_api", out var supportedElement)
-                    || supportedElement.ValueKind != JsonValueKind.False;
+                    || supportedElement.ValueKind == JsonValueKind.True;
                 if (!supportedInApi)
                     continue;
 

--- a/tests/JD.AI.Tests/Providers/OpenAICodexDetectorTests.cs
+++ b/tests/JD.AI.Tests/Providers/OpenAICodexDetectorTests.cs
@@ -37,6 +37,7 @@ public sealed class OpenAICodexDetectorTests : IDisposable
                        { "slug": "hidden-model", "display_name": "hidden-model", "visibility": "hide", "supported_in_api": true, "priority": 1 },
                        { "slug": "gpt-5.3-codex", "display_name": "gpt-5.3-codex", "visibility": "list", "supported_in_api": true, "priority": 0 },
                        { "slug": "not-in-api", "display_name": "not-in-api", "visibility": "list", "supported_in_api": false, "priority": 2 },
+                       { "slug": "unknown-api-state", "display_name": "unknown-api-state", "visibility": "list", "supported_in_api": null, "priority": 2 },
                        { "slug": "duplicate-model", "display_name": "B-model", "visibility": "list", "supported_in_api": true, "priority": 5 },
                        { "slug": "duplicate-model", "display_name": "A-model", "visibility": "list", "supported_in_api": true, "priority": 3 }
                      ]


### PR DESCRIPTION
## Summary
- load OpenAI Codex models from the local Codex models_cache.json instead of relying on stale hardcoded defaults
- filter to picker-visible API-supported models and preserve priority ordering
- keep existing package discovery/static fallback as safety paths
- add unit tests for cache parsing/filtering/sorting and invalid JSON handling

## Testing
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~OpenAICodexDetectorTests
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --no-restore (fails due to pre-existing ProcessExecutor timeout test)
