### PR TITLE
feat: dynamic model discovery for API-key providers

### DIFF
--- a/src/JD.AI.Core/Providers/AnthropicDetector.cs
+++ b/src/JD.AI.Core/Providers/AnthropicDetector.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using Anthropic.SDK;
 using JD.AI.Core.Providers.Credentials;
 using Microsoft.Extensions.AI;
@@ -9,7 +12,8 @@ namespace JD.AI.Core.Providers;
 
 /// <summary>
 /// Detects Anthropic API availability via API key.
-/// Uses Anthropic's native messages API through the Anthropic SDK.
+/// Dynamically discovers models from the Anthropic API, falling back to a
+/// curated catalog of well-known Claude models.
 /// </summary>
 public sealed class AnthropicDetector : ApiKeyProviderDetectorBase
 {
@@ -28,6 +32,29 @@ public sealed class AnthropicDetector : ApiKeyProviderDetectorBase
     }
 
     protected override IReadOnlyList<ProviderModelInfo> KnownModels => KnownModelsCatalog;
+
+    protected override async Task<IReadOnlyList<ProviderModelInfo>> DiscoverModelsAsync(
+        string apiKey, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        http.DefaultRequestHeaders.Add("x-api-key", apiKey);
+        http.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
+
+        var response = await http
+            .GetFromJsonAsync<AnthropicModelsResponse>(
+                "https://api.anthropic.com/v1/models?limit=20", ct)
+            .ConfigureAwait(false);
+
+        if (response?.Data is not { Count: > 0 })
+            return KnownModels;
+
+        return response.Data
+            .Where(m => !string.IsNullOrEmpty(m.Id) && string.Equals(m.Type, "model", StringComparison.Ordinal))
+            .OrderByDescending(m => m.CreatedAt)
+            .Select(m => new ProviderModelInfo(
+                m.Id!, m.DisplayName ?? m.Id!, ProviderName))
+            .ToList();
+    }
 
     protected override void ConfigureKernel(IKernelBuilder builder, ProviderModelInfo model, string apiKey)
     {
@@ -50,4 +77,13 @@ public sealed class AnthropicDetector : ApiKeyProviderDetectorBase
         builder.Services.AddSingleton<IChatCompletionService>(sp =>
             sp.GetRequiredService<IChatClient>().AsChatCompletionService(sp));
     }
+
+    private sealed record AnthropicModelsResponse(
+        [property: JsonPropertyName("data")] List<AnthropicModel>? Data);
+
+    private sealed record AnthropicModel(
+        [property: JsonPropertyName("id")] string? Id,
+        [property: JsonPropertyName("display_name")] string? DisplayName,
+        [property: JsonPropertyName("type")] string? Type,
+        [property: JsonPropertyName("created_at")] string? CreatedAt);
 }

--- a/src/JD.AI.Core/Providers/ApiKeyProviderDetectorBase.cs
+++ b/src/JD.AI.Core/Providers/ApiKeyProviderDetectorBase.cs
@@ -5,6 +5,9 @@ namespace JD.AI.Core.Providers;
 
 /// <summary>
 /// Shared template for API-key based provider detectors.
+/// Subclasses supply a static <see cref="KnownModels"/> catalog as a fallback
+/// and may override <see cref="DiscoverModelsAsync"/> to query their API for
+/// the current model list at detection time.
 /// </summary>
 public abstract class ApiKeyProviderDetectorBase : IProviderDetector
 {
@@ -24,12 +27,26 @@ public abstract class ApiKeyProviderDetectorBase : IProviderDetector
 
     public string ProviderName { get; }
 
+    /// <summary>
+    /// Static fallback catalog used when <see cref="DiscoverModelsAsync"/> is not
+    /// overridden or when live discovery fails.
+    /// </summary>
     protected abstract IReadOnlyList<ProviderModelInfo> KnownModels { get; }
 
     protected virtual string MissingApiKeyMessage => "No API key configured";
 
     protected virtual string BuildAuthenticatedStatus(int modelCount) =>
         $"Authenticated - {modelCount} model(s)";
+
+    /// <summary>
+    /// Override to query the provider's API for its current model list.
+    /// The default implementation returns <see cref="KnownModels"/>.
+    /// Implementations should catch transport errors and return <see cref="KnownModels"/>
+    /// as the fallback.
+    /// </summary>
+    protected virtual Task<IReadOnlyList<ProviderModelInfo>> DiscoverModelsAsync(
+        string apiKey, CancellationToken ct) =>
+        Task.FromResult(KnownModels);
 
     public async Task<ProviderInfo> DetectAsync(CancellationToken ct = default)
     {
@@ -45,7 +62,21 @@ public abstract class ApiKeyProviderDetectorBase : IProviderDetector
                 Models: []);
         }
 
-        var models = KnownModels.ToList();
+        IReadOnlyList<ProviderModelInfo> models;
+        try
+        {
+            models = await DiscoverModelsAsync(_apiKey, ct).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // best-effort discovery — fall back to static catalog
+        catch
+        {
+            models = KnownModels;
+        }
+#pragma warning restore CA1031
+
+        if (models.Count == 0)
+            models = KnownModels;
+
         return new ProviderInfo(
             ProviderName,
             IsAvailable: true,

--- a/src/JD.AI.Core/Providers/GoogleGeminiDetector.cs
+++ b/src/JD.AI.Core/Providers/GoogleGeminiDetector.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using JD.AI.Core.Providers.Credentials;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Connectors.Google;
@@ -6,7 +8,8 @@ namespace JD.AI.Core.Providers;
 
 /// <summary>
 /// Detects Google Gemini API availability via API key.
-/// Uses the official Microsoft.SemanticKernel.Connectors.Google package.
+/// Dynamically discovers models from the Generative Language API,
+/// filtering to <c>generateContent</c>-capable models.
 /// </summary>
 public sealed class GoogleGeminiDetector : ApiKeyProviderDetectorBase
 {
@@ -26,6 +29,33 @@ public sealed class GoogleGeminiDetector : ApiKeyProviderDetectorBase
 
     protected override IReadOnlyList<ProviderModelInfo> KnownModels => KnownModelsCatalog;
 
+    protected override async Task<IReadOnlyList<ProviderModelInfo>> DiscoverModelsAsync(
+        string apiKey, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+        var url = $"https://generativelanguage.googleapis.com/v1beta/models?key={Uri.EscapeDataString(apiKey)}";
+        var response = await http.GetFromJsonAsync<GeminiModelsResponse>(url, ct)
+            .ConfigureAwait(false);
+
+        if (response?.Models is not { Count: > 0 })
+            return KnownModels;
+
+        return response.Models
+            .Where(m => !string.IsNullOrEmpty(m.Name)
+                        && m.SupportedMethods?.Contains("generateContent") == true)
+            .Select(m =>
+            {
+                // API returns "models/gemini-2.5-pro" — strip prefix
+                var id = m.Name!.StartsWith("models/", StringComparison.Ordinal)
+                    ? m.Name["models/".Length..]
+                    : m.Name;
+                var display = m.DisplayName ?? id;
+                return new ProviderModelInfo(id, display, ProviderName);
+            })
+            .ToList();
+    }
+
     protected override void ConfigureKernel(IKernelBuilder builder, ProviderModelInfo model, string apiKey)
     {
 #pragma warning disable SKEXP0070
@@ -34,4 +64,12 @@ public sealed class GoogleGeminiDetector : ApiKeyProviderDetectorBase
             apiKey: apiKey);
 #pragma warning restore SKEXP0070
     }
+
+    private sealed record GeminiModelsResponse(
+        [property: JsonPropertyName("models")] List<GeminiModel>? Models);
+
+    private sealed record GeminiModel(
+        [property: JsonPropertyName("name")] string? Name,
+        [property: JsonPropertyName("displayName")] string? DisplayName,
+        [property: JsonPropertyName("supportedGenerationMethods")] List<string>? SupportedMethods);
 }

--- a/src/JD.AI.Core/Providers/HuggingFaceDetector.cs
+++ b/src/JD.AI.Core/Providers/HuggingFaceDetector.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using JD.AI.Core.Providers.Credentials;
 using Microsoft.SemanticKernel;
 
@@ -5,14 +8,9 @@ namespace JD.AI.Core.Providers;
 
 /// <summary>
 /// Detects HuggingFace Inference API availability via API key.
-/// Uses the official Microsoft.SemanticKernel.Connectors.HuggingFace package.
+/// Dynamically discovers the most popular inference-ready chat models from
+/// the HuggingFace Hub, falling back to a curated catalog when offline.
 /// </summary>
-/// <remarks>
-/// Model catalog targets the HuggingFace serverless Inference API.
-/// Large models (70B+) may not be available on the free tier and can
-/// return HTTP 410 Gone — prefer smaller inference-ready models here.
-/// Use <c>/model search</c> to discover additional models dynamically.
-/// </remarks>
 public sealed class HuggingFaceDetector : ApiKeyProviderDetectorBase
 {
     private static readonly ProviderModelInfo[] KnownModelsCatalog =
@@ -31,6 +29,30 @@ public sealed class HuggingFaceDetector : ApiKeyProviderDetectorBase
 
     protected override IReadOnlyList<ProviderModelInfo> KnownModels => KnownModelsCatalog;
 
+    protected override async Task<IReadOnlyList<ProviderModelInfo>> DiscoverModelsAsync(
+        string apiKey, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        const string url = "https://huggingface.co/api/models?" +
+                           "pipeline_tag=text-generation&" +
+                           "inference_provider=all&" +
+                           "sort=downloads&direction=-1&limit=10&" +
+                           "filter=conversational";
+
+        var models = await http.GetFromJsonAsync<List<HfModelEntry>>(url, ct)
+            .ConfigureAwait(false);
+
+        if (models is null or { Count: 0 })
+            return KnownModels;
+
+        return models
+            .Where(m => !string.IsNullOrEmpty(m.Id))
+            .Select(m => new ProviderModelInfo(m.Id!, FormatName(m.Id!), ProviderName))
+            .ToList();
+    }
+
     protected override void ConfigureKernel(IKernelBuilder builder, ProviderModelInfo model, string apiKey)
     {
 #pragma warning disable SKEXP0070
@@ -39,4 +61,16 @@ public sealed class HuggingFaceDetector : ApiKeyProviderDetectorBase
             apiKey: apiKey);
 #pragma warning restore SKEXP0070
     }
+
+    private static string FormatName(string id)
+    {
+        var name = id.Contains('/') ? id[(id.IndexOf('/') + 1)..] : id;
+        return name
+            .Replace("-Instruct", "", StringComparison.OrdinalIgnoreCase)
+            .Replace('-', ' ')
+            .Trim();
+    }
+
+    private sealed record HfModelEntry(
+        [property: JsonPropertyName("id")] string? Id);
 }

--- a/src/JD.AI.Core/Providers/MistralDetector.cs
+++ b/src/JD.AI.Core/Providers/MistralDetector.cs
@@ -1,3 +1,6 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using JD.AI.Core.Providers.Credentials;
 using Microsoft.SemanticKernel;
 
@@ -5,7 +8,8 @@ namespace JD.AI.Core.Providers;
 
 /// <summary>
 /// Detects Mistral AI availability via API key.
-/// Uses the official Microsoft.SemanticKernel.Connectors.MistralAI package.
+/// Dynamically discovers models from the Mistral API, falling back to a
+/// curated catalog when the endpoint is unreachable.
 /// </summary>
 public sealed class MistralDetector : ApiKeyProviderDetectorBase
 {
@@ -26,6 +30,26 @@ public sealed class MistralDetector : ApiKeyProviderDetectorBase
 
     protected override IReadOnlyList<ProviderModelInfo> KnownModels => KnownModelsCatalog;
 
+    protected override async Task<IReadOnlyList<ProviderModelInfo>> DiscoverModelsAsync(
+        string apiKey, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var response = await http
+            .GetFromJsonAsync<MistralModelsResponse>("https://api.mistral.ai/v1/models", ct)
+            .ConfigureAwait(false);
+
+        if (response?.Data is not { Count: > 0 })
+            return KnownModels;
+
+        return response.Data
+            .Where(m => !string.IsNullOrEmpty(m.Id))
+            .OrderByDescending(m => m.Created)
+            .Select(m => new ProviderModelInfo(m.Id!, FormatName(m.Id!), ProviderName))
+            .ToList();
+    }
+
     protected override void ConfigureKernel(IKernelBuilder builder, ProviderModelInfo model, string apiKey)
     {
 #pragma warning disable SKEXP0070
@@ -34,4 +58,16 @@ public sealed class MistralDetector : ApiKeyProviderDetectorBase
             apiKey: apiKey);
 #pragma warning restore SKEXP0070
     }
+
+    private static string FormatName(string id) =>
+        id.Replace('-', ' ')
+          .Replace("latest", "", StringComparison.OrdinalIgnoreCase)
+          .Trim();
+
+    private sealed record MistralModelsResponse(
+        [property: JsonPropertyName("data")] List<MistralModel>? Data);
+
+    private sealed record MistralModel(
+        [property: JsonPropertyName("id")] string? Id,
+        [property: JsonPropertyName("created")] long Created);
 }


### PR DESCRIPTION
## Summary

Replaces hardcoded model catalogs with live API discovery for all API-key-based providers. Each provider now queries its respective API at startup to get the latest available models, falling back gracefully to a curated static catalog on failure.

## Changes

### Base class: \ApiKeyProviderDetectorBase\
- Added \irtual DiscoverModelsAsync(string apiKey, CancellationToken ct)\ hook
- \DetectAsync\ now calls discovery with try/catch fallback to \KnownModels\
- Backward-compatible: providers that don't override still use static catalogs

### Provider implementations
| Provider | API Endpoint | Notes |
|----------|-------------|-------|
| **HuggingFace** | HF Hub API \/api/models\ | Top 10 conversational text-gen models by downloads |
| **Mistral** | \/v1/models\ | Bearer auth, sorted by creation date |
| **Google Gemini** | Generative Language API \/v1beta/models\ | Filtered to \generateContent\ capable |
| **Anthropic** | \/v1/models\ | \x-api-key\ + \nthropic-version\ headers |

### Already dynamic (no changes needed)
Ollama, Foundry Local, OpenAI, Codex, GitHub Copilot, OpenAI-Compatible

### Kept static (by design)
Claude Code (proxy models), AWS Bedrock (needs AWS SDK), Azure OpenAI (config-based)

## Testing
- All 2248 non-git tests pass
- 7 GitToolsTests failures are pre-existing (git state dependent)
- Each discovery uses 10s timeout with graceful fallback

Closes #130