### PR TITLE
fix: make rich output default and remove Claude comparison framing

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -329,8 +329,8 @@ Environment variables configured in `skills.json` are injected only for the curr
 
 ### Semantic Kernel mapping
 
-| Claude Code concept | Semantic Kernel equivalent |
-|---------------------|---------------------------|
+| External skill-system concept | Semantic Kernel equivalent |
+|-------------------------------|---------------------------|
 | `SKILL.md` | `KernelFunction` (prompt-based) |
 | `hooks.json` | `IFunctionInvocationFilter` / `IPromptRenderFilter` |
 | `plugin.json` | Plugin with dependency resolution |

--- a/docs/plans/2026-03-03-enterprise-governance-workflow-store.md
+++ b/docs/plans/2026-03-03-enterprise-governance-workflow-store.md
@@ -1,6 +1,6 @@
 # Enterprise Governance and Shared Workflow Store — Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add enterprise governance (policy engine, audit logging, budget tracking, data redaction), a shared workflow store, and hierarchical org instructions to JD.AI.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -348,6 +348,7 @@ Toggles vim editing mode in the interactive prompt.
 ### `/output-style [rich|plain|compact|json]`
 
 Sets renderer output mode.
+`json` is session-only and is not persisted as the startup default.
 
 ### `/stats [--history|--daily]`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -87,12 +87,12 @@ These override global defaults when JD.AI is launched from that project director
 
 JD.AI searches for instruction files in priority order. All discovered files are merged, with `JDAI.md` taking highest priority:
 
-| Priority | File | Compatibility |
+| Priority | File | Notes |
 |---|---|---|
 | 1 | `JDAI.md` | JD.AI native |
-| 2 | `CLAUDE.md` | Claude Code |
-| 3 | `AGENTS.md` | Codex CLI |
-| 4 | `.github/copilot-instructions.md` | GitHub Copilot |
+| 2 | `CLAUDE.md` | Recognized instruction filename |
+| 3 | `AGENTS.md` | Recognized instruction filename |
+| 4 | `.github/copilot-instructions.md` | Recognized instruction filename |
 | 5 | `.jdai/instructions.md` | Dot-directory variant |
 
 ### Example JDAI.md
@@ -168,7 +168,7 @@ File missing              → empty config (defaults)
 
 ## Skills, plugins, and hooks
 
-JD.AI uses native `.jdai` locations for skills/plugins and keeps `.claude` skills as lower-precedence compatibility inputs.
+JD.AI uses native `.jdai` locations for skills/plugins and keeps `.claude` skills as lower-precedence legacy inputs.
 
 ### Skills
 
@@ -177,8 +177,8 @@ JD.AI uses native `.jdai` locations for skills/plugins and keeps `.claude` skill
 | `<install>/skills/` | Bundled baseline skills |
 | `~/.jdai/skills/` | User-managed skills |
 | `.jdai/skills/` | Workspace skills |
-| `~/.claude/skills/` | Legacy compatibility skills (lower precedence) |
-| `.claude/skills/` | Legacy compatibility skills (lower precedence) |
+| `~/.claude/skills/` | Legacy skills (lower precedence) |
+| `.claude/skills/` | Legacy skills (lower precedence) |
 
 Skill runtime policy/config:
 
@@ -242,6 +242,8 @@ See [Skills and Plugins](../developer-guide/plugins.md) for lifecycle, precedenc
 | `autorun` | Auto-run tool confirmation behavior | `/config set autorun off` |
 | `permissions` | Global permission checks | `/config set permissions on` |
 | `plan_mode` | Plan mode state | `/config set plan_mode off` |
+
+Note: `output_style=json` is session-only and will not persist as startup default.
 
 ### Prompt caching defaults
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -16,9 +16,9 @@ JD.AI works out of the box with sensible defaults. This page covers the main way
 JD.AI looks for instruction files in this priority order:
 
 1. `JDAI.md` — JD.AI native format
-2. `CLAUDE.md` — Claude Code compatibility
-3. `AGENTS.md` — Codex CLI compatibility
-4. `.github/copilot-instructions.md` — Copilot compatibility
+2. `CLAUDE.md` — recognized instruction filename
+3. `AGENTS.md` — recognized instruction filename
+4. `.github/copilot-instructions.md` — recognized instruction filename
 5. `.jdai/instructions.md` — dot-directory variant
 
 All discovered files are merged, with `JDAI.md` taking highest priority when directives overlap.

--- a/docs/user-guide/org-instructions.md
+++ b/docs/user-guide/org-instructions.md
@@ -100,10 +100,10 @@ An org config repository is a plain directory. JD.AI scans it for the same file 
 ```text
 jdai-org-config/
 ├── JDAI.md                         # primary org instructions (loaded first)
-├── CLAUDE.md                       # loaded if JDAI.md not present
-├── AGENTS.md                       # loaded if neither above present
+├── CLAUDE.md                       # recognized instruction filename
+├── AGENTS.md                       # recognized instruction filename
 ├── .github/
-│   └── copilot-instructions.md     # Copilot-compatible fallback
+│   └── copilot-instructions.md     # recognized instruction filename
 └── .jdai/
     └── instructions.md             # dot-directory variant
 ```
@@ -168,8 +168,8 @@ Writing the path to this file persists the setting across terminal sessions with
 - Input validation on all public endpoints using FluentValidation
 
 ## Approved AI Providers
-- Claude Code (primary)
-- GitHub Copilot (secondary)
+- Claude Code
+- GitHub Copilot
 - Local models via LLamaSharp for offline work
 - Do not use unapproved providers on systems with access to production data
 ```
@@ -215,9 +215,9 @@ JD.AI scans the org config directory for instruction files using the same priori
 | Priority | File name | Notes |
 |:-:|---|---|
 | 1 | `JDAI.md` | JD.AI native format — loaded first |
-| 2 | `CLAUDE.md` | Claude Code compatibility |
-| 3 | `AGENTS.md` | Codex CLI / OpenAI Agents SDK compatibility |
-| 4 | `.github/copilot-instructions.md` | GitHub Copilot compatibility |
+| 2 | `CLAUDE.md` | Recognized instruction filename |
+| 3 | `AGENTS.md` | Recognized instruction filename |
+| 4 | `.github/copilot-instructions.md` | Recognized instruction filename |
 | 5 | `.jdai/instructions.md` | Dot-directory variant |
 
 All files that exist and are non-empty are loaded. Files whose content is entirely whitespace are skipped.
@@ -335,7 +335,7 @@ The following is a complete, production-quality org instruction file for an engi
 - Dependency audit: `dotnet list package --vulnerable` must be clean before release
 
 ## Approved AI Providers
-- Claude Code — primary, approved for all code on all systems
+- Claude Code — approved for all code on all systems
 - GitHub Copilot — approved for all code on all systems
 - Ollama (local) — approved for offline and privacy-sensitive work
 - LLamaSharp (local) — approved for air-gapped environments

--- a/src/JD.AI.Core/Config/TuiSettings.cs
+++ b/src/JD.AI.Core/Config/TuiSettings.cs
@@ -53,10 +53,7 @@ public sealed record TuiSettings
         {
             var json = File.ReadAllText(path);
             var settings = JsonSerializer.Deserialize<TuiSettings>(json, JsonOptions) ?? new TuiSettings();
-            return settings with
-            {
-                SystemPromptBudgetPercent = Math.Clamp(settings.SystemPromptBudgetPercent, 0, 100),
-            };
+            return Normalize(settings);
         }
 #pragma warning disable CA1031 // Best-effort deserialization
         catch (Exception)
@@ -74,6 +71,19 @@ public sealed record TuiSettings
         if (dir is not null)
             Directory.CreateDirectory(dir);
 
-        File.WriteAllText(path, JsonSerializer.Serialize(this, JsonOptions));
+        // JSON output mode is intentionally session-only opt-in and should not
+        // become the startup default via persisted settings.
+        File.WriteAllText(path, JsonSerializer.Serialize(Normalize(this), JsonOptions));
+    }
+
+    private static TuiSettings Normalize(TuiSettings settings)
+    {
+        return settings with
+        {
+            SystemPromptBudgetPercent = Math.Clamp(settings.SystemPromptBudgetPercent, 0, 100),
+            OutputStyle = settings.OutputStyle == OutputStyle.Json
+                ? OutputStyle.Rich
+                : settings.OutputStyle,
+        };
     }
 }

--- a/src/JD.AI.Core/Providers/OpenAICodexDetector.cs
+++ b/src/JD.AI.Core/Providers/OpenAICodexDetector.cs
@@ -37,26 +37,23 @@ public sealed class OpenAICodexDetector : IProviderDetector
                     Models: []);
             }
 
-            // Use model discovery to enumerate available models
+            // Use live model discovery first, then local cache as a supplement.
             var models = new List<ProviderModelInfo>();
-            AddUniqueModels(models, DiscoverModelsFromCache(options));
-
-            if (models.Count == 0)
+            try
             {
-                try
-                {
-                    var discovery = new CodexModelDiscovery();
-                    var discovered = await discovery.DiscoverModelsAsync(ct).ConfigureAwait(false);
-                    AddUniqueModels(models, discovered.Select(m =>
-                        new ProviderModelInfo(m.Id, m.Name ?? m.Id, ProviderName)));
-                }
-#pragma warning disable CA1031 // catch broad — discovery is optional
-                catch
-#pragma warning restore CA1031
-                {
-                    // Keep going to fallback list.
-                }
+                var discovery = new CodexModelDiscovery();
+                var discovered = await discovery.DiscoverModelsAsync(ct).ConfigureAwait(false);
+                AddUniqueModels(models, discovered.Select(m =>
+                    new ProviderModelInfo(m.Id, m.Name ?? m.Id, ProviderName)));
             }
+#pragma warning disable CA1031 // catch broad — discovery is optional
+            catch
+#pragma warning restore CA1031
+            {
+                // Keep going to cache/fallback discovery.
+            }
+
+            AddUniqueModels(models, DiscoverModelsFromCache(options));
 
             if (models.Count == 0)
             {

--- a/src/JD.AI.Core/Tools/BenchmarkTools.cs
+++ b/src/JD.AI.Core/Tools/BenchmarkTools.cs
@@ -10,7 +10,7 @@ namespace JD.AI.Core.Tools;
 
 /// <summary>
 /// Parity benchmark harness for evaluating JD.AI capability coverage
-/// against target surfaces (OpenClaw, Claude Code, Copilot CLI, Codex CLI).
+/// against target agent capability surfaces.
 /// </summary>
 [ToolPlugin("benchmark", RequiresInjection = true)]
 public sealed class BenchmarkTools
@@ -119,7 +119,7 @@ public sealed class BenchmarkTools
 
     [KernelFunction("benchmark_scorecard")]
     [ToolSafetyTier(SafetyTier.AutoApprove)]
-    [Description("Generate a parity scorecard comparing current JD.AI capabilities against the canonical registry. Shows coverage percentage and gaps.")]
+    [Description("Generate a parity scorecard for current JD.AI capabilities against the canonical registry. Shows coverage percentage and gaps.")]
     public string GenerateScorecard()
     {
         var available = _kernel.Plugins

--- a/src/JD.AI.Core/Tools/MigrationTools.cs
+++ b/src/JD.AI.Core/Tools/MigrationTools.cs
@@ -254,14 +254,14 @@ public sealed class MigrationTools
 
     [KernelFunction("migration_parity")]
     [ToolSafetyTier(SafetyTier.AutoApprove)]
-    [Description("Generate a parity matrix showing Claude skill equivalents in JD.AI. Shows what's native, planned, or not applicable.")]
+    [Description("Generate a migration matrix showing source skill mappings in JD.AI. Shows what's native, planned, or not applicable.")]
     public static string GenerateParityMatrix()
     {
         var mappings = GetKnownMappings();
         var sb = new StringBuilder();
-        sb.AppendLine("## Claude → JD.AI Skill Parity Matrix");
+        sb.AppendLine("## Skill Migration Matrix");
         sb.AppendLine();
-        sb.AppendLine("| Claude Skill | JD.AI Status | JD.AI Equivalent | Notes |");
+        sb.AppendLine("| Source Skill | JD.AI Status | JD.AI Equivalent | Notes |");
         sb.AppendLine("|-------------|-------------|------------------|-------|");
 
         foreach (var (name, mapping) in mappings.OrderBy(m => m.Key))
@@ -314,7 +314,7 @@ public sealed class MigrationTools
             plugins = plugins.Select(p => new { p.Name, p.Description, p.Path }).ToArray(),
             mappings = GetKnownMappings().Select(m => new
             {
-                claudeSkill = m.Key,
+                sourceSkill = m.Key,
                 m.Value.Status,
                 m.Value.Equivalent,
                 m.Value.Notes

--- a/src/JD.AI.Core/Tools/ParityDocsTools.cs
+++ b/src/JD.AI.Core/Tools/ParityDocsTools.cs
@@ -8,7 +8,7 @@ using Microsoft.SemanticKernel;
 namespace JD.AI.Core.Tools;
 
 /// <summary>
-/// Tools for generating competitive parity documentation, compatibility matrices,
+/// Tools for generating capability documentation, compatibility matrices,
 /// migration guides, and governance runbooks from source metadata.
 /// </summary>
 [ToolPlugin("parityDocs")]
@@ -20,7 +20,7 @@ public sealed class ParityDocsTools
 
     [KernelFunction("parity_compatibility_matrix")]
     [ToolSafetyTier(SafetyTier.AutoApprove)]
-    [Description("Generate a versioned compatibility matrix comparing JD.AI features against Claude Code, OpenClaw, GitHub Copilot, and Codex CLI.")]
+    [Description("Generate a versioned compatibility matrix covering JD.AI features across supported agent ecosystems.")]
     public static string GenerateCompatibilityMatrix(
         [Description("Optional category filter: 'tools', 'skills', 'mcp', 'governance', 'runtime', or 'all' (default)")] string? category = null)
     {
@@ -31,15 +31,15 @@ public sealed class ParityDocsTools
                 string.Equals(f.Category, category, StringComparison.OrdinalIgnoreCase)).ToList();
 
         var sb = new StringBuilder();
-        sb.AppendLine("## JD.AI Competitive Parity Matrix");
+        sb.AppendLine("## JD.AI Capability Matrix");
         sb.AppendLine($"*Generated {DateTime.UtcNow:yyyy-MM-dd}*");
         sb.AppendLine();
-        sb.AppendLine("| Feature | Category | JD.AI | Claude Code | OpenClaw | Copilot CLI | Codex CLI |");
-        sb.AppendLine("|---------|----------|-------|-------------|----------|-------------|-----------|");
+        sb.AppendLine("| Feature | Category | JD.AI | OpenClaw | Copilot CLI | Codex CLI |");
+        sb.AppendLine("|---------|----------|-------|----------|-------------|-----------|");
 
         foreach (var f in features.OrderBy(f => f.Category).ThenBy(f => f.Name))
         {
-            sb.AppendLine($"| {f.Name} | {f.Category} | {Icon(f.JdAi)} | {Icon(f.Claude)} | {Icon(f.OpenClaw)} | {Icon(f.Copilot)} | {Icon(f.Codex)} |");
+            sb.AppendLine($"| {f.Name} | {f.Category} | {Icon(f.JdAi)} | {Icon(f.OpenClaw)} | {Icon(f.Copilot)} | {Icon(f.Codex)} |");
         }
 
         sb.AppendLine();
@@ -52,7 +52,7 @@ public sealed class ParityDocsTools
 
     [KernelFunction("parity_migration_guide")]
     [ToolSafetyTier(SafetyTier.AutoApprove)]
-    [Description("Generate a migration guide for users switching from a specific competitor to JD.AI.")]
+    [Description("Generate a migration guide for users switching from a specific source platform to JD.AI.")]
     public static string GenerateMigrationGuide(
         [Description("Source platform: 'claude', 'openclaw', 'copilot', or 'codex'")] string source)
     {
@@ -244,7 +244,6 @@ public sealed class ParityDocsTools
                 f.Name,
                 f.Category,
                 jdai = f.JdAi,
-                claude = f.Claude,
                 openclaw = f.OpenClaw,
                 copilot = f.Copilot,
                 codex = f.Codex
@@ -252,7 +251,6 @@ public sealed class ParityDocsTools
             scores = new
             {
                 jdai = features.Count(f => f.JdAi is "full" or "native"),
-                claude = features.Count(f => f.Claude is "full" or "native"),
                 openclaw = features.Count(f => f.OpenClaw is "full" or "native"),
                 copilot = features.Count(f => f.Copilot is "full" or "native"),
                 codex = features.Count(f => f.Codex is "full" or "native"),
@@ -276,14 +274,13 @@ public sealed class ParityDocsTools
 
     private static void AppendScoreSummary(StringBuilder sb, List<FeatureEntry> features)
     {
-        sb.AppendLine("### Parity Scores");
+        sb.AppendLine("### Coverage Scores");
 
         int Score(Func<FeatureEntry, string> selector) =>
             features.Count(f => selector(f) is "full" or "native");
 
         var total = features.Count;
         sb.AppendLine($"- **JD.AI**: {Score(f => f.JdAi)}/{total}");
-        sb.AppendLine($"- **Claude Code**: {Score(f => f.Claude)}/{total}");
         sb.AppendLine($"- **OpenClaw**: {Score(f => f.OpenClaw)}/{total}");
         sb.AppendLine($"- **Copilot CLI**: {Score(f => f.Copilot)}/{total}");
         sb.AppendLine($"- **Codex CLI**: {Score(f => f.Codex)}/{total}");
@@ -426,7 +423,7 @@ public sealed class ParityDocsTools
     {
         "claude" =>
         [
-            new("claude", "jdai", "Direct replacement"),
+            new("claude", "jdai", "Equivalent command"),
             new("claude -p \"query\"", "jdai -p \"query\"", "Print mode"),
             new("claude --continue", "jdai --continue", "Resume session"),
             new("claude --model", "jdai --model", "Model selection"),
@@ -438,7 +435,7 @@ public sealed class ParityDocsTools
         ],
         "openclaw" =>
         [
-            new("openclaw", "jdai", "Direct replacement"),
+            new("openclaw", "jdai", "Equivalent command"),
             new("openclaw chat", "jdai", "TUI is default mode"),
             new("openclaw gateway", "jdai gateway", "Gateway mode"),
             new("openclaw skills list", "skills_parity_matrix tool", "Via agent tools"),
@@ -452,7 +449,7 @@ public sealed class ParityDocsTools
         ],
         "codex" =>
         [
-            new("codex", "jdai", "Direct replacement"),
+            new("codex", "jdai", "Equivalent command"),
             new("codex --model", "jdai --model", "Model selection"),
             new("codex --approval-mode", "jdai --permission-mode", "Similar concept"),
             new("AGENTS.md", "JDAI.md", "Auto-detected (both work)"),
@@ -465,53 +462,53 @@ public sealed class ParityDocsTools
         return
         [
             // Tools
-            new("File read/write/edit", "tools", "full", "full", "full", "full", "full"),
-            new("Shell execution", "tools", "full", "full", "full", "partial", "full"),
-            new("Git operations", "tools", "full", "full", "full", "partial", "full"),
-            new("Web fetch", "tools", "full", "full", "full", "partial", "none"),
-            new("Web search", "tools", "full", "full", "partial", "partial", "none"),
-            new("Code search (grep/glob)", "tools", "full", "full", "full", "full", "full"),
-            new("Memory/embeddings", "tools", "full", "partial", "full", "none", "none"),
-            new("Notebook execution", "tools", "full", "none", "partial", "none", "none"),
-            new("Clipboard access", "tools", "full", "full", "none", "none", "none"),
-            new("Batch file editing", "tools", "full", "full", "none", "none", "partial"),
-            new("Multimodal (image/PDF)", "tools", "full", "full", "partial", "partial", "none"),
-            new("Browser automation", "tools", "full", "none", "partial", "none", "none"),
+            new("File read/write/edit", "tools", "full", "full", "full", "full"),
+            new("Shell execution", "tools", "full", "full", "partial", "full"),
+            new("Git operations", "tools", "full", "full", "partial", "full"),
+            new("Web fetch", "tools", "full", "full", "partial", "none"),
+            new("Web search", "tools", "full", "partial", "partial", "none"),
+            new("Code search (grep/glob)", "tools", "full", "full", "full", "full"),
+            new("Memory/embeddings", "tools", "full", "full", "none", "none"),
+            new("Notebook execution", "tools", "full", "partial", "none", "none"),
+            new("Clipboard access", "tools", "full", "none", "none", "none"),
+            new("Batch file editing", "tools", "full", "none", "none", "partial"),
+            new("Multimodal (image/PDF)", "tools", "full", "partial", "partial", "none"),
+            new("Browser automation", "tools", "full", "partial", "none", "none"),
 
             // Skills
-            new("Project instructions (CLAUDE.md/JDAI.md)", "skills", "full", "full", "full", "full", "full"),
-            new("Skill loading (directory)", "skills", "full", "full", "full", "none", "none"),
-            new("Plugin system", "skills", "full", "full", "full", "none", "none"),
-            new("Skill hot-reload", "skills", "full", "full", "full", "none", "none"),
-            new("Skill trust/gating", "skills", "full", "partial", "partial", "none", "none"),
+            new("Project instructions (CLAUDE.md/JDAI.md)", "skills", "full", "full", "full", "full"),
+            new("Skill loading (directory)", "skills", "full", "full", "none", "none"),
+            new("Plugin system", "skills", "full", "full", "none", "none"),
+            new("Skill hot-reload", "skills", "full", "full", "none", "none"),
+            new("Skill trust/gating", "skills", "full", "partial", "none", "none"),
 
             // MCP
-            new("MCP stdio transport", "mcp", "full", "full", "full", "none", "none"),
-            new("MCP SSE transport", "mcp", "full", "full", "full", "none", "none"),
-            new("MCP StreamableHTTP", "mcp", "planned", "full", "planned", "none", "none"),
-            new("MCP OAuth", "mcp", "planned", "full", "planned", "none", "none"),
+            new("MCP stdio transport", "mcp", "full", "full", "none", "none"),
+            new("MCP SSE transport", "mcp", "full", "full", "none", "none"),
+            new("MCP StreamableHTTP", "mcp", "planned", "planned", "none", "none"),
+            new("MCP OAuth", "mcp", "planned", "planned", "none", "none"),
 
             // Governance
-            new("Tool safety tiers", "governance", "full", "partial", "partial", "none", "partial"),
-            new("Policy-as-code", "governance", "full", "none", "partial", "none", "none"),
-            new("RBAC", "governance", "full", "none", "partial", "none", "none"),
-            new("Audit logging", "governance", "full", "none", "partial", "none", "none"),
-            new("Budget controls", "governance", "full", "partial", "none", "none", "none"),
-            new("Signed capabilities", "governance", "planned", "none", "planned", "none", "none"),
+            new("Tool safety tiers", "governance", "full", "partial", "none", "partial"),
+            new("Policy-as-code", "governance", "full", "partial", "none", "none"),
+            new("RBAC", "governance", "full", "partial", "none", "none"),
+            new("Audit logging", "governance", "full", "partial", "none", "none"),
+            new("Budget controls", "governance", "full", "none", "none", "none"),
+            new("Signed capabilities", "governance", "planned", "planned", "none", "none"),
 
             // Runtime
-            new("Multi-provider", "runtime", "full", "none", "none", "none", "none"),
-            new("Subagents", "runtime", "full", "full", "full", "full", "partial"),
-            new("Team orchestration", "runtime", "full", "partial", "partial", "none", "none"),
-            new("Session persistence", "runtime", "full", "full", "full", "partial", "none"),
-            new("Git checkpointing", "runtime", "full", "full", "partial", "none", "none"),
-            new("Gateway/multi-channel", "runtime", "full", "none", "full", "none", "none"),
-            new("Daemon mode", "runtime", "full", "none", "full", "none", "none"),
-            new("Dashboard UI", "runtime", "full", "none", "partial", "none", "none"),
+            new("Multi-provider", "runtime", "full", "none", "none", "none"),
+            new("Subagents", "runtime", "full", "full", "full", "partial"),
+            new("Team orchestration", "runtime", "full", "partial", "none", "none"),
+            new("Session persistence", "runtime", "full", "full", "partial", "none"),
+            new("Git checkpointing", "runtime", "full", "partial", "none", "none"),
+            new("Gateway/multi-channel", "runtime", "full", "full", "none", "none"),
+            new("Daemon mode", "runtime", "full", "full", "none", "none"),
+            new("Dashboard UI", "runtime", "full", "partial", "none", "none"),
         ];
     }
 
-    private sealed record FeatureEntry(string Name, string Category, string JdAi, string Claude, string OpenClaw, string Copilot, string Codex);
+    private sealed record FeatureEntry(string Name, string Category, string JdAi, string OpenClaw, string Copilot, string Codex);
     private sealed record CommandMapping(string Source, string Target, string Notes);
     private sealed record ThreatEntry(string Name, string Severity, string Vector, string Mitigation, string Status);
 }

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -2950,6 +2950,8 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
         _onOutputStyleChanged(style);
         SaveSettings(TuiSettings.Load() with { OutputStyle = style });
+        if (style == OutputStyle.Json)
+            return "Output style set to json for this session only.";
         return $"Output style set to {style.ToString().ToLowerInvariant()}.";
     }
 
@@ -3063,6 +3065,8 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                     return $"Unknown output_style '{value}'.";
                 _onOutputStyleChanged?.Invoke(outputStyle);
                 SaveSettings(settings with { OutputStyle = outputStyle });
+                if (outputStyle == OutputStyle.Json)
+                    return "output_style=json (session-only)";
                 return $"output_style={outputStyle.ToString().ToLowerInvariant()}";
 
             case "spinner_style":

--- a/src/JD.AI/Rendering/ChatRenderer.cs
+++ b/src/JD.AI/Rendering/ChatRenderer.cs
@@ -173,7 +173,7 @@ public static class ChatRenderer
             return;
         }
 
-        // Claude-style compact tool display
+        // Compact tool-call display used by rich output mode
         var header = string.IsNullOrWhiteSpace(args)
             ? toolName
             : $"{toolName}({args})";

--- a/src/JD.AI/Rendering/InteractiveInput.cs
+++ b/src/JD.AI/Rendering/InteractiveInput.cs
@@ -6,7 +6,7 @@ namespace JD.AI.Rendering;
 /// <summary>
 /// Interactive readline replacement with ghost-text completions, dropdown menu,
 /// command syntax highlighting, clipboard paste detection, and input history.
-/// Replaces Console.ReadLine() for a Claude Code-like editing experience.
+/// Replaces Console.ReadLine() with a modern terminal editing experience.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public sealed class InteractiveInput

--- a/tests/JD.AI.Tests/Config/TuiSettingsTests.cs
+++ b/tests/JD.AI.Tests/Config/TuiSettingsTests.cs
@@ -29,6 +29,7 @@ public sealed class TuiSettingsTests : IDisposable
         var settings = TuiSettings.Load();
 
         Assert.Equal(SpinnerStyle.Normal, settings.SpinnerStyle);
+        Assert.Equal(OutputStyle.Rich, settings.OutputStyle);
         Assert.True(settings.PromptCacheEnabled);
         Assert.Equal(PromptCacheTtl.FiveMinutes, settings.PromptCacheTtl);
     }
@@ -98,5 +99,16 @@ public sealed class TuiSettingsTests : IDisposable
         var loaded = TuiSettings.Load();
 
         Assert.Equal(style, loaded.SpinnerStyle);
+    }
+
+    [Fact]
+    public void SaveAndLoad_OutputStyleJson_NormalizesToRich()
+    {
+        var settings = new TuiSettings { OutputStyle = OutputStyle.Json };
+        settings.Save();
+
+        var loaded = TuiSettings.Load();
+
+        Assert.Equal(OutputStyle.Rich, loaded.OutputStyle);
     }
 }

--- a/tests/JD.AI.Tests/MigrationToolsTests.cs
+++ b/tests/JD.AI.Tests/MigrationToolsTests.cs
@@ -184,8 +184,8 @@ public class MigrationToolsTests : IDisposable
     {
         var result = MigrationTools.GenerateParityMatrix();
 
-        Assert.Contains("## Claude → JD.AI Skill Parity Matrix", result);
-        Assert.Contains("| Claude Skill |", result);
+        Assert.Contains("## Skill Migration Matrix", result);
+        Assert.Contains("| Source Skill |", result);
         Assert.Contains("`brainstorming`", result);
         Assert.Contains("native", result);
     }

--- a/tests/JD.AI.Tests/ParityDocsToolsTests.cs
+++ b/tests/JD.AI.Tests/ParityDocsToolsTests.cs
@@ -11,9 +11,8 @@ public class ParityDocsToolsTests
     {
         var result = ParityDocsTools.GenerateCompatibilityMatrix();
 
-        Assert.Contains("## JD.AI Competitive Parity Matrix", result);
+        Assert.Contains("## JD.AI Capability Matrix", result);
         Assert.Contains("| Feature |", result);
-        Assert.Contains("Claude Code", result);
         Assert.Contains("OpenClaw", result);
     }
 
@@ -40,7 +39,7 @@ public class ParityDocsToolsTests
     {
         var result = ParityDocsTools.GenerateCompatibilityMatrix();
 
-        Assert.Contains("### Parity Scores", result);
+        Assert.Contains("### Coverage Scores", result);
         Assert.Contains("**JD.AI**:", result);
     }
 
@@ -225,7 +224,6 @@ public class ParityDocsToolsTests
         var json = ParityDocsTools.ExportParityData();
 
         Assert.Contains("\"jdai\":", json);
-        Assert.Contains("\"claude\":", json);
         Assert.Contains("\"total\":", json);
     }
 }


### PR DESCRIPTION
## Summary
- enforce rich as the persisted startup output style and keep json as explicit session-only opt-in
- prioritize live model lookup for OpenAI Codex model discovery, then supplement from local cache with curated fallback models
- remove Claude comparison/competitor framing from tooling/docs while keeping neutral interoperability references
- sanitize migration/capability matrix language and update tests accordingly

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --nologo