### PR TITLE
fix: stabilize failing release tests in CI

### DIFF
--- a/src/JD.AI.Core/Tools/ProcessSessionManager.cs
+++ b/src/JD.AI.Core/Tools/ProcessSessionManager.cs
@@ -211,8 +211,8 @@ public sealed class ProcessSessionManager
             process.Kill(entireProcessTree: true);
         }
 
-        record.Completion.TrySetResult(true);
         Persist(record);
+        record.Completion.TrySetResult(true);
         snapshot = Snapshot(record);
         return true;
     }

--- a/tests/JD.AI.Tests/Security/SlidingWindowRateLimiterTests.cs
+++ b/tests/JD.AI.Tests/Security/SlidingWindowRateLimiterTests.cs
@@ -33,7 +33,9 @@ public class SlidingWindowRateLimiterTests
     [Fact]
     public async Task Allow_AfterWindowExpires_AllowsAgain()
     {
-        var limiter = new SlidingWindowRateLimiter(maxRequests: 1, window: TimeSpan.FromMilliseconds(50));
+        // Keep the window long enough that immediate back-to-back calls cannot
+        // accidentally cross the boundary under CI load.
+        var limiter = new SlidingWindowRateLimiter(maxRequests: 1, window: TimeSpan.FromMilliseconds(250));
 
         (await limiter.AllowAsync("user1")).Should().BeTrue();
         (await limiter.AllowAsync("user1")).Should().BeFalse();


### PR DESCRIPTION
## Summary
- fix process-session completion ordering so foreground exec waits until metadata persistence is finished
- harden a timing-sensitive sliding-window rate limiter test by using a less brittle window duration under CI load

## Why
Main CI failed in the `release` job during `dotnet test JD.AI.slnx --configuration Release --no-build --filter "Category!=Integration"` due a file-lock race in `ProcessSessionManagerTests.DeleteMetadata_HandlesLockedFile`.

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter "FullyQualifiedName~ProcessSessionManagerTests.DeleteMetadata_HandlesLockedFile|FullyQualifiedName~SlidingWindowRateLimiterTests.Allow_AfterWindowExpires_AllowsAgain" --nologo
- dotnet test JD.AI.slnx --configuration Release --no-build --filter "Category!=Integration" --nologo