### PR TITLE
feat(workflows): SemVer-aware catalog resolution and version constraints

### DIFF
--- a/src/JD.AI.Workflows/FileWorkflowCatalog.cs
+++ b/src/JD.AI.Workflows/FileWorkflowCatalog.cs
@@ -26,6 +26,32 @@ public sealed class FileWorkflowCatalog : IWorkflowCatalog
 
     public async Task SaveAsync(AgentWorkflowDefinition definition, CancellationToken ct = default)
     {
+        var nextVersion = WorkflowVersioning.ParseVersionOrThrow(definition.Version);
+
+        var priorVersions = await LoadByNameAsync(definition.Name, ct).ConfigureAwait(false);
+        var previous = WorkflowVersioning.SelectVersion(priorVersions, "latest");
+        if (previous is not null &&
+            !string.Equals(previous.Version, definition.Version, StringComparison.Ordinal))
+        {
+            var previousVersion = WorkflowVersioning.ParseVersionOrThrow(previous.Version);
+            var breaking = WorkflowVersioning.DetectBreakingChanges(previous, definition);
+
+            definition.BreakingChanges.Clear();
+            foreach (var change in breaking)
+                definition.BreakingChanges.Add(change);
+
+            if (breaking.Count > 0 && nextVersion.Major <= previousVersion.Major)
+            {
+                throw new InvalidDataException(
+                    $"Breaking changes detected between versions {previous.Version} and {definition.Version}. " +
+                    "Increment major version for breaking workflow changes.");
+            }
+        }
+        else
+        {
+            definition.BreakingChanges.Clear();
+        }
+
         definition.UpdatedAt = DateTime.UtcNow;
         var path = GetPath(definition.Name, definition.Version);
         var json = JsonSerializer.Serialize(definition, JsonOptions);
@@ -35,20 +61,8 @@ public sealed class FileWorkflowCatalog : IWorkflowCatalog
     public async Task<AgentWorkflowDefinition?> GetAsync(
         string name, string? version = null, CancellationToken ct = default)
     {
-        if (version is not null)
-        {
-            var path = GetPath(name, version);
-            return File.Exists(path)
-                ? await ReadAsync(path, ct).ConfigureAwait(false)
-                : null;
-        }
-
-        // Return latest version
-        var files = Directory.GetFiles(_baseDirectory, $"{Sanitize(name)}-*.json");
-        if (files.Length == 0) return null;
-
-        var latest = files.OrderByDescending(f => f).First();
-        return await ReadAsync(latest, ct).ConfigureAwait(false);
+        var versions = await LoadByNameAsync(name, ct).ConfigureAwait(false);
+        return WorkflowVersioning.SelectVersion(versions, version);
     }
 
     public async Task<IReadOnlyList<AgentWorkflowDefinition>> ListAsync(CancellationToken ct = default)
@@ -71,7 +85,18 @@ public sealed class FileWorkflowCatalog : IWorkflowCatalog
 
     public Task<bool> DeleteAsync(string name, string? version = null, CancellationToken ct = default)
     {
-        var path = GetPath(name, version ?? "1.0");
+        if (version is null)
+        {
+            var files = Directory.GetFiles(_baseDirectory, $"{Sanitize(name)}-*.json");
+            if (files.Length == 0)
+                return Task.FromResult(false);
+
+            foreach (var file in files)
+                File.Delete(file);
+            return Task.FromResult(true);
+        }
+
+        var path = GetPath(name, version);
         if (!File.Exists(path))
             return Task.FromResult(false);
 
@@ -83,11 +108,33 @@ public sealed class FileWorkflowCatalog : IWorkflowCatalog
         Path.Combine(_baseDirectory, $"{Sanitize(name)}-{Sanitize(version)}.json");
 
     private static string Sanitize(string input) =>
-        string.Concat(input.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '.' ? c : '_'));
+        string.Concat(input.Select(c => char.IsLetterOrDigit(c) || c is '-' or '.' or '+' ? c : '_'));
 
     private static async Task<AgentWorkflowDefinition?> ReadAsync(string path, CancellationToken ct)
     {
         var json = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize<AgentWorkflowDefinition>(json, JsonOptions);
+    }
+
+    private async Task<IReadOnlyList<AgentWorkflowDefinition>> LoadByNameAsync(
+        string name,
+        CancellationToken ct)
+    {
+        var files = Directory.GetFiles(_baseDirectory, $"{Sanitize(name)}-*.json");
+        if (files.Length == 0)
+            return [];
+
+        var results = new List<AgentWorkflowDefinition>(files.Length);
+        foreach (var file in files)
+        {
+            var def = await ReadAsync(file, ct).ConfigureAwait(false);
+            if (def is not null &&
+                string.Equals(def.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                results.Add(def);
+            }
+        }
+
+        return results;
     }
 }

--- a/src/JD.AI.Workflows/InMemoryWorkflowCatalog.cs
+++ b/src/JD.AI.Workflows/InMemoryWorkflowCatalog.cs
@@ -14,12 +14,36 @@ public sealed class InMemoryWorkflowCatalog : IWorkflowCatalog
     /// <inheritdoc/>
     public Task SaveAsync(AgentWorkflowDefinition definition, CancellationToken ct = default)
     {
+        var nextVersion = WorkflowVersioning.ParseVersionOrThrow(definition.Version);
+
         lock (_lock)
         {
             if (!_store.TryGetValue(definition.Name, out var versions))
             {
                 versions = [];
                 _store[definition.Name] = versions;
+            }
+
+            var previous = WorkflowVersioning.SelectVersion(versions, "latest");
+            if (previous is not null &&
+                !string.Equals(previous.Version, definition.Version, StringComparison.Ordinal))
+            {
+                var previousVersion = WorkflowVersioning.ParseVersionOrThrow(previous.Version);
+                var breaking = WorkflowVersioning.DetectBreakingChanges(previous, definition);
+                definition.BreakingChanges.Clear();
+                foreach (var change in breaking)
+                    definition.BreakingChanges.Add(change);
+
+                if (breaking.Count > 0 && nextVersion.Major <= previousVersion.Major)
+                {
+                    throw new InvalidDataException(
+                        $"Breaking changes detected between versions {previous.Version} and {definition.Version}. " +
+                        "Increment major version for breaking workflow changes.");
+                }
+            }
+            else
+            {
+                definition.BreakingChanges.Clear();
             }
 
             versions.RemoveAll(w =>
@@ -39,12 +63,7 @@ public sealed class InMemoryWorkflowCatalog : IWorkflowCatalog
             if (!_store.TryGetValue(name, out var versions))
                 return Task.FromResult<AgentWorkflowDefinition?>(null);
 
-            var result = version is not null
-                ? versions.FirstOrDefault(w =>
-                    string.Equals(w.Version, version, StringComparison.Ordinal))
-                : versions.OrderByDescending(w => ParseVersion(w.Version))
-                          .FirstOrDefault();
-
+            var result = WorkflowVersioning.SelectVersion(versions, version);
             return Task.FromResult(result);
         }
     }
@@ -56,7 +75,9 @@ public sealed class InMemoryWorkflowCatalog : IWorkflowCatalog
         {
             var all = _store.Values
                 .Select(versions =>
-                    versions.OrderByDescending(w => ParseVersion(w.Version)).First())
+                    WorkflowVersioning.SelectVersion(versions, "latest"))
+                .Where(v => v is not null)
+                .Select(v => v!)
                 .ToList()
                 .AsReadOnly();
 
@@ -83,7 +104,4 @@ public sealed class InMemoryWorkflowCatalog : IWorkflowCatalog
             return Task.FromResult(true);
         }
     }
-
-    private static Version ParseVersion(string versionString) =>
-        Version.TryParse(versionString, out var v) ? v : new Version(0, 0);
 }

--- a/src/JD.AI.Workflows/Models.cs
+++ b/src/JD.AI.Workflows/Models.cs
@@ -9,6 +9,9 @@ public sealed class AgentWorkflowDefinition
     public string Name { get; set; } = string.Empty;
     public string Version { get; set; } = "1.0";
     public string Description { get; set; } = string.Empty;
+    public bool IsDeprecated { get; set; }
+    public string? MigrationGuidance { get; set; }
+    public IList<string> BreakingChanges { get; init; } = [];
     public IList<string> Tags { get; init; } = [];
     public IList<AgentStepDefinition> Steps { get; init; } = [];
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/JD.AI.Workflows/Store/FileWorkflowStore.cs
+++ b/src/JD.AI.Workflows/Store/FileWorkflowStore.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using JD.AI.Workflows;
 
 namespace JD.AI.Workflows.Store;
 
@@ -28,6 +29,8 @@ public sealed class FileWorkflowStore : IWorkflowStore
     /// <inheritdoc/>
     public async Task PublishAsync(SharedWorkflow workflow, CancellationToken ct = default)
     {
+        _ = WorkflowVersioning.ParseVersionOrThrow(workflow.Version);
+
         var dir = GetWorkflowDirectory(workflow.Name);
         Directory.CreateDirectory(dir);
 
@@ -40,14 +43,7 @@ public sealed class FileWorkflowStore : IWorkflowStore
     public async Task<SharedWorkflow?> GetAsync(
         string nameOrId, string? version = null, CancellationToken ct = default)
     {
-        // First try by name/version
-        if (version is not null)
-        {
-            var path = GetVersionPath(nameOrId, version);
-            if (File.Exists(path))
-                return await ReadAsync(path, ct).ConfigureAwait(false);
-        }
-        else
+        if (version is null)
         {
             // Try as a name — return latest version
             var dir = GetWorkflowDirectory(nameOrId);
@@ -56,8 +52,26 @@ public sealed class FileWorkflowStore : IWorkflowStore
                 var files = Directory.GetFiles(dir, "*.json");
                 if (files.Length > 0)
                 {
-                    var latest = GetLatestVersionFile(files);
-                    return await ReadAsync(latest, ct).ConfigureAwait(false);
+                    var workflows = await ReadAllAsync(files, ct).ConfigureAwait(false);
+                    var latest = SelectSharedVersion(workflows, "latest");
+                    if (latest is not null)
+                        return latest;
+                }
+            }
+        }
+        else
+        {
+            // Try as a name + version selector
+            var dir = GetWorkflowDirectory(nameOrId);
+            if (Directory.Exists(dir))
+            {
+                var files = Directory.GetFiles(dir, "*.json");
+                if (files.Length > 0)
+                {
+                    var workflows = await ReadAllAsync(files, ct).ConfigureAwait(false);
+                    var selected = SelectSharedVersion(workflows, version);
+                    if (selected is not null)
+                        return selected;
                 }
             }
         }
@@ -68,7 +82,13 @@ public sealed class FileWorkflowStore : IWorkflowStore
             string.Equals(w.Id, nameOrId, StringComparison.OrdinalIgnoreCase));
 
         if (byId is not null && version is not null)
-            return string.Equals(byId.Version, version, StringComparison.Ordinal) ? byId : null;
+        {
+            if (!WorkflowSemVersion.TryParse(byId.Version, out var parsedById))
+                return null;
+
+            var selector = WorkflowVersioning.WorkflowVersionSelector.Parse(version);
+            return selector.Matches(parsedById) ? byId : null;
+        }
 
         return byId;
     }
@@ -186,7 +206,7 @@ public sealed class FileWorkflowStore : IWorkflowStore
         Path.Combine(GetWorkflowDirectory(name), $"{Sanitize(version)}.json");
 
     internal static string Sanitize(string input) =>
-        string.Concat(input.Select(c => char.IsLetterOrDigit(c) || c == '-' || c == '.' ? c : '_'));
+        string.Concat(input.Select(c => char.IsLetterOrDigit(c) || c is '-' or '.' or '+' ? c : '_'));
 
     /// <summary>
     /// Returns the file path with the highest semantic version from an array of version files.
@@ -195,10 +215,12 @@ public sealed class FileWorkflowStore : IWorkflowStore
     private static string GetLatestVersionFile(string[] files) =>
         files.OrderByDescending(ParseVersionFromPath).First();
 
-    private static Version ParseVersionFromPath(string path)
+    private static WorkflowSemVersion ParseVersionFromPath(string path)
     {
         var name = Path.GetFileNameWithoutExtension(path);
-        return Version.TryParse(name, out var v) ? v : new Version(0, 0, 0);
+        return WorkflowSemVersion.TryParse(name, out var v)
+            ? v
+            : new WorkflowSemVersion(0, 0, 0, [], null);
     }
 
     private static async Task<SharedWorkflow?> ReadAsync(string path, CancellationToken ct)
@@ -214,5 +236,38 @@ public sealed class FileWorkflowStore : IWorkflowStore
             return null;
         }
 #pragma warning restore CA1031
+    }
+
+    private static async Task<IReadOnlyList<SharedWorkflow>> ReadAllAsync(
+        IEnumerable<string> files,
+        CancellationToken ct)
+    {
+        var results = new List<SharedWorkflow>();
+        foreach (var file in files)
+        {
+            var workflow = await ReadAsync(file, ct).ConfigureAwait(false);
+            if (workflow is not null)
+                results.Add(workflow);
+        }
+
+        return results;
+    }
+
+    private static SharedWorkflow? SelectSharedVersion(
+        IEnumerable<SharedWorkflow> workflows,
+        string? selector)
+    {
+        var parsedSelector = WorkflowVersioning.WorkflowVersionSelector.Parse(selector);
+
+        return workflows
+            .Select(w =>
+            {
+                var ok = WorkflowSemVersion.TryParse(w.Version, out var parsed);
+                return (Workflow: w, Version: parsed, Valid: ok);
+            })
+            .Where(x => x.Valid && parsedSelector.Matches(x.Version))
+            .OrderByDescending(x => x.Version)
+            .Select(x => x.Workflow)
+            .FirstOrDefault();
     }
 }

--- a/src/JD.AI.Workflows/WorkflowVersioning.cs
+++ b/src/JD.AI.Workflows/WorkflowVersioning.cs
@@ -1,0 +1,353 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace JD.AI.Workflows;
+
+internal static partial class WorkflowVersioning
+{
+    private static readonly StringComparer NameComparer = StringComparer.OrdinalIgnoreCase;
+
+    internal static WorkflowSemVersion ParseVersionOrThrow(string version)
+    {
+        if (!WorkflowSemVersion.TryParse(version, out var parsed))
+            throw new InvalidDataException(
+                $"Workflow version '{version}' is not valid SemVer. Expected: major.minor[.patch][-prerelease][+build].");
+
+        return parsed;
+    }
+
+    internal static AgentWorkflowDefinition? SelectVersion(
+        IEnumerable<AgentWorkflowDefinition> definitions,
+        string? selector)
+    {
+        var versioned = definitions
+            .Select(def =>
+            {
+                var ok = WorkflowSemVersion.TryParse(def.Version, out var parsed);
+                return (Definition: def, Parsed: parsed, Valid: ok);
+            })
+            .Where(x => x.Valid)
+            .ToList();
+
+        if (versioned.Count == 0)
+            return null;
+
+        var parsedSelector = WorkflowVersionSelector.Parse(selector);
+
+        var candidates = versioned
+            .Where(v => parsedSelector.Matches(v.Parsed))
+            .OrderByDescending(v => v.Parsed)
+            .ToList();
+
+        if (candidates.Count == 0)
+            return null;
+
+        var nonDeprecated = candidates.FirstOrDefault(v => !v.Definition.IsDeprecated);
+        return nonDeprecated.Definition ?? candidates[0].Definition;
+    }
+
+    internal static IReadOnlyList<string> DetectBreakingChanges(
+        AgentWorkflowDefinition previous,
+        AgentWorkflowDefinition current)
+    {
+        var previousIndex = FlattenStepSignatures(previous.Steps)
+            .ToDictionary(x => x.Path, x => x, NameComparer);
+        var currentIndex = FlattenStepSignatures(current.Steps)
+            .ToDictionary(x => x.Path, x => x, NameComparer);
+
+        var changes = new List<string>();
+        foreach (var (path, prior) in previousIndex)
+        {
+            if (!currentIndex.TryGetValue(path, out var next))
+            {
+                changes.Add($"Removed step '{prior.Name}' at '{path}'.");
+                continue;
+            }
+
+            if (prior.Kind != next.Kind)
+                changes.Add($"Changed step kind at '{path}' ({prior.Kind} -> {next.Kind}).");
+
+            if (!string.Equals(prior.Target, next.Target, StringComparison.Ordinal))
+                changes.Add($"Changed step target at '{path}' ('{prior.Target}' -> '{next.Target}').");
+
+            if (!string.Equals(prior.Condition, next.Condition, StringComparison.Ordinal))
+                changes.Add($"Changed step condition at '{path}'.");
+
+            if (!prior.AllowedPlugins.SetEquals(next.AllowedPlugins))
+                changes.Add($"Changed allowed plugins at '{path}'.");
+        }
+
+        return changes;
+    }
+
+    private static IEnumerable<StepSignature> FlattenStepSignatures(
+        IEnumerable<AgentStepDefinition> steps,
+        string pathPrefix = "")
+    {
+        var index = 0;
+        foreach (var step in steps)
+        {
+            var path = string.IsNullOrEmpty(pathPrefix)
+                ? $"{index}:{step.Name}"
+                : $"{pathPrefix}/{index}:{step.Name}";
+
+            yield return new StepSignature(
+                path,
+                step.Name,
+                step.Kind,
+                step.Target ?? string.Empty,
+                step.Condition ?? string.Empty,
+                step.AllowedPlugins.ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+            foreach (var child in FlattenStepSignatures(step.SubSteps, path))
+                yield return child;
+
+            index++;
+        }
+    }
+
+    private sealed record StepSignature(
+        string Path,
+        string Name,
+        AgentStepKind Kind,
+        string Target,
+        string Condition,
+        HashSet<string> AllowedPlugins);
+
+    internal sealed class WorkflowVersionSelector
+    {
+        private readonly WorkflowSemVersion? _exact;
+        private readonly IReadOnlyList<Comparator> _comparators;
+
+        private WorkflowVersionSelector(WorkflowSemVersion? exact, IReadOnlyList<Comparator> comparators)
+        {
+            _exact = exact;
+            _comparators = comparators;
+        }
+
+        public static WorkflowVersionSelector Parse(string? selector)
+        {
+            if (string.IsNullOrWhiteSpace(selector) ||
+                string.Equals(selector, "latest", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WorkflowVersionSelector(exact: null, comparators: []);
+            }
+
+            var trimmed = selector.Trim();
+
+            if (trimmed.StartsWith('^'))
+            {
+                var floor = ParseVersionOrThrow(trimmed[1..].Trim());
+                return new WorkflowVersionSelector(
+                    exact: null,
+                    comparators:
+                    [
+                        new Comparator(ComparisonOp.GreaterThanOrEqual, floor),
+                        new Comparator(ComparisonOp.LessThan, floor.CaretUpperBound()),
+                    ]);
+            }
+
+            if (trimmed.StartsWith('~'))
+            {
+                var floor = ParseVersionOrThrow(trimmed[1..].Trim());
+                return new WorkflowVersionSelector(
+                    exact: null,
+                    comparators:
+                    [
+                        new Comparator(ComparisonOp.GreaterThanOrEqual, floor),
+                        new Comparator(ComparisonOp.LessThan, floor.TildeUpperBound()),
+                    ]);
+            }
+
+            var tokens = trimmed
+                .Split([' ', ','], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (tokens.Length == 1 && WorkflowSemVersion.TryParse(tokens[0], out var exact))
+                return new WorkflowVersionSelector(exact, []);
+
+            var comparators = new List<Comparator>();
+            foreach (var token in tokens)
+                comparators.Add(Comparator.Parse(token));
+
+            return new WorkflowVersionSelector(exact: null, comparators);
+        }
+
+        public bool Matches(WorkflowSemVersion version)
+        {
+            if (_exact is not null)
+                return version == _exact;
+
+            if (_comparators.Count == 0)
+                return true;
+
+            return _comparators.All(c => c.Matches(version));
+        }
+    }
+
+    private enum ComparisonOp
+    {
+        Equal,
+        GreaterThan,
+        GreaterThanOrEqual,
+        LessThan,
+        LessThanOrEqual,
+    }
+
+    private sealed record Comparator(ComparisonOp Op, WorkflowSemVersion Version)
+    {
+        public static Comparator Parse(string token)
+        {
+            var value = token.Trim();
+            if (value.Length == 0)
+                throw new InvalidDataException("Empty workflow version constraint token.");
+
+            var op = value switch
+            {
+                _ when value.StartsWith(">=", StringComparison.Ordinal) => ComparisonOp.GreaterThanOrEqual,
+                _ when value.StartsWith("<=", StringComparison.Ordinal) => ComparisonOp.LessThanOrEqual,
+                _ when value.StartsWith('>') => ComparisonOp.GreaterThan,
+                _ when value.StartsWith('<') => ComparisonOp.LessThan,
+                _ when value.StartsWith('=') => ComparisonOp.Equal,
+                _ => throw new InvalidDataException(
+                    $"Unsupported workflow version constraint token '{token}'. " +
+                    "Supported: ^, ~, =, >, >=, <, <="),
+            };
+
+            var start = op is ComparisonOp.GreaterThanOrEqual or ComparisonOp.LessThanOrEqual ? 2 : 1;
+            var version = ParseVersionOrThrow(value[start..].Trim());
+            return new Comparator(op, version);
+        }
+
+        public bool Matches(WorkflowSemVersion candidate)
+        {
+            var cmp = candidate.CompareTo(Version);
+            return Op switch
+            {
+                ComparisonOp.Equal => cmp == 0,
+                ComparisonOp.GreaterThan => cmp > 0,
+                ComparisonOp.GreaterThanOrEqual => cmp >= 0,
+                ComparisonOp.LessThan => cmp < 0,
+                ComparisonOp.LessThanOrEqual => cmp <= 0,
+                _ => false,
+            };
+        }
+    }
+}
+
+internal readonly partial record struct WorkflowSemVersion(
+    int Major,
+    int Minor,
+    int Patch,
+    IReadOnlyList<string> PreRelease,
+    string? BuildMetadata) : IComparable<WorkflowSemVersion>
+{
+    public static bool operator <(WorkflowSemVersion left, WorkflowSemVersion right) =>
+        left.CompareTo(right) < 0;
+
+    public static bool operator >(WorkflowSemVersion left, WorkflowSemVersion right) =>
+        left.CompareTo(right) > 0;
+
+    public static bool operator <=(WorkflowSemVersion left, WorkflowSemVersion right) =>
+        left.CompareTo(right) <= 0;
+
+    public static bool operator >=(WorkflowSemVersion left, WorkflowSemVersion right) =>
+        left.CompareTo(right) >= 0;
+
+    public static bool TryParse(string? value, out WorkflowSemVersion version)
+    {
+        version = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var match = SemVerRegex().Match(value.Trim());
+        if (!match.Success)
+            return false;
+
+        if (!int.TryParse(match.Groups["major"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var major) ||
+            !int.TryParse(match.Groups["minor"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var minor))
+        {
+            return false;
+        }
+
+        var patchGroup = match.Groups["patch"].Value;
+        var patch = 0;
+        if (patchGroup.Length > 0 &&
+            !int.TryParse(patchGroup, NumberStyles.None, CultureInfo.InvariantCulture, out patch))
+        {
+            return false;
+        }
+
+        var preRelease = match.Groups["pre"].Success
+            ? match.Groups["pre"].Value.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : [];
+        var build = match.Groups["build"].Success ? match.Groups["build"].Value : null;
+
+        version = new WorkflowSemVersion(major, minor, patch, preRelease, build);
+        return true;
+    }
+
+    public int CompareTo(WorkflowSemVersion other)
+    {
+        var majorCmp = Major.CompareTo(other.Major);
+        if (majorCmp != 0) return majorCmp;
+
+        var minorCmp = Minor.CompareTo(other.Minor);
+        if (minorCmp != 0) return minorCmp;
+
+        var patchCmp = Patch.CompareTo(other.Patch);
+        if (patchCmp != 0) return patchCmp;
+
+        var thisHasPre = PreRelease.Count > 0;
+        var otherHasPre = other.PreRelease.Count > 0;
+        if (!thisHasPre && !otherHasPre) return 0;
+        if (!thisHasPre) return 1;
+        if (!otherHasPre) return -1;
+
+        var max = Math.Max(PreRelease.Count, other.PreRelease.Count);
+        for (var i = 0; i < max; i++)
+        {
+            if (i >= PreRelease.Count) return -1;
+            if (i >= other.PreRelease.Count) return 1;
+
+            var left = PreRelease[i];
+            var right = other.PreRelease[i];
+
+            var leftNum = int.TryParse(left, NumberStyles.None, CultureInfo.InvariantCulture, out var leftInt);
+            var rightNum = int.TryParse(right, NumberStyles.None, CultureInfo.InvariantCulture, out var rightInt);
+
+            if (leftNum && rightNum)
+            {
+                var cmp = leftInt.CompareTo(rightInt);
+                if (cmp != 0) return cmp;
+                continue;
+            }
+
+            if (leftNum != rightNum)
+                return leftNum ? -1 : 1;
+
+            var lexicalCmp = string.Compare(left, right, StringComparison.Ordinal);
+            if (lexicalCmp != 0) return lexicalCmp;
+        }
+
+        return 0;
+    }
+
+    public WorkflowSemVersion CaretUpperBound()
+    {
+        if (Major > 0)
+            return new WorkflowSemVersion(Major + 1, 0, 0, [], null);
+
+        if (Minor > 0)
+            return new WorkflowSemVersion(0, Minor + 1, 0, [], null);
+
+        return new WorkflowSemVersion(0, 0, Patch + 1, [], null);
+    }
+
+    public WorkflowSemVersion TildeUpperBound() =>
+        new(Major, Minor + 1, 0, [], null);
+
+    [GeneratedRegex(
+        "^(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)(?:\\.(?<patch>0|[1-9]\\d*))?(?:-(?<pre>[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+(?<build>[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant)]
+    private static partial Regex SemVerRegex();
+}

--- a/tests/JD.AI.Tests/Governance/WorkflowStore/FileWorkflowStoreTests.cs
+++ b/tests/JD.AI.Tests/Governance/WorkflowStore/FileWorkflowStoreTests.cs
@@ -72,6 +72,13 @@ public class FileWorkflowStoreTests : IDisposable
         Directory.GetFiles(dir, "*.json").Should().HaveCount(2);
     }
 
+    [Fact]
+    public async Task Publish_InvalidSemVer_Throws()
+    {
+        var act = async () => await _store.PublishAsync(MakeWorkflow("bad", "not-semver"));
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
     // ── Catalog ───────────────────────────────────────────────
 
     [Fact]
@@ -95,6 +102,16 @@ public class FileWorkflowStoreTests : IDisposable
         var catalog = await _store.CatalogAsync();
         catalog.Should().HaveCount(1);
         catalog[0].Version.Should().Be("2.0.0");
+    }
+
+    [Fact]
+    public async Task Catalog_WithSemVerMinorOrdering_ReturnsActualLatest()
+    {
+        await _store.PublishAsync(MakeWorkflow("semver-catalog", "1.9.0"));
+        await _store.PublishAsync(MakeWorkflow("semver-catalog", "1.10.0"));
+
+        var catalog = await _store.CatalogAsync();
+        catalog.Should().ContainSingle(w => w.Name == "semver-catalog" && w.Version == "1.10.0");
     }
 
     [Fact]
@@ -303,6 +320,18 @@ public class FileWorkflowStoreTests : IDisposable
         result.Should().NotBeNull();
         result!.Name.Should().Be("get-test");
         result.Version.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public async Task Get_ByConstraint_ReturnsHighestMatching()
+    {
+        await _store.PublishAsync(MakeWorkflow("constraint-test", "1.2.0"));
+        await _store.PublishAsync(MakeWorkflow("constraint-test", "1.8.0"));
+        await _store.PublishAsync(MakeWorkflow("constraint-test", "2.0.0"));
+
+        var result = await _store.GetAsync("constraint-test", "^1.0.0");
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("1.8.0");
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/WorkflowTests.cs
+++ b/tests/JD.AI.Tests/WorkflowTests.cs
@@ -156,6 +156,108 @@ public class FileWorkflowCatalogTests : IDisposable
     }
 
     [Fact]
+    public async Task GetLatest_UsesSemVerOrdering()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "semver", Version = "1.9.0" });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "semver", Version = "1.10.0" });
+
+        var latest = await _catalog.GetAsync("semver");
+        latest.Should().NotBeNull();
+        latest!.Version.Should().Be("1.10.0");
+    }
+
+    [Fact]
+    public async Task Get_WithVersionConstraint_ResolvesHighestMatching()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "constrained", Version = "1.2.0" });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "constrained", Version = "1.9.0" });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "constrained", Version = "2.1.0" });
+
+        var caret = await _catalog.GetAsync("constrained", "^1.0.0");
+        var range = await _catalog.GetAsync("constrained", ">=1.0.0 <2.0.0");
+        var pin = await _catalog.GetAsync("constrained", "1.2.0");
+
+        caret!.Version.Should().Be("1.9.0");
+        range!.Version.Should().Be("1.9.0");
+        pin!.Version.Should().Be("1.2.0");
+    }
+
+    [Fact]
+    public async Task GetLatest_SkipsDeprecatedWhenPossible()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "deprecation",
+            Version = "1.0.0",
+            IsDeprecated = true,
+        });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "deprecation",
+            Version = "1.1.0",
+        });
+
+        var latest = await _catalog.GetAsync("deprecation", "latest");
+        latest!.Version.Should().Be("1.1.0");
+    }
+
+    [Fact]
+    public async Task Save_InvalidSemVer_Throws()
+    {
+        var act = async () => await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "invalid",
+            Version = "definitely-not-semver",
+        });
+
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
+    [Fact]
+    public async Task Save_BreakingChangeWithoutMajorBump_Throws()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "breaking",
+            Version = "1.0.0",
+            Steps = [AgentStepDefinition.RunSkill("analyze")],
+        });
+
+        var act = async () => await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "breaking",
+            Version = "1.1.0",
+            Steps = [AgentStepDefinition.InvokeTool("git.diff")],
+        });
+
+        await act.Should().ThrowAsync<InvalidDataException>();
+    }
+
+    [Fact]
+    public async Task Save_BreakingChangeWithMajorBump_IsAllowedAndCaptured()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "breaking-major",
+            Version = "1.0.0",
+            Steps = [AgentStepDefinition.RunSkill("analyze")],
+        });
+
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "breaking-major",
+            Version = "2.0.0",
+            Steps = [AgentStepDefinition.InvokeTool("git.diff")],
+            MigrationGuidance = "Switch to git.diff first.",
+        });
+
+        var latest = await _catalog.GetAsync("breaking-major");
+        latest.Should().NotBeNull();
+        latest!.BreakingChanges.Should().NotBeEmpty();
+        latest.MigrationGuidance.Should().Be("Switch to git.diff first.");
+    }
+
+    [Fact]
     public async Task List_ReturnsAll()
     {
         await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "a", Version = "1.0" })
@@ -359,6 +461,50 @@ public class InMemoryWorkflowCatalogTests
         var latest = await _catalog.GetAsync("v");
         latest.Should().NotBeNull();
         latest!.Version.Should().Be("10.0", "10.0 > 9.0 > 2.0 with numeric ordering");
+    }
+
+    [Fact]
+    public async Task GetLatest_SkipsDeprecated()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "mem-latest",
+            Version = "1.0.0",
+            IsDeprecated = true,
+        });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "mem-latest",
+            Version = "1.1.0",
+        });
+
+        var latest = await _catalog.GetAsync("mem-latest");
+        latest.Should().NotBeNull();
+        latest!.Version.Should().Be("1.1.0");
+    }
+
+    [Fact]
+    public async Task Get_WithRangeSelector_ReturnsHighestMatch()
+    {
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "mem-range", Version = "1.2.0" });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "mem-range", Version = "1.5.0" });
+        await _catalog.SaveAsync(new AgentWorkflowDefinition { Name = "mem-range", Version = "2.0.0" });
+
+        var selected = await _catalog.GetAsync("mem-range", "^1.0.0");
+        selected.Should().NotBeNull();
+        selected!.Version.Should().Be("1.5.0");
+    }
+
+    [Fact]
+    public async Task Save_InvalidSemVer_Throws()
+    {
+        var act = async () => await _catalog.SaveAsync(new AgentWorkflowDefinition
+        {
+            Name = "mem-invalid",
+            Version = "bad",
+        });
+
+        await act.Should().ThrowAsync<InvalidDataException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add SemVer parsing/comparison utility for workflows (including prerelease/build metadata handling)
- add version selector support for exact pinning plus constraints (`^`, `~`, `>=`, `<=`, `<`, `>`, `=`)
- enforce SemVer validation on local catalog save and shared-store publish
- add deprecation metadata (`isDeprecated`, `migrationGuidance`) and ensure `latest` resolves to highest non-deprecated version
- add breaking-change detection between workflow versions and require major bump when breaking changes are detected
- update file and in-memory workflow catalogs to use SemVer-aware resolution
- extend shared workflow store retrieval to support SemVer selectors
- add tests for SemVer ordering, constraints, deprecation-aware latest, invalid version rejection, and breaking-change enforcement

## Validation
- `dotnet format --verify-no-changes`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter "FullyQualifiedName~WorkflowTests|FullyQualifiedName~FileWorkflowStoreTests"`

Closes #143
