### PR TITLE
feat: provider fallback for OpenClaw and gateway agents

### DIFF
--- a/src/JD.AI.Daemon/appsettings.json
+++ b/src/JD.AI.Daemon/appsettings.json
@@ -22,10 +22,11 @@
     "Agents": [
       {
         "Id": "default",
-        "Provider": "ollama",
-        "Model": "qwen3.5:27b",
+        "Provider": "copilot",
+        "Model": "claude-sonnet-4-6",
         "SystemPrompt": "You are a helpful AI assistant connected to the JD.AI gateway.",
-        "AutoSpawn": true
+        "AutoSpawn": true,
+        "FallbackProviders": [ "claude-code", "ollama/qwen3.5:27b" ]
       }
     ],
 
@@ -97,8 +98,8 @@
           "Id": "jdai-default",
           "Name": "JD.AI Assistant",
           "Emoji": "🤖",
-          "Theme": "Helpful .NET AI assistant powered by Semantic Kernel and Ollama",
-          "Model": "ollama/qwen3.5:27b",
+          "Theme": "Helpful .NET AI assistant powered by Semantic Kernel",
+          "Model": "copilot/claude-sonnet-4-6",
           "GatewayAgentId": "default",
           "Bindings": [
             { "Channel": "discord" },

--- a/src/JD.AI.Gateway/Config/GatewayConfig.cs
+++ b/src/JD.AI.Gateway/Config/GatewayConfig.cs
@@ -68,6 +68,13 @@ public sealed class AgentDefinition
     public int MaxTurns { get; set; }
     public IList<string> Tools { get; set; } = [];
     public ModelParameters Parameters { get; set; } = new();
+
+    /// <summary>
+    /// Ordered list of fallback providers to try when the primary provider is unavailable.
+    /// Each entry is "provider/model" (e.g. "copilot/claude-sonnet-4-6") or just "provider"
+    /// (auto-selects first available model).
+    /// </summary>
+    public IList<string> FallbackProviders { get; set; } = [];
 }
 
 /// <summary>Tunable model inference parameters (Ollama, OpenAI, etc.).</summary>

--- a/src/JD.AI.Gateway/Endpoints/GatewayConfigEndpoints.cs
+++ b/src/JD.AI.Gateway/Endpoints/GatewayConfigEndpoints.cs
@@ -138,7 +138,9 @@ public static class GatewayConfigEndpoints
             AgentPoolService pool,
             CancellationToken ct) =>
         {
-            var id = await pool.SpawnAgentAsync(def.Provider, def.Model, def.SystemPrompt, ct, def.Parameters);
+            var id = await pool.SpawnAgentAsync(
+                def.Provider, def.Model, def.SystemPrompt, ct, def.Parameters,
+                def.FallbackProviders as IReadOnlyList<string> ?? [.. def.FallbackProviders]);
             return Results.Created($"/api/agents/{id}", new
             {
                 Id = id,

--- a/src/JD.AI.Gateway/Services/AgentPoolService.cs
+++ b/src/JD.AI.Gateway/Services/AgentPoolService.cs
@@ -51,7 +51,8 @@ public sealed class AgentPoolService : IHostedService
 
     public async Task<string> SpawnAgentAsync(
         string provider, string model, string? systemPrompt,
-        CancellationToken ct, ModelParameters? parameters = null)
+        CancellationToken ct, ModelParameters? parameters = null,
+        IReadOnlyList<string>? fallbackProviders = null)
     {
         var allProviders = await _providers.DetectProvidersAsync(ct);
         var providerInfo = allProviders.FirstOrDefault(p =>
@@ -75,7 +76,7 @@ public sealed class AgentPoolService : IHostedService
             history.AddSystemMessage(systemPrompt);
 
         var id = Guid.NewGuid().ToString("N")[..12];
-        var instance = new AgentInstance(id, provider, model, kernel, history, parameters);
+        var instance = new AgentInstance(id, provider, model, kernel, history, parameters, fallbackProviders);
         _agents[id] = instance;
 
         await _eventBus.PublishAsync(
@@ -139,6 +140,24 @@ public sealed class AgentPoolService : IHostedService
             turnActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             Meters.ProviderErrors.Add(1,
                 new KeyValuePair<string, object?>("gen_ai.system", agent.Provider));
+
+            // Try fallback providers before giving up
+            var fallbackResult = await TryFallbackProvidersAsync(agent, settings, ct).ConfigureAwait(false);
+            if (fallbackResult is not null)
+            {
+                content = fallbackResult;
+                agent.History.AddAssistantMessage(content);
+                agent.TurnCount++;
+
+                turnActivity?.SetTag("jdai.agent.fallback_used", "true");
+
+                await _eventBus.PublishAsync(
+                    new GatewayEvent("agent.turn_complete", agentId, DateTimeOffset.UtcNow,
+                        new { Turn = agent.TurnCount, Fallback = true }), ct);
+
+                return content;
+            }
+
             throw;
         }
 
@@ -150,8 +169,92 @@ public sealed class AgentPoolService : IHostedService
     }
 
     /// <summary>
+    /// Tries each configured fallback provider/model in order. Returns the
+    /// response content on first success, or <c>null</c> if all fallbacks fail.
+    /// </summary>
+    private async Task<string?> TryFallbackProvidersAsync(
+        AgentInstance agent, OpenAIPromptExecutionSettings settings, CancellationToken ct)
+    {
+        if (agent.FallbackProviders.Count == 0)
+            return null;
+
+        foreach (var fallback in agent.FallbackProviders)
+        {
+            if (ct.IsCancellationRequested) break;
+
+            var (fbProvider, fbModel) = ParseProviderModel(fallback);
+
+            try
+            {
+                var allProviders = await _providers.DetectProvidersAsync(ct);
+                var providerInfo = allProviders.FirstOrDefault(p =>
+                    p.Name.Equals(fbProvider, StringComparison.OrdinalIgnoreCase));
+
+                if (providerInfo is null || !providerInfo.IsAvailable)
+                {
+                    _logger.LogDebug("Fallback provider '{Provider}' not available, skipping", fbProvider);
+                    continue;
+                }
+
+                var modelInfo = fbModel is not null
+                    ? providerInfo.Models.FirstOrDefault(m =>
+                        m.Id.Equals(fbModel, StringComparison.OrdinalIgnoreCase)
+                        || m.DisplayName.Equals(fbModel, StringComparison.OrdinalIgnoreCase)
+                        || m.Id.StartsWith(fbModel + ":", StringComparison.OrdinalIgnoreCase))
+                    : providerInfo.Models.Count > 0 ? providerInfo.Models[0] : null;
+
+                if (modelInfo is null)
+                {
+                    _logger.LogDebug("No suitable model found for fallback provider '{Provider}', skipping", fbProvider);
+                    continue;
+                }
+
+                var detector = _providers.GetDetector(fbProvider);
+                if (detector is null) continue;
+
+                var fbKernel = detector.BuildKernel(modelInfo);
+                var fbChat = fbKernel.GetRequiredService<IChatCompletionService>();
+
+                _logger.LogInformation(
+                    "Falling back to {Provider}/{Model} for agent {AgentId}",
+                    fbProvider, modelInfo.Id, agent.Id);
+
+                await _eventBus.PublishAsync(
+                    new GatewayEvent("agent.fallback", agent.Id, DateTimeOffset.UtcNow,
+                        new { Provider = fbProvider, Model = modelInfo.Id }), ct);
+
+                var result = await fbChat.GetChatMessageContentAsync(
+                    agent.History, settings, cancellationToken: ct).ConfigureAwait(false);
+
+                return result.Content ?? "";
+            }
+#pragma warning disable CA1031
+            catch (Exception fbEx)
+            {
+                _logger.LogWarning(
+                    "Fallback provider '{Provider}' also failed: {Error}",
+                    fallback, fbEx.Message);
+            }
+#pragma warning restore CA1031
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses "provider/model" or "provider" into its components.
+    /// </summary>
+    internal static (string Provider, string? Model) ParseProviderModel(string input)
+    {
+        var slashIdx = input.IndexOf('/', StringComparison.Ordinal);
+        return slashIdx >= 0
+            ? (input[..slashIdx], input[(slashIdx + 1)..])
+            : (input, null);
+    }
+
+    /// <summary>
     /// Sends a chat completion request with exponential-backoff retry for
-    /// transient Ollama errors (model runner crash, 500s, connection resets).
+    /// transient provider errors (model runner crash, 500s, connection resets).
     /// </summary>
     internal async Task<ChatMessageContent> SendWithRetryAsync(
         IChatCompletionService chat, AgentInstance agent,
@@ -179,7 +282,7 @@ public sealed class AgentPoolService : IHostedService
 
                 return result;
             }
-            catch (Exception ex) when (attempt < MaxRetries && IsTransientOllamaError(ex) && !ct.IsCancellationRequested)
+            catch (Exception ex) when (attempt < MaxRetries && IsTransientProviderError(ex) && !ct.IsCancellationRequested)
             {
                 sw.Stop();
                 providerActivity?.AddException(ex);
@@ -187,7 +290,7 @@ public sealed class AgentPoolService : IHostedService
 
                 var delay = BaseRetryDelay * Math.Pow(2, attempt);
                 _logger.LogWarning(
-                    "Ollama transient error on attempt {Attempt}/{MaxRetries}: {Error}. Retrying in {Delay}s...",
+                    "Transient provider error on attempt {Attempt}/{MaxRetries}: {Error}. Retrying in {Delay}s...",
                     attempt + 1, MaxRetries, ex.Message, delay.TotalSeconds);
 
                 await _eventBus.PublishAsync(
@@ -207,11 +310,11 @@ public sealed class AgentPoolService : IHostedService
     }
 
     /// <summary>
-    /// Determines whether an exception represents a transient Ollama error
+    /// Determines whether an exception represents a transient provider error
     /// that is likely to succeed on retry (model runner crash, resource limits,
     /// connection reset, timeout).
     /// </summary>
-    internal static bool IsTransientOllamaError(Exception ex)
+    internal static bool IsTransientProviderError(Exception ex)
     {
         // Walk the exception chain for inner causes
         for (var current = ex; current is not null; current = current.InnerException)
@@ -297,7 +400,8 @@ public sealed class AgentPoolService : IHostedService
     internal sealed class AgentInstance(
         string id, string provider, string model,
         Kernel kernel, ChatHistory history,
-        ModelParameters? parameters = null)
+        ModelParameters? parameters = null,
+        IReadOnlyList<string>? fallbackProviders = null)
     {
         public string Id => id;
         public string Provider => provider;
@@ -305,6 +409,7 @@ public sealed class AgentPoolService : IHostedService
         public Kernel Kernel => kernel;
         public ChatHistory History => history;
         public ModelParameters? Parameters => parameters;
+        public IReadOnlyList<string> FallbackProviders => fallbackProviders ?? [];
         public int TurnCount { get; set; }
         public DateTimeOffset CreatedAt { get; } = DateTimeOffset.UtcNow;
     }

--- a/src/JD.AI.Gateway/Services/GatewayOrchestrator.cs
+++ b/src/JD.AI.Gateway/Services/GatewayOrchestrator.cs
@@ -166,7 +166,8 @@ public sealed class GatewayOrchestrator : IHostedService
             try
             {
                 var poolId = await _agentPool.SpawnAgentAsync(
-                    def.Provider, def.Model, def.SystemPrompt, ct, def.Parameters);
+                    def.Provider, def.Model, def.SystemPrompt, ct, def.Parameters,
+                    def.FallbackProviders as IReadOnlyList<string> ?? [.. def.FallbackProviders]);
 
                 _spawnedAgents[def.Id] = poolId;
                 _logger.LogInformation(

--- a/tests/JD.AI.Gateway.Tests/OllamaResilienceTests.cs
+++ b/tests/JD.AI.Gateway.Tests/OllamaResilienceTests.cs
@@ -15,7 +15,7 @@ public sealed class OllamaResilienceTests
             "Ollama API error 500: {\"error\":\"model runner has unexpectedly stopped, " +
             "this may be due to resource limitations or an internal error\"}");
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public sealed class OllamaResilienceTests
         var ex = new InvalidOperationException(
             "Failed due to resource limitations on the host");
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class OllamaResilienceTests
             inner: null,
             statusCode: System.Net.HttpStatusCode.InternalServerError);
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public sealed class OllamaResilienceTests
             inner: null,
             statusCode: System.Net.HttpStatusCode.ServiceUnavailable);
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public sealed class OllamaResilienceTests
             inner: null,
             statusCode: System.Net.HttpStatusCode.BadGateway);
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public sealed class OllamaResilienceTests
             (int)System.Net.Sockets.SocketError.ConnectionRefused);
         var httpEx = new HttpRequestException("Connection refused", socketEx);
 
-        AgentPoolService.IsTransientOllamaError(httpEx).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(httpEx).Should().BeTrue();
     }
 
     [Fact]
@@ -76,7 +76,7 @@ public sealed class OllamaResilienceTests
         var ioEx = new IOException("The response ended prematurely.");
         var httpEx = new HttpRequestException("Error sending request", ioEx);
 
-        AgentPoolService.IsTransientOllamaError(httpEx).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(httpEx).Should().BeTrue();
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public sealed class OllamaResilienceTests
         var outer = new InvalidOperationException(
             "Chat completion failed", inner);
 
-        AgentPoolService.IsTransientOllamaError(outer).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(outer).Should().BeTrue();
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed class OllamaResilienceTests
             inner: null,
             statusCode: System.Net.HttpStatusCode.BadRequest);
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeFalse();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeFalse();
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public sealed class OllamaResilienceTests
             inner: null,
             statusCode: System.Net.HttpStatusCode.NotFound);
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeFalse();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeFalse();
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public sealed class OllamaResilienceTests
         var ex = new ArgumentException("Invalid parameter");
 #pragma warning restore MA0015
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeFalse();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeFalse();
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public sealed class OllamaResilienceTests
     {
         var ex = new InvalidOperationException("Object reference not set");
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeFalse();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeFalse();
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public sealed class OllamaResilienceTests
         var ex = new InvalidOperationException(
             "HTTP request returned status code 500 with error response");
 
-        AgentPoolService.IsTransientOllamaError(ex).Should().BeTrue();
+        AgentPoolService.IsTransientProviderError(ex).Should().BeTrue();
     }
 
     [Fact]
@@ -146,5 +146,17 @@ public sealed class OllamaResilienceTests
     {
         AgentPoolService.MaxRetries.Should().Be(3);
         AgentPoolService.BaseRetryDelay.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    [Theory]
+    [InlineData("copilot/claude-sonnet-4-6", "copilot", "claude-sonnet-4-6")]
+    [InlineData("ollama/qwen3.5:27b", "ollama", "qwen3.5:27b")]
+    [InlineData("claude-code", "claude-code", null)]
+    [InlineData("openai", "openai", null)]
+    public void ParseProviderModel_SplitsCorrectly(string input, string expectedProvider, string? expectedModel)
+    {
+        var (provider, model) = AgentPoolService.ParseProviderModel(input);
+        provider.Should().Be(expectedProvider);
+        model.Should().Be(expectedModel);
     }
 }


### PR DESCRIPTION
## Problem

OpenClaw cron runs are stuck on Ollama which crashes repeatedly with 500 errors. When Ollama fails, there's no fallback - the error repeats indefinitely.

## Solution

Add a configurable provider fallback chain to gateway agents. When the primary provider exhausts all retry attempts, the agent automatically tries each fallback in order.

### How it works
1. Primary provider fails -> 3 retries with exponential backoff
2. All retries exhausted -> iterate FallbackProviders in order
3. For each fallback: detect provider -> resolve model -> build kernel -> send request
4. First successful response returned; all failures logged and skipped
5. If all fallbacks fail, the original error propagates

### Default config updated
- Primary: copilot/claude-sonnet-4-6
- Fallback 1: claude-code
- Fallback 2: ollama/qwen3.5:27b

## Changes
- GatewayConfig: FallbackProviders on AgentDefinition
- AgentPoolService: TryFallbackProvidersAsync, ParseProviderModel, rename IsTransientOllamaError -> IsTransientProviderError
- GatewayOrchestrator: Pass fallbacks when spawning
- appsettings.json: Default to copilot with fallback chain
- Tests: Updated + 4 new ParseProviderModel tests

## Testing
- Build: 0 warnings, 0 errors
- Format: clean
- Tests: 2,261 passed, 0 failed
