### PR TITLE
feat: plugin permission enforcement and trust policy hardening

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -152,7 +152,7 @@ public interface IPluginContext
 | `Kernel` | Register SK functions and plugins |
 | `Configuration` | Plugin-specific key-value settings from the manifest |
 | `OnEvent` | Subscribe to gateway events (`agent.spawned`, `agent.turn_complete`, etc.) |
-| `GetService<T>` | Resolve services from the gateway DI container |
+| `GetService<T>` | Resolve services from the gateway DI container (permission-gated) |
 | `Log` | Structured logging at Debug, Info, Warning, or Error level |
 
 ### Event handling
@@ -172,13 +172,19 @@ context.OnEvent("agent.turn_complete", async data =>
 
 ### Service resolution
 
-Access gateway services via DI:
+Access gateway services via DI. Plugins must declare matching service permissions in `plugin.json`:
 
 ```csharp
 var channelRegistry = context.GetService<IChannelRegistry>();
 var eventBus = context.GetService<IEventBus>();
 var sessionStore = context.GetService<SessionStore>();
 ```
+
+For `GetService<T>()`, declare either:
+
+- `service:*` (all DI service access)
+- `service:Namespace.TypeName` (full CLR type name)
+- `service:TypeName` (short type name)
 
 ### Plugin manifest
 
@@ -191,15 +197,33 @@ Distribute plugins with a `plugin.json`:
   "version": "1.2.0",
   "description": "GitHub PR reviews, issue management, and CI status.",
   "author": "JD.AI Contributors",
+  "publisher": "JD.AI Contributors",
   "license": "MIT",
   "entryAssembly": "JD.AI.Plugin.GitHub.dll",
-  "permissions": ["network", "read-events"],
+  "entryAssemblySha256": "C7E332D87854B9D4FEFD93A0D0414F6E594D256973A4689DCE8A273A7A6CE7A1",
+  "permissions": [
+    "event:*",
+    "service:JD.AI.Core.Events.IEventBus",
+    "service:ILoggerFactory"
+  ],
   "configuration": {
     "github_token": "",
     "default_org": ""
   }
 }
 ```
+
+### Plugin security policy
+
+- `permissions` are enforced at runtime with deny-by-default behavior.
+- `GetService<T>()` and `OnEvent(...)` requests are audited in host logs.
+- Optional trusted publisher enforcement is controlled via `JDAI_PLUGIN_TRUSTED_PUBLISHERS`:
+
+```bash
+export JDAI_PLUGIN_TRUSTED_PUBLISHERS="JD.AI Contributors,Contoso Security Team"
+```
+
+When set, plugin install/load fails unless `publisher` (or `author`) matches one of the trusted values.
 
 ### Plugin directories
 

--- a/src/JD.AI.Core/Plugins/PermissionEnforcedPluginContext.cs
+++ b/src/JD.AI.Core/Plugins/PermissionEnforcedPluginContext.cs
@@ -1,0 +1,110 @@
+using JD.AI.Plugins.SDK;
+using Microsoft.Extensions.Logging;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Plugins;
+
+internal sealed class PermissionEnforcedPluginContext : IPluginContext
+{
+    private const string AllServicesPermission = "service:*";
+    private const string AllEventsPermission = "event:*";
+    private const string LegacyReadEventsPermission = "read-events";
+
+    private readonly IPluginContext _inner;
+    private readonly string _pluginId;
+    private readonly ILogger _logger;
+    private readonly HashSet<string> _permissions;
+
+    public PermissionEnforcedPluginContext(
+        IPluginContext inner,
+        string pluginId,
+        IEnumerable<string> declaredPermissions,
+        ILogger logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _pluginId = string.IsNullOrWhiteSpace(pluginId)
+            ? "unknown-plugin"
+            : pluginId.Trim();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _permissions = declaredPermissions
+            .Select(static p => p?.Trim())
+            .Where(static p => !string.IsNullOrWhiteSpace(p))
+            .Cast<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public Kernel Kernel => _inner.Kernel;
+
+    public IReadOnlyDictionary<string, string> Configuration => _inner.Configuration;
+
+    public void OnEvent(string eventType, Func<object?, Task> handler)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var normalizedEvent = eventType.Trim();
+        var eventPermission = $"event:{normalizedEvent}";
+        if (!HasAnyPermission(AllEventsPermission, eventPermission, LegacyReadEventsPermission))
+        {
+            throw Denied(
+                operation: "event subscription",
+                requiredPermissions: ["event:*", eventPermission, LegacyReadEventsPermission]);
+        }
+
+        Audit(operation: "event subscription", resource: normalizedEvent, allowed: true);
+        _inner.OnEvent(normalizedEvent, handler);
+    }
+
+    public T? GetService<T>() where T : class
+    {
+        var serviceType = typeof(T);
+        var fullName = serviceType.FullName ?? serviceType.Name;
+        var requiredFull = $"service:{fullName}";
+        var requiredShort = $"service:{serviceType.Name}";
+
+        if (!HasAnyPermission(AllServicesPermission, requiredFull, requiredShort))
+        {
+            throw Denied(
+                operation: "service resolution",
+                requiredPermissions: ["service:*", requiredFull, requiredShort]);
+        }
+
+        Audit(operation: "service resolution", resource: fullName, allowed: true);
+        return _inner.GetService<T>();
+    }
+
+    public void Log(PluginLogLevel level, string message)
+    {
+        _inner.Log(level, message);
+    }
+
+    private bool HasAnyPermission(params string[] requiredPermissions)
+    {
+        return requiredPermissions.Any(p => _permissions.Contains(p));
+    }
+
+    private InvalidOperationException Denied(string operation, IReadOnlyList<string> requiredPermissions)
+    {
+        Audit(operation, resource: string.Join(", ", requiredPermissions), allowed: false);
+        return new InvalidOperationException(
+            $"Plugin '{_pluginId}' permission denied for {operation}. " +
+            $"Declare one of: {string.Join(", ", requiredPermissions)}.");
+    }
+
+    private void Audit(string operation, string resource, bool allowed)
+    {
+        _logger.LogInformation(
+            "Plugin security audit: plugin={PluginId} operation={Operation} resource={Resource} allowed={Allowed}",
+            _pluginId,
+            operation,
+            Sanitize(resource),
+            allowed);
+    }
+
+    private static string Sanitize(string value)
+    {
+        return value
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
+    }
+}

--- a/src/JD.AI.Core/Plugins/PluginInstaller.cs
+++ b/src/JD.AI.Core/Plugins/PluginInstaller.cs
@@ -52,6 +52,7 @@ public sealed class PluginInstaller : IPluginInstaller
         CopyDirectory(Path.GetDirectoryName(manifestPath)!, installPath);
 
         var entryAssemblyPath = ResolveEntryAssemblyPath(manifest, installPath);
+        PluginIntegrityVerifier.VerifyEntryAssemblyHash(manifest, entryAssemblyPath);
         _logger.LogInformation(
             "Installed plugin package {Id} v{Version} to {InstallPath}",
             manifest.Id, version, installPath);

--- a/src/JD.AI.Core/Plugins/PluginIntegrityVerifier.cs
+++ b/src/JD.AI.Core/Plugins/PluginIntegrityVerifier.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using JD.AI.Plugins.SDK;
+
+namespace JD.AI.Core.Plugins;
+
+internal static class PluginIntegrityVerifier
+{
+    public static void VerifyEntryAssemblyHash(PluginManifest manifest, string entryAssemblyPath)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryAssemblyPath);
+
+        if (string.IsNullOrWhiteSpace(manifest.EntryAssemblySha256))
+        {
+            return;
+        }
+
+        var expected = NormalizeHex(manifest.EntryAssemblySha256);
+        var actual = ComputeSha256(entryAssemblyPath);
+
+        if (!string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"Plugin '{manifest.Id}' entry assembly hash verification failed. " +
+                $"Expected SHA-256 '{expected}', but found '{actual}'.");
+        }
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var hash = SHA256.HashData(stream);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string NormalizeHex(string value)
+    {
+        return value
+            .Trim()
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .ToUpperInvariant();
+    }
+}

--- a/src/JD.AI.Core/Plugins/PluginLifecycleManager.cs
+++ b/src/JD.AI.Core/Plugins/PluginLifecycleManager.cs
@@ -1,3 +1,4 @@
+using JD.AI.Plugins.SDK;
 using Microsoft.Extensions.Logging;
 
 namespace JD.AI.Core.Plugins;
@@ -12,19 +13,22 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
     private readonly IPluginRuntime _runtime;
     private readonly IPluginContextFactory _contextFactory;
     private readonly ILogger<PluginLifecycleManager> _logger;
+    private readonly PluginSecurityOptions _securityOptions;
 
     public PluginLifecycleManager(
         IPluginInstaller installer,
         PluginRegistryStore registry,
         IPluginRuntime runtime,
         IPluginContextFactory contextFactory,
-        ILogger<PluginLifecycleManager> logger)
+        ILogger<PluginLifecycleManager> logger,
+        PluginSecurityOptions? securityOptions = null)
     {
         _installer = installer;
         _registry = registry;
         _runtime = runtime;
         _contextFactory = contextFactory;
         _logger = logger;
+        _securityOptions = securityOptions ?? PluginSecurityOptions.FromEnvironment();
     }
 
     public async Task<IReadOnlyList<PluginStatusInfo>> ListAsync(CancellationToken ct = default)
@@ -59,6 +63,7 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
         CancellationToken ct = default)
     {
         var artifact = await _installer.InstallAsync(source, ct).ConfigureAwait(false);
+        ValidateManifestSecurity(artifact.Manifest);
         var record = new InstalledPluginRecord
         {
             Id = artifact.Manifest.Id,
@@ -68,6 +73,11 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
             EntryAssemblyPath = artifact.EntryAssemblyPath,
             ManifestPath = artifact.ManifestPath,
             Source = artifact.Source,
+            Publisher = ResolvePublisher(artifact.Manifest),
+            Permissions = artifact.Manifest.Permissions
+                .Where(static p => !string.IsNullOrWhiteSpace(p))
+                .Select(static p => p.Trim())
+                .ToArray(),
             Enabled = enable,
             InstalledAtUtc = DateTimeOffset.UtcNow,
         };
@@ -124,6 +134,7 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
         await _runtime.UnloadAsync(existing.Id, ct).ConfigureAwait(false);
 
         var artifact = await _installer.InstallAsync(existing.Source, ct).ConfigureAwait(false);
+        ValidateManifestSecurity(artifact.Manifest);
         if (!string.Equals(artifact.Manifest.Id, existing.Id, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidDataException(
@@ -139,6 +150,11 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
             EntryAssemblyPath = artifact.EntryAssemblyPath,
             ManifestPath = artifact.ManifestPath,
             Source = existing.Source,
+            Publisher = ResolvePublisher(artifact.Manifest),
+            Permissions = artifact.Manifest.Permissions
+                .Where(static p => !string.IsNullOrWhiteSpace(p))
+                .Select(static p => p.Trim())
+                .ToArray(),
             Enabled = existing.Enabled,
             InstalledAtUtc = existing.InstalledAtUtc,
             LastEnabledAtUtc = existing.LastEnabledAtUtc,
@@ -215,11 +231,28 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
     {
         try
         {
+            var manifest = await PluginManifestReader.ReadAsync(record.ManifestPath, ct).ConfigureAwait(false);
+            ValidateManifestSecurity(manifest);
+            PluginIntegrityVerifier.VerifyEntryAssemblyHash(manifest, record.EntryAssemblyPath);
+
+            var permissions = manifest.Permissions
+                .Where(static p => !string.IsNullOrWhiteSpace(p))
+                .Select(static p => p.Trim())
+                .ToArray();
+
+            var secureContext = new PermissionEnforcedPluginContext(
+                _contextFactory.CreateContext(),
+                record.Id,
+                permissions,
+                _logger);
+
             await _runtime
-                .LoadAssemblyAsync(record.EntryAssemblyPath, _contextFactory.CreateContext(), record.Id, ct)
+                .LoadAssemblyAsync(record.EntryAssemblyPath, secureContext, record.Id, ct)
                 .ConfigureAwait(false);
             record.LastEnabledAtUtc = DateTimeOffset.UtcNow;
             record.LastError = null;
+            record.Permissions = permissions;
+            record.Publisher = ResolvePublisher(manifest);
             return true;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -244,5 +277,40 @@ public sealed class PluginLifecycleManager : IPluginLifecycleManager
             InstalledAtUtc: record.InstalledAtUtc,
             LastEnabledAtUtc: record.LastEnabledAtUtc,
             LastError: record.LastError);
+    }
+
+    private void ValidateManifestSecurity(PluginManifest manifest)
+    {
+        if (!_securityOptions.EnforceTrustedPublishers)
+        {
+            return;
+        }
+
+        var publisher = ResolvePublisher(manifest);
+        if (string.IsNullOrWhiteSpace(publisher))
+        {
+            throw new InvalidDataException(
+                $"Plugin '{manifest.Id}' is missing publisher metadata. " +
+                "Set 'publisher' in plugin.json.");
+        }
+
+        if (!_securityOptions.TrustedPublishers.Contains(publisher))
+        {
+            throw new InvalidDataException(
+                $"Plugin '{manifest.Id}' publisher '{publisher}' is not in trusted publishers: " +
+                $"{string.Join(", ", _securityOptions.TrustedPublishers)}");
+        }
+    }
+
+    private static string? ResolvePublisher(PluginManifest manifest)
+    {
+        if (!string.IsNullOrWhiteSpace(manifest.Publisher))
+        {
+            return manifest.Publisher.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(manifest.Author)
+            ? null
+            : manifest.Author.Trim();
     }
 }

--- a/src/JD.AI.Core/Plugins/PluginLifecycleModels.cs
+++ b/src/JD.AI.Core/Plugins/PluginLifecycleModels.cs
@@ -14,6 +14,8 @@ public sealed record InstalledPluginRecord
     public required string EntryAssemblyPath { get; init; }
     public required string ManifestPath { get; init; }
     public required string Source { get; init; }
+    public string? Publisher { get; set; }
+    public IReadOnlyList<string> Permissions { get; set; } = [];
     public bool Enabled { get; set; } = true;
     public DateTimeOffset InstalledAtUtc { get; init; } = DateTimeOffset.UtcNow;
     public DateTimeOffset? LastEnabledAtUtc { get; set; }

--- a/src/JD.AI.Core/Plugins/PluginManifestReader.cs
+++ b/src/JD.AI.Core/Plugins/PluginManifestReader.cs
@@ -57,5 +57,24 @@ public static class PluginManifestReader
             throw new InvalidDataException(
                 $"Manifest '{manifestPath}' has invalid id '{manifest.Id}'.");
         }
+
+        if (!string.IsNullOrWhiteSpace(manifest.EntryAssemblySha256))
+        {
+            var normalizedHash = manifest.EntryAssemblySha256
+                .Trim()
+                .Replace("-", string.Empty, StringComparison.Ordinal);
+            if (normalizedHash.Length != 64 || !normalizedHash.All(Uri.IsHexDigit))
+            {
+                throw new InvalidDataException(
+                    $"Manifest '{manifestPath}' has invalid field 'entryAssemblySha256'. " +
+                    "Expected 64 hex characters.");
+            }
+        }
+
+        if (manifest.Permissions.Any(static p => string.IsNullOrWhiteSpace(p)))
+        {
+            throw new InvalidDataException(
+                $"Manifest '{manifestPath}' contains empty values in 'permissions'.");
+        }
     }
 }

--- a/src/JD.AI.Core/Plugins/PluginSecurityOptions.cs
+++ b/src/JD.AI.Core/Plugins/PluginSecurityOptions.cs
@@ -1,0 +1,32 @@
+namespace JD.AI.Core.Plugins;
+
+/// <summary>
+/// Security policy options for plugin installation and runtime loading.
+/// </summary>
+public sealed class PluginSecurityOptions
+{
+    public const string TrustedPublishersEnvironmentVariable = "JDAI_PLUGIN_TRUSTED_PUBLISHERS";
+
+    public IReadOnlySet<string> TrustedPublishers { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    public bool EnforceTrustedPublishers => TrustedPublishers.Count > 0;
+
+    public static PluginSecurityOptions FromEnvironment()
+    {
+        var raw = Environment.GetEnvironmentVariable(TrustedPublishersEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return new PluginSecurityOptions();
+        }
+
+        var publishers = raw
+            .Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(static p => !string.IsNullOrWhiteSpace(p))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return new PluginSecurityOptions
+        {
+            TrustedPublishers = publishers,
+        };
+    }
+}

--- a/src/JD.AI.Plugins.SDK/PluginSdk.cs
+++ b/src/JD.AI.Plugins.SDK/PluginSdk.cs
@@ -82,8 +82,10 @@ public record PluginManifest
     public required string Version { get; init; }
     public string? Description { get; init; }
     public string? Author { get; init; }
+    public string? Publisher { get; init; }
     public string? License { get; init; }
     public string? EntryAssembly { get; init; }
+    public string? EntryAssemblySha256 { get; init; }
     public IReadOnlyList<string> Permissions { get; init; } = [];
     public IReadOnlyDictionary<string, string> Configuration { get; init; } =
         new Dictionary<string, string>();

--- a/tests/JD.AI.Tests/Plugins/PermissionEnforcedPluginContextTests.cs
+++ b/tests/JD.AI.Tests/Plugins/PermissionEnforcedPluginContextTests.cs
@@ -1,0 +1,95 @@
+using JD.AI.Core.Plugins;
+using JD.AI.Plugins.SDK;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Tests.Plugins;
+
+public sealed class PermissionEnforcedPluginContextTests
+{
+    [Fact]
+    public void GetService_WithoutPermission_Throws()
+    {
+        var inner = new FakePluginContext();
+        var context = new PermissionEnforcedPluginContext(
+            inner,
+            pluginId: "sample.plugin",
+            declaredPermissions: [],
+            NullLogger.Instance);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => context.GetService<object>());
+        Assert.Contains("permission denied", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("service:*", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetService_WithServicePermission_ReturnsValue()
+    {
+        var expected = new object();
+        var inner = new FakePluginContext
+        {
+            ServiceFactory = type => type == typeof(object) ? expected : null,
+        };
+
+        var context = new PermissionEnforcedPluginContext(
+            inner,
+            pluginId: "sample.plugin",
+            declaredPermissions: [$"service:{typeof(object).FullName}"],
+            NullLogger.Instance);
+
+        var resolved = context.GetService<object>();
+        Assert.Same(expected, resolved);
+    }
+
+    [Fact]
+    public void OnEvent_WithoutPermission_Throws()
+    {
+        var inner = new FakePluginContext();
+        var context = new PermissionEnforcedPluginContext(
+            inner,
+            pluginId: "sample.plugin",
+            declaredPermissions: [],
+            NullLogger.Instance);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            context.OnEvent("agent.spawned", _ => Task.CompletedTask));
+
+        Assert.Contains("event:*", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OnEvent_WithLegacyReadEventsPermission_AllowsSubscription()
+    {
+        var inner = new FakePluginContext();
+        var context = new PermissionEnforcedPluginContext(
+            inner,
+            pluginId: "sample.plugin",
+            declaredPermissions: ["read-events"],
+            NullLogger.Instance);
+
+        context.OnEvent("agent.spawned", _ => Task.CompletedTask);
+
+        Assert.Equal("agent.spawned", inner.LastEventType);
+    }
+
+    private sealed class FakePluginContext : IPluginContext
+    {
+        public Kernel Kernel { get; } = new();
+        public IReadOnlyDictionary<string, string> Configuration { get; } =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+        public Func<Type, object?>? ServiceFactory { get; init; }
+        public string? LastEventType { get; private set; }
+
+        public void OnEvent(string eventType, Func<object?, Task> handler)
+        {
+            LastEventType = eventType;
+        }
+
+        public T? GetService<T>() where T : class
+        {
+            return ServiceFactory?.Invoke(typeof(T)) as T;
+        }
+
+        public void Log(PluginLogLevel level, string message) { }
+    }
+}

--- a/tests/JD.AI.Tests/Plugins/PluginLifecycleManagerTests.cs
+++ b/tests/JD.AI.Tests/Plugins/PluginLifecycleManagerTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Text.Json;
 using JD.AI.Core.Plugins;
 using JD.AI.Plugins.SDK;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,7 +21,14 @@ public sealed class PluginLifecycleManagerTests
             var entryAssembly = Path.Combine(recordDir, "Sample.Plugin.dll");
             await File.WriteAllTextAsync(entryAssembly, "stub");
             var manifestPath = Path.Combine(recordDir, "plugin.json");
-            await File.WriteAllTextAsync(manifestPath, "{}");
+            await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(new PluginManifest
+            {
+                Id = "sample.plugin",
+                Name = "Sample Plugin",
+                Version = "1.2.3",
+                Publisher = "test-publisher",
+                EntryAssembly = "Sample.Plugin.dll",
+            }));
 
             var manager = CreateManager(
                 root,
@@ -132,7 +140,40 @@ public sealed class PluginLifecycleManagerTests
         }
     }
 
-    private static PluginLifecycleManager CreateManager(string root, IPluginInstaller installer)
+    [Fact]
+    public async Task InstallAsync_UntrustedPublisher_Throws()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var artifact = CreateInstallArtifact(root, "sample.plugin", "1.0.0", source: "catalog://sample.plugin");
+            var manager = CreateManager(
+                root,
+                new FakeInstaller(artifact),
+                new PluginSecurityOptions
+                {
+                    TrustedPublishers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        "trusted-publisher",
+                    },
+                });
+
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(() =>
+                manager.InstallAsync("catalog://sample.plugin", enable: true));
+
+            Assert.Contains("publisher", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("trusted-publisher", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static PluginLifecycleManager CreateManager(
+        string root,
+        IPluginInstaller installer,
+        PluginSecurityOptions? securityOptions = null)
     {
         var registry = new PluginRegistryStore(Path.Combine(root, "registry.json"));
         return new PluginLifecycleManager(
@@ -140,7 +181,8 @@ public sealed class PluginLifecycleManagerTests
             registry,
             new FakeRuntime(),
             new DelegatePluginContextFactory(() => new NoopPluginContext()),
-            NullLogger<PluginLifecycleManager>.Instance);
+            NullLogger<PluginLifecycleManager>.Instance,
+            securityOptions);
     }
 
     private static InstalledPluginRecord CreateRecord(string root, string id, bool enabled)
@@ -150,7 +192,14 @@ public sealed class PluginLifecycleManagerTests
         var entryAssemblyPath = Path.Combine(pluginDir, "Sample.Plugin.dll");
         File.WriteAllText(entryAssemblyPath, "stub");
         var manifestPath = Path.Combine(pluginDir, "plugin.json");
-        File.WriteAllText(manifestPath, "{}");
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(new PluginManifest
+        {
+            Id = id,
+            Name = id,
+            Version = "1.0.0",
+            Publisher = "test-publisher",
+            EntryAssembly = "Sample.Plugin.dll",
+        }));
 
         return new InstalledPluginRecord
         {
@@ -178,7 +227,14 @@ public sealed class PluginLifecycleManagerTests
         File.WriteAllText(entryAssembly, "stub");
 
         var manifestPath = Path.Combine(installPath, "plugin.json");
-        File.WriteAllText(manifestPath, "{}");
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(new PluginManifest
+        {
+            Id = id,
+            Name = "Sample Plugin",
+            Version = version,
+            Publisher = "test-publisher",
+            EntryAssembly = "Sample.Plugin.dll",
+        }));
 
         return new PluginInstallArtifact(
             Manifest: new PluginManifest
@@ -186,6 +242,7 @@ public sealed class PluginLifecycleManagerTests
                 Id = id,
                 Name = "Sample Plugin",
                 Version = version,
+                Publisher = "test-publisher",
                 EntryAssembly = "Sample.Plugin.dll",
             },
             InstallPath: installPath,

--- a/tests/JD.AI.Tests/Plugins/PluginManifestReaderTests.cs
+++ b/tests/JD.AI.Tests/Plugins/PluginManifestReaderTests.cs
@@ -71,6 +71,40 @@ public sealed class PluginManifestReaderTests
             PluginManifestReader.Validate(manifest, "plugin.json"));
     }
 
+    [Fact]
+    public void Validate_InvalidEntryAssemblySha256_Throws()
+    {
+        var manifest = new PluginManifest
+        {
+            Id = "sample.plugin",
+            Name = "Sample Plugin",
+            Version = "1.0.0",
+            EntryAssemblySha256 = "bad-hash",
+        };
+
+        var ex = Assert.Throws<InvalidDataException>(() =>
+            PluginManifestReader.Validate(manifest, "plugin.json"));
+
+        Assert.Contains("entryAssemblySha256", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_EmptyPermissionValue_Throws()
+    {
+        var manifest = new PluginManifest
+        {
+            Id = "sample.plugin",
+            Name = "Sample Plugin",
+            Version = "1.0.0",
+            Permissions = ["service:*", " "],
+        };
+
+        var ex = Assert.Throws<InvalidDataException>(() =>
+            PluginManifestReader.Validate(manifest, "plugin.json"));
+
+        Assert.Contains("permissions", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string CreateTempDirectory()
     {
         var path = Path.Combine(Path.GetTempPath(), $"jdai-plugin-manifest-{Guid.NewGuid():N}");

--- a/tests/JD.AI.Tests/Plugins/PluginRegistryStoreTests.cs
+++ b/tests/JD.AI.Tests/Plugins/PluginRegistryStoreTests.cs
@@ -20,6 +20,8 @@ public sealed class PluginRegistryStoreTests
                 EntryAssemblyPath = Path.Combine(dir, "sample.plugin", "1.0.0", "Sample.Plugin.dll"),
                 ManifestPath = Path.Combine(dir, "sample.plugin", "1.0.0", "plugin.json"),
                 Source = "./sample",
+                Publisher = "acme",
+                Permissions = ["service:*", "event:*"],
                 Enabled = true,
             };
 
@@ -30,6 +32,8 @@ public sealed class PluginRegistryStoreTests
             Assert.NotNull(found);
             Assert.Single(list);
             Assert.Equal("Sample Plugin", found!.Name);
+            Assert.Equal("acme", found.Publisher);
+            Assert.Contains("service:*", found.Permissions);
 
             var removed = await store.RemoveAsync("sample.plugin");
             var empty = await store.ListAsync();


### PR DESCRIPTION
## Summary
- enforce plugin runtime permissions with deny-by-default via a new `PermissionEnforcedPluginContext`
- gate `GetService<T>()` and `OnEvent(...)` behind declared manifest permissions, with explicit permission-denied errors
- add plugin security audit logging for cross-boundary service/event access attempts
- add optional trusted-publisher enforcement via `JDAI_PLUGIN_TRUSTED_PUBLISHERS`
- add `entryAssemblySha256` integrity verification for plugin entry assemblies during install/load
- persist plugin publisher/permissions metadata in plugin registry
- document manifest security fields and runtime permission model in plugin SDK docs

## Testing
- `dotnet format --verify-no-changes`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter "FullyQualifiedName~Plugins"`

Closes #146
