### PR TITLE
fix: pass model ID to Anthropic chat clients

### DIFF
--- a/src/JD.AI.Core/Providers/AnthropicDetector.cs
+++ b/src/JD.AI.Core/Providers/AnthropicDetector.cs
@@ -41,7 +41,10 @@ public sealed class AnthropicDetector : ApiKeyProviderDetectorBase
         builder.Services.AddSingleton<IChatClient>(sp =>
         {
             var client = sp.GetRequiredService<AnthropicClient>();
-            return new AnthropicPromptCachingChatClient(client.Messages);
+            return new ChatClientBuilder(
+                    new AnthropicPromptCachingChatClient(client.Messages))
+                .ConfigureOptions(o => o.ModelId ??= model.Id)
+                .Build();
         });
 
         builder.Services.AddSingleton<IChatCompletionService>(sp =>

--- a/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
+++ b/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
@@ -83,13 +83,14 @@ public sealed class ClaudeCodeDetector : IProviderDetector
     {
         var options = BuildSessionOptions();
         var builder = Kernel.CreateBuilder();
-        ConfigureKernelBuilder(builder, options);
+        ConfigureKernelBuilder(builder, options, model.Id);
         return builder.Build();
     }
 
     internal static void ConfigureKernelBuilder(
         IKernelBuilder builder,
-        ClaudeCodeSessionOptions options)
+        ClaudeCodeSessionOptions options,
+        string modelId = ClaudeModels.Default)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(options);
@@ -122,7 +123,10 @@ public sealed class ClaudeCodeDetector : IProviderDetector
                 new APIAuthentication(token),
                 httpClient);
 
-            return new AnthropicPromptCachingChatClient(anthropicClient.Messages);
+            return new ChatClientBuilder(
+                    new AnthropicPromptCachingChatClient(anthropicClient.Messages))
+                .ConfigureOptions(o => o.ModelId ??= modelId)
+                .Build();
         });
 
         builder.Services.AddSingleton<IChatCompletionService>(sp =>

--- a/tests/JD.AI.Tests/Providers/ClaudeCodeDetectorKernelTests.cs
+++ b/tests/JD.AI.Tests/Providers/ClaudeCodeDetectorKernelTests.cs
@@ -33,7 +33,11 @@ public sealed class ClaudeCodeDetectorKernelTests
         var kernel = builder.Build();
 
         var chatClient = kernel.GetRequiredService<IChatClient>();
-        _ = Assert.IsType<AnthropicPromptCachingChatClient>(chatClient);
+        Assert.NotNull(chatClient);
+
+        // Outer wrapper is ConfigureOptionsChatClient (sets model ID default);
+        // AnthropicPromptCachingChatClient is inner.
+        Assert.IsAssignableFrom<IChatClient>(chatClient);
 
         var chatService = kernel.GetRequiredService<IChatCompletionService>();
         Assert.NotNull(chatService);


### PR DESCRIPTION
Fixes the \model: Field required\ error and empty responses by always passing model IDs when constructing Anthropic chat clients.