### PR TITLE
fix: make first model in each provider group selectable

### DIFF
--- a/src/JD.AI/Rendering/ModelPicker.cs
+++ b/src/JD.AI/Rendering/ModelPicker.cs
@@ -61,7 +61,7 @@ internal static class ModelPicker
 
         foreach (var group in grouped)
         {
-            prompt.AddChoiceGroup(group.First(), group.Skip(1));
+            prompt.AddChoices(group);
         }
 
         try


### PR DESCRIPTION
## Problem

\/model\ and \/provider\ commands showed the first model in each provider group (e.g. Mistral Large, Claude Opus 4) as grayed out and not selectable.

## Root Cause

\SelectionPrompt.AddChoiceGroup(first, rest)\ uses the first argument as a **non-selectable group header**. Since we passed \group.First()\ as the header, the first model in each group became a decorative label instead of a selectable choice.

## Fix

Replace \AddChoiceGroup(group.First(), group.Skip(1))\ with \AddChoices(group)\ so all models are selectable. The provider name is already shown in the converter via \[[ProviderName]]\ brackets, so visual grouping is preserved.

## One-line change
\\\diff
-prompt.AddChoiceGroup(group.First(), group.Skip(1));
+prompt.AddChoices(group);
\\\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>