### PR TITLE
fix: update HuggingFace model catalog to currently available inference models

### DIFF
--- a/src/JD.AI.Core/Providers/HuggingFaceDetector.cs
+++ b/src/JD.AI.Core/Providers/HuggingFaceDetector.cs
@@ -7,15 +7,21 @@ namespace JD.AI.Core.Providers;
 /// Detects HuggingFace Inference API availability via API key.
 /// Uses the official Microsoft.SemanticKernel.Connectors.HuggingFace package.
 /// </summary>
+/// <remarks>
+/// Model catalog targets the HuggingFace serverless Inference API.
+/// Large models (70B+) may not be available on the free tier and can
+/// return HTTP 410 Gone — prefer smaller inference-ready models here.
+/// Use <c>/model search</c> to discover additional models dynamically.
+/// </remarks>
 public sealed class HuggingFaceDetector : ApiKeyProviderDetectorBase
 {
     private static readonly ProviderModelInfo[] KnownModelsCatalog =
     [
-        new("meta-llama/Llama-3.3-70B-Instruct", "Llama 3.3 70B", "HuggingFace"),
+        new("Qwen/Qwen2.5-7B-Instruct", "Qwen 2.5 7B", "HuggingFace"),
         new("meta-llama/Llama-3.1-8B-Instruct", "Llama 3.1 8B", "HuggingFace"),
-        new("mistralai/Mixtral-8x7B-Instruct-v0.1", "Mixtral 8x7B", "HuggingFace"),
-        new("microsoft/Phi-3-mini-4k-instruct", "Phi-3 Mini", "HuggingFace"),
-        new("Qwen/Qwen2.5-72B-Instruct", "Qwen 2.5 72B", "HuggingFace"),
+        new("Qwen/Qwen3-8B", "Qwen 3 8B", "HuggingFace"),
+        new("mistralai/Mistral-7B-Instruct-v0.3", "Mistral 7B v0.3", "HuggingFace"),
+        new("microsoft/Phi-3.5-mini-instruct", "Phi 3.5 Mini", "HuggingFace"),
     ];
 
     public HuggingFaceDetector(ProviderConfigurationManager config)


### PR DESCRIPTION
Replaces stale models (Llama 3.3 70B, Mixtral 8x7B, Phi-3 Mini, Qwen 2.5 72B) that return HTTP 410 Gone with smaller, currently available models on the HuggingFace serverless Inference API.