### PR TITLE
Update ClaudeCode connector to 0.1.23 and enable interactive OAuth sessions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.41" />
     <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.41" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="0.1.22" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="0.1.23" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.14" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.OpenAICodex" Version="0.1.3" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />

--- a/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
+++ b/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
@@ -140,7 +140,11 @@ public sealed class ClaudeCodeDetector : IProviderDetector
     /// </summary>
     private static ClaudeCodeSessionOptions BuildSessionOptions()
     {
-        var options = new ClaudeCodeSessionOptions();
+        var options = new ClaudeCodeSessionOptions
+        {
+            // OAuth-based Claude Code session credentials are only valid in interactive usage.
+            EnableOAuthTokenSupport = Environment.UserInteractive,
+        };
 
         // Check if the default path would resolve to a service account home
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);

--- a/tests/JD.AI.Tests/Providers/ClaudeCodeDetectorKernelTests.cs
+++ b/tests/JD.AI.Tests/Providers/ClaudeCodeDetectorKernelTests.cs
@@ -21,12 +21,12 @@ public sealed class ClaudeCodeDetectorKernelTests
     }
 
     [Fact]
-    public void ConfigureKernelBuilder_WithOAuthToken_RegistersPromptCachingChatClient()
+    public void ConfigureKernelBuilder_WithApiKey_RegistersPromptCachingChatClient()
     {
         var builder = Kernel.CreateBuilder();
         var options = new ClaudeCodeSessionOptions
         {
-            OAuthToken = "sk-ant-oat-test-token",
+            ApiKey = "sk-ant-api-test-token",
         };
 
         ClaudeCodeDetector.ConfigureKernelBuilder(builder, options);
@@ -48,7 +48,7 @@ public sealed class ClaudeCodeDetectorKernelTests
     {
         var options = new ClaudeCodeSessionOptions
         {
-            OAuthToken = "sk-ant-oat-test-token",
+            ApiKey = "sk-ant-api-test-token",
         };
 
         Assert.Throws<ArgumentNullException>(() =>


### PR DESCRIPTION
## Summary
- bump JD.SemanticKernel.Connectors.ClaudeCode from 0.1.22 to 0.1.23
- set ClaudeCodeSessionOptions.EnableOAuthTokenSupport in ClaudeCodeDetector when running interactively
- update ClaudeCodeDetectorKernelTests to use API-key configuration for stable non-interactive test execution

## Why
0.1.23 introduces compliance hardening where OAuth is opt-in and interactive-only by default. The TUI remains interactive, so local credential harvesting is still supported when interactive.

## Validation
- dotnet nuget locals http-cache --clear
- dotnet restore src/JD.AI.Core/JD.AI.Core.csproj
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj