### PR TITLE
feat: distributed rate limiting with Redis and standard headers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,10 @@
     <PackageVersion Include="LLamaSharp" Version="0.26.0" />
     <PackageVersion Include="LLamaSharp.Backend.Cpu" Version="0.26.0" />
   </ItemGroup>
+  <!-- Distributed infrastructure -->
+  <ItemGroup>
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.41" />
+  </ItemGroup>
   <!-- Gateway -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />

--- a/src/JD.AI.Core/JD.AI.Core.csproj
+++ b/src/JD.AI.Core/JD.AI.Core.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="LLamaSharp" />
     <PackageReference Include="LLamaSharp.Backend.Cpu" />
+    <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JD.AI.Core/Security/ISecurity.cs
+++ b/src/JD.AI.Core/Security/ISecurity.cs
@@ -63,7 +63,17 @@ public interface IRateLimiter
 {
     /// <summary>Returns true if the request is allowed; false if rate-limited.</summary>
     Task<bool> AllowAsync(string key, CancellationToken ct = default);
+
+    /// <summary>Checks the rate limit and returns detailed result with remaining quota and reset time.</summary>
+    Task<RateLimitResult> CheckAsync(string key, CancellationToken ct = default);
 }
+
+/// <summary>Result of a rate limit check with quota metadata.</summary>
+public sealed record RateLimitResult(
+    bool Allowed,
+    int Limit,
+    int Remaining,
+    DateTimeOffset ResetsAt);
 
 /// <summary>
 /// Simple sliding window rate limiter.
@@ -83,6 +93,15 @@ public sealed class SlidingWindowRateLimiter : IRateLimiter
 
     public Task<bool> AllowAsync(string key, CancellationToken ct = default)
     {
+        var result = Check(key);
+        return Task.FromResult(result.Allowed);
+    }
+
+    public Task<RateLimitResult> CheckAsync(string key, CancellationToken ct = default) =>
+        Task.FromResult(Check(key));
+
+    private RateLimitResult Check(string key)
+    {
         lock (_lock)
         {
             var now = DateTimeOffset.UtcNow;
@@ -96,11 +115,13 @@ public sealed class SlidingWindowRateLimiter : IRateLimiter
             while (queue.Count > 0 && now - queue.Peek() >= _window)
                 queue.Dequeue();
 
+            var resetsAt = queue.Count > 0 ? queue.Peek() + _window : now + _window;
+
             if (queue.Count >= _maxRequests)
-                return Task.FromResult(false);
+                return new RateLimitResult(false, _maxRequests, 0, resetsAt);
 
             queue.Enqueue(now);
-            return Task.FromResult(true);
+            return new RateLimitResult(true, _maxRequests, _maxRequests - queue.Count, resetsAt);
         }
     }
 }

--- a/src/JD.AI.Core/Security/RedisRateLimiter.cs
+++ b/src/JD.AI.Core/Security/RedisRateLimiter.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace JD.AI.Core.Security;
+
+/// <summary>
+/// Redis-backed distributed sliding window rate limiter using sorted sets.
+/// Falls back to local <see cref="SlidingWindowRateLimiter"/> if Redis is unavailable.
+/// </summary>
+public sealed class RedisRateLimiter : IRateLimiter
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly ILogger<RedisRateLimiter> _logger;
+    private readonly SlidingWindowRateLimiter _fallback;
+    private readonly int _maxRequests;
+    private readonly TimeSpan _window;
+    private const string KeyPrefix = "jdai:ratelimit:";
+
+    public RedisRateLimiter(
+        IConnectionMultiplexer redis,
+        ILogger<RedisRateLimiter> logger,
+        int maxRequests = 60,
+        TimeSpan? window = null)
+    {
+        _redis = redis;
+        _logger = logger;
+        _maxRequests = maxRequests;
+        _window = window ?? TimeSpan.FromMinutes(1);
+        _fallback = new SlidingWindowRateLimiter(maxRequests, _window);
+    }
+
+    public async Task<bool> AllowAsync(string key, CancellationToken ct = default)
+    {
+        var result = await CheckAsync(key, ct).ConfigureAwait(false);
+        return result.Allowed;
+    }
+
+    public async Task<RateLimitResult> CheckAsync(string key, CancellationToken ct = default)
+    {
+        try
+        {
+            return await CheckRedisAsync(key).ConfigureAwait(false);
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis rate limiter unavailable, falling back to local limiter");
+            return await _fallback.CheckAsync(key, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<RateLimitResult> CheckRedisAsync(string key)
+    {
+        var db = _redis.GetDatabase();
+        var redisKey = new RedisKey(KeyPrefix + key);
+        var now = DateTimeOffset.UtcNow;
+        var windowStart = now - _window;
+        var nowScore = now.ToUnixTimeMilliseconds();
+        var windowStartScore = windowStart.ToUnixTimeMilliseconds();
+
+        // Lua script: atomic ZREMRANGEBYSCORE + ZCARD + ZADD + EXPIRE
+        var script = @"
+            redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+            local count = redis.call('ZCARD', KEYS[1])
+            if count < tonumber(ARGV[2]) then
+                redis.call('ZADD', KEYS[1], ARGV[3], ARGV[3] .. ':' .. math.random(1000000))
+                redis.call('EXPIRE', KEYS[1], ARGV[4])
+                return {1, count + 1}
+            else
+                redis.call('EXPIRE', KEYS[1], ARGV[4])
+                return {0, count}
+            end
+        ";
+
+        var result = (RedisResult[]?)await db.ScriptEvaluateAsync(
+            script,
+            [redisKey],
+            [
+                windowStartScore,
+                _maxRequests,
+                nowScore,
+                (int)_window.TotalSeconds + 1,
+            ]).ConfigureAwait(false);
+
+        var allowed = (int)result![0] == 1;
+        var currentCount = (int)result[1];
+        var remaining = Math.Max(0, _maxRequests - currentCount);
+        var resetsAt = now + _window;
+
+        return new RateLimitResult(allowed, _maxRequests, remaining, resetsAt);
+    }
+}

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -176,8 +176,20 @@ static void RunDaemon(string[] args)
     }
 
     builder.Services.AddSingleton<IAuthProvider>(authProvider);
-    builder.Services.AddSingleton<IRateLimiter>(
-        new SlidingWindowRateLimiter(gatewayConfig.RateLimit.MaxRequestsPerMinute));
+    if (string.Equals(gatewayConfig.RateLimit.Provider, "Redis", StringComparison.OrdinalIgnoreCase)
+        && !string.IsNullOrWhiteSpace(gatewayConfig.RateLimit.RedisConnectionString))
+    {
+        builder.Services.AddSingleton<IRateLimiter>(sp =>
+            new RedisRateLimiter(
+                StackExchange.Redis.ConnectionMultiplexer.Connect(gatewayConfig.RateLimit.RedisConnectionString),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<RedisRateLimiter>>(),
+                gatewayConfig.RateLimit.MaxRequestsPerMinute));
+    }
+    else
+    {
+        builder.Services.AddSingleton<IRateLimiter>(
+            new SlidingWindowRateLimiter(gatewayConfig.RateLimit.MaxRequestsPerMinute));
+    }
 
     // --- Core services ---
     builder.Services.AddSingleton<IEventBus, InProcessEventBus>();

--- a/src/JD.AI.Gateway/Config/GatewayConfig.cs
+++ b/src/JD.AI.Gateway/Config/GatewayConfig.cs
@@ -39,6 +39,12 @@ public sealed class RateLimitConfig
 {
     public bool Enabled { get; set; } = true;
     public int MaxRequestsPerMinute { get; set; } = 60;
+
+    /// <summary>Provider type: <c>"InProcess"</c> (default) or <c>"Redis"</c>.</summary>
+    public string Provider { get; set; } = "InProcess";
+
+    /// <summary>Redis connection string. Required when <see cref="Provider"/> is <c>"Redis"</c>.</summary>
+    public string? RedisConnectionString { get; set; }
 }
 
 public sealed class ChannelConfig

--- a/src/JD.AI.Gateway/Middleware/RateLimitMiddleware.cs
+++ b/src/JD.AI.Gateway/Middleware/RateLimitMiddleware.cs
@@ -1,9 +1,10 @@
+using System.Globalization;
 using JD.AI.Core.Security;
 
 namespace JD.AI.Gateway.Middleware;
 
 /// <summary>
-/// Enforces per-identity (or per-IP) rate limiting.
+/// Enforces per-identity (or per-IP) rate limiting with standard rate limit headers.
 /// </summary>
 public sealed class RateLimitMiddleware(RequestDelegate next, IRateLimiter rateLimiter)
 {
@@ -35,8 +36,19 @@ public sealed class RateLimitMiddleware(RequestDelegate next, IRateLimiter rateL
             ? identity.Id
             : context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
-        if (!await rateLimiter.AllowAsync(key, context.RequestAborted))
+        var result = await rateLimiter.CheckAsync(key, context.RequestAborted);
+
+        // Always set rate limit headers
+        var headers = context.Response.Headers;
+        headers["X-RateLimit-Limit"] = result.Limit.ToString(CultureInfo.InvariantCulture);
+        headers["X-RateLimit-Remaining"] = result.Remaining.ToString(CultureInfo.InvariantCulture);
+        headers["X-RateLimit-Reset"] = result.ResetsAt.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+
+        if (!result.Allowed)
         {
+            var retryAfter = Math.Max(1, (int)(result.ResetsAt - DateTimeOffset.UtcNow).TotalSeconds);
+            headers["Retry-After"] = retryAfter.ToString(CultureInfo.InvariantCulture);
+
             context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
             await context.Response.WriteAsJsonAsync(
                 new { error = "Too Many Requests" },

--- a/src/JD.AI.Gateway/Program.cs
+++ b/src/JD.AI.Gateway/Program.cs
@@ -36,8 +36,20 @@ foreach (var entry in gatewayConfig.Auth.ApiKeys)
 }
 
 builder.Services.AddSingleton<IAuthProvider>(authProvider);
-builder.Services.AddSingleton<IRateLimiter>(
-    new SlidingWindowRateLimiter(gatewayConfig.RateLimit.MaxRequestsPerMinute));
+if (string.Equals(gatewayConfig.RateLimit.Provider, "Redis", StringComparison.OrdinalIgnoreCase)
+    && !string.IsNullOrWhiteSpace(gatewayConfig.RateLimit.RedisConnectionString))
+{
+    builder.Services.AddSingleton<IRateLimiter>(sp =>
+        new RedisRateLimiter(
+            StackExchange.Redis.ConnectionMultiplexer.Connect(gatewayConfig.RateLimit.RedisConnectionString),
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<RedisRateLimiter>>(),
+            gatewayConfig.RateLimit.MaxRequestsPerMinute));
+}
+else
+{
+    builder.Services.AddSingleton<IRateLimiter>(
+        new SlidingWindowRateLimiter(gatewayConfig.RateLimit.MaxRequestsPerMinute));
+}
 
 // --- Core services ---
 builder.Services.AddSingleton<IEventBus, InProcessEventBus>();

--- a/tests/JD.AI.Tests/Security/SlidingWindowRateLimiterTests.cs
+++ b/tests/JD.AI.Tests/Security/SlidingWindowRateLimiterTests.cs
@@ -73,4 +73,43 @@ public class SlidingWindowRateLimiterTests
 
         (await limiter.AllowAsync("user1")).Should().BeFalse("61st request should be blocked");
     }
+
+    [Fact]
+    public async Task CheckAsync_ReturnsRemainingQuota()
+    {
+        var limiter = new SlidingWindowRateLimiter(maxRequests: 5, window: TimeSpan.FromMinutes(1));
+
+        var result = await limiter.CheckAsync("user1");
+
+        result.Allowed.Should().BeTrue();
+        result.Limit.Should().Be(5);
+        result.Remaining.Should().Be(4);
+        result.ResetsAt.Should().BeAfter(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task CheckAsync_AtLimit_RemainingIsZero()
+    {
+        var limiter = new SlidingWindowRateLimiter(maxRequests: 2, window: TimeSpan.FromMinutes(1));
+
+        await limiter.CheckAsync("user1");
+        await limiter.CheckAsync("user1");
+        var result = await limiter.CheckAsync("user1");
+
+        result.Allowed.Should().BeFalse();
+        result.Remaining.Should().Be(0);
+        result.Limit.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CheckAsync_DecreasesRemaining()
+    {
+        var limiter = new SlidingWindowRateLimiter(maxRequests: 3, window: TimeSpan.FromMinutes(1));
+
+        var r1 = await limiter.CheckAsync("user1");
+        var r2 = await limiter.CheckAsync("user1");
+
+        r1.Remaining.Should().Be(2);
+        r2.Remaining.Should().Be(1);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `RedisRateLimiter` using Redis sorted sets with atomic Lua script for distributed sliding window
- Adds `RateLimitResult` record with quota metadata (`Limit`, `Remaining`, `ResetsAt`)
- Adds `CheckAsync` method to `IRateLimiter` interface
- `RateLimitMiddleware` now emits `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, and `Retry-After` headers
- Graceful fallback to local `SlidingWindowRateLimiter` when Redis is unavailable
- Configurable via `Gateway:RateLimit:Provider` = `"Redis"` + `RedisConnectionString`

## Test plan
- [x] All 9 rate limit unit tests pass (6 existing + 3 new)
- [x] All 181 Gateway tests pass
- [x] Full solution builds with zero errors
- [ ] Manual: verify rate limit headers appear in HTTP responses
- [ ] Manual: verify Redis-backed rate limiting across multiple nodes

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)