### PR TITLE
feat: add container images and Kubernetes Helm deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+**/.git
+**/.gitignore
+**/.vs
+**/.vscode
+**/bin
+**/obj
+**/TestResults*
+**/.idea
+**/*.user
+**/*.suo
+**/*.nupkg
+**/*.snupkg
+docs/_site
+.codex

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,92 @@
+name: Container Images
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: gateway
+            dockerfile: deploy/docker/Dockerfile.gateway
+          - component: daemon
+            dockerfile: deploy/docker/Dockerfile.daemon
+          - component: tui
+            dockerfile: deploy/docker/Dockerfile.tui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Normalize image name
+        id: image
+        shell: bash
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "name=${{ env.REGISTRY }}/${owner}/jd.ai-${{ matrix.component }}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ steps.image.outputs.name }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.component }}.spdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ matrix.component }}
+          path: sbom-${{ matrix.component }}.spdx.json
+
+      - name: Attest SBOM to image
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-${{ matrix.component }}.spdx.json

--- a/deploy/docker/Dockerfile.daemon
+++ b/deploy/docker/Dockerfile.daemon
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet restore src/JD.AI.Daemon/JD.AI.Daemon.csproj
+RUN dotnet publish src/JD.AI.Daemon/JD.AI.Daemon.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos "" --uid 10001 jdai
+
+COPY --from=build /app/publish .
+EXPOSE 15790
+
+ENV ASPNETCORE_URLS=http://+:15790
+USER 10001
+ENTRYPOINT ["dotnet", "JD.AI.Daemon.dll"]

--- a/deploy/docker/Dockerfile.gateway
+++ b/deploy/docker/Dockerfile.gateway
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet restore src/JD.AI.Gateway/JD.AI.Gateway.csproj
+RUN dotnet publish src/JD.AI.Gateway/JD.AI.Gateway.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos "" --uid 10001 jdai
+
+COPY --from=build /app/publish .
+EXPOSE 15790
+
+ENV ASPNETCORE_URLS=http://+:15790
+USER 10001
+ENTRYPOINT ["dotnet", "JD.AI.Gateway.dll"]

--- a/deploy/docker/Dockerfile.tui
+++ b/deploy/docker/Dockerfile.tui
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.7
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY . .
+RUN dotnet restore src/JD.AI/JD.AI.csproj
+RUN dotnet publish src/JD.AI/JD.AI.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos "" --uid 10001 jdai
+
+COPY --from=build /app/publish .
+USER 10001
+ENTRYPOINT ["dotnet", "JD.AI.dll"]

--- a/deploy/helm/jdai/Chart.yaml
+++ b/deploy/helm/jdai/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: jdai
+description: Helm chart for deploying JD.AI Gateway and Daemon on Kubernetes.
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/deploy/helm/jdai/README.md
+++ b/deploy/helm/jdai/README.md
@@ -1,0 +1,37 @@
+# JD.AI Helm Chart
+
+Deploys:
+
+- `JD.AI.Gateway` Deployment + Service
+- `JD.AI.Daemon` Deployment
+- optional Ingress
+- optional HPA and PodDisruptionBudget for gateway
+- optional ConfigMap/Secret wiring
+
+## Install
+
+```bash
+helm upgrade --install jdai ./deploy/helm/jdai \
+  --namespace jdai \
+  --create-namespace
+```
+
+## Key values
+
+- `gateway.image.repository` / `gateway.image.tag`
+- `daemon.image.repository` / `daemon.image.tag`
+- `gateway.hpa.*`
+- `gateway.pdb.*`
+- `gateway.persistence.*` / `daemon.persistence.*`
+- `ingress.*`
+- `config.data` / `config.secretData`
+
+## Service mesh compatibility
+
+Use pod annotations to enable sidecar injection:
+
+```yaml
+gateway:
+  podAnnotations:
+    sidecar.istio.io/inject: "true"
+```

--- a/deploy/helm/jdai/templates/_helpers.tpl
+++ b/deploy/helm/jdai/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{- define "jdai.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jdai.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jdai.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jdai.labels" -}}
+helm.sh/chart: {{ include "jdai.chart" . }}
+app.kubernetes.io/name: {{ include "jdai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "jdai.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jdai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "jdai.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "jdai.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/jdai/templates/configmap.yaml
+++ b/deploy/helm/jdai/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.config.data }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jdai.fullname" . }}-config
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.config.data | nindent 2 }}
+{{- end }}

--- a/deploy/helm/jdai/templates/deployment-daemon.yaml
+++ b/deploy/helm/jdai/templates/deployment-daemon.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.daemon.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jdai.fullname" . }}-daemon
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: daemon
+spec:
+  replicas: {{ .Values.daemon.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jdai.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: daemon
+  template:
+    metadata:
+      labels:
+        {{- include "jdai.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: daemon
+        {{- with .Values.daemon.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.daemon.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "jdai.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.daemon.podSecurityContext | nindent 8 }}
+      containers:
+        - name: daemon
+          image: "{{ .Values.daemon.image.repository }}:{{ .Values.daemon.image.tag }}"
+          imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.daemon.service.port }}
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:{{ .Values.daemon.service.port }}"
+            {{- with .Values.daemon.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.config.data .Values.config.secretData }}
+          envFrom:
+            {{- if .Values.config.data }}
+            - configMapRef:
+                name: {{ include "jdai.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.config.secretData }}
+            - secretRef:
+                name: {{ include "jdai.fullname" . }}-secrets
+            {{- end }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.daemon.startupProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.daemon.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.daemon.startupProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.daemon.readinessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.daemon.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.daemon.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.daemon.livenessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.daemon.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.daemon.livenessProbe.failureThreshold }}
+          securityContext:
+            {{- toYaml .Values.daemon.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.daemon.resources | nindent 12 }}
+          {{- if .Values.daemon.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.daemon.persistence.mountPath }}
+          {{- end }}
+      {{- if .Values.daemon.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-daemon" (include "jdai.fullname" .)) .Values.daemon.persistence.existingClaim }}
+      {{- end }}
+      {{- with .Values.daemon.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemon.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemon.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/jdai/templates/deployment-gateway.yaml
+++ b/deploy/helm/jdai/templates/deployment-gateway.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: {{ .Values.gateway.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jdai.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        {{- include "jdai.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+        {{- with .Values.gateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.gateway.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "jdai.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.gateway.podSecurityContext | nindent 8 }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.service.port }}
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:{{ .Values.gateway.service.port }}"
+            {{- with .Values.gateway.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.config.data .Values.config.secretData }}
+          envFrom:
+            {{- if .Values.config.data }}
+            - configMapRef:
+                name: {{ include "jdai.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.config.secretData }}
+            - secretRef:
+                name: {{ include "jdai.fullname" . }}-secrets
+            {{- end }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.gateway.startupProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.gateway.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.gateway.startupProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.gateway.readinessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.gateway.livenessProbe.path }}
+              port: http
+            periodSeconds: {{ .Values.gateway.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
+          securityContext:
+            {{- toYaml .Values.gateway.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+          {{- if .Values.gateway.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.gateway.persistence.mountPath }}
+          {{- end }}
+      {{- if .Values.gateway.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-gateway" (include "jdai.fullname" .)) .Values.gateway.persistence.existingClaim }}
+      {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/jdai/templates/hpa-gateway.yaml
+++ b/deploy/helm/jdai/templates/hpa-gateway.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.gateway.enabled .Values.gateway.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "jdai.fullname" . }}-gateway
+  minReplicas: {{ .Values.gateway.hpa.minReplicas }}
+  maxReplicas: {{ .Values.gateway.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.gateway.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.gateway.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/jdai/templates/ingress.yaml
+++ b/deploy/helm/jdai/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.gateway.enabled .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "jdai.fullname" $ }}-gateway
+                port:
+                  number: {{ $.Values.gateway.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/jdai/templates/pdb-gateway.yaml
+++ b/deploy/helm/jdai/templates/pdb-gateway.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.gateway.enabled .Values.gateway.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  minAvailable: {{ .Values.gateway.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "jdai.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+{{- end }}

--- a/deploy/helm/jdai/templates/pvc-daemon.yaml
+++ b/deploy/helm/jdai/templates/pvc-daemon.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.daemon.enabled .Values.daemon.persistence.enabled (not .Values.daemon.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jdai.fullname" . }}-daemon
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.daemon.persistence.accessModes | nindent 4 }}
+  {{- if .Values.daemon.persistence.storageClassName }}
+  storageClassName: {{ .Values.daemon.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.daemon.persistence.size }}
+{{- end }}

--- a/deploy/helm/jdai/templates/pvc-gateway.yaml
+++ b/deploy/helm/jdai/templates/pvc-gateway.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.gateway.enabled .Values.gateway.persistence.enabled (not .Values.gateway.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.gateway.persistence.accessModes | nindent 4 }}
+  {{- if .Values.gateway.persistence.storageClassName }}
+  storageClassName: {{ .Values.gateway.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.gateway.persistence.size }}
+{{- end }}

--- a/deploy/helm/jdai/templates/secret.yaml
+++ b/deploy/helm/jdai/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config.secretData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "jdai.fullname" . }}-secrets
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.config.secretData | nindent 2 }}
+{{- end }}

--- a/deploy/helm/jdai/templates/service-gateway.yaml
+++ b/deploy/helm/jdai/templates/service-gateway.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jdai.fullname" . }}-gateway
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  type: {{ .Values.gateway.service.type }}
+  selector:
+    {{- include "jdai.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.gateway.service.port }}
+      targetPort: http
+{{- end }}

--- a/deploy/helm/jdai/templates/serviceaccount.yaml
+++ b/deploy/helm/jdai/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jdai.serviceAccountName" . }}
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/jdai/values.yaml
+++ b/deploy/helm/jdai/values.yaml
@@ -1,0 +1,124 @@
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+
+config:
+  data: {}
+  secretData: {}
+
+gateway:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-gateway
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 15790
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  env: []
+  persistence:
+    enabled: true
+    existingClaim: ""
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    mountPath: /home/jdai/.jdai
+  startupProbe:
+    path: /health/live
+    periodSeconds: 5
+    failureThreshold: 30
+  readinessProbe:
+    path: /health/ready
+    periodSeconds: 10
+    failureThreshold: 3
+  livenessProbe:
+    path: /health/live
+    periodSeconds: 15
+    failureThreshold: 3
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+  pdb:
+    enabled: true
+    minAvailable: 1
+
+daemon:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-daemon
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    port: 15790
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  env: []
+  persistence:
+    enabled: true
+    existingClaim: ""
+    storageClassName: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    mountPath: /home/jdai/.jdai
+  startupProbe:
+    path: /health
+    periodSeconds: 5
+    failureThreshold: 30
+  readinessProbe:
+    path: /health
+    periodSeconds: 10
+    failureThreshold: 3
+  livenessProbe:
+    path: /health
+    periodSeconds: 15
+    failureThreshold: 3
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: jdai.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+tui:
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-tui
+    tag: latest

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -83,6 +83,14 @@ docker run -d \
 
 Mount the `~/.jdai` directory as a volume to persist sessions, credentials, and local models across container restarts.
 
+Container build definitions are versioned in this repository:
+
+- `deploy/docker/Dockerfile.gateway`
+- `deploy/docker/Dockerfile.daemon`
+- `deploy/docker/Dockerfile.tui`
+
+For Kubernetes + Helm deployment, see [Kubernetes Deployment](kubernetes.md).
+
 ## Reverse Proxy Configuration
 
 ### Nginx

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -13,6 +13,10 @@ This section covers deploying, monitoring, securing, and governing JD.AI in prod
 
 Install and run JD.AI Gateway as a system service. Covers Windows Service installation, Linux systemd configuration, Docker container deployment, reverse proxy setup, auto-update management, and daemon CLI commands.
 
+### [Kubernetes Deployment](kubernetes.md)
+
+Deploy JD.AI to Kubernetes with Helm. Covers GHCR images, values-driven configuration, startup/readiness/liveness probes, autoscaling (HPA), PodDisruptionBudget, ingress, and service mesh annotations.
+
 ### [Observability](observability.md)
 
 Monitor JD.AI with OpenTelemetry distributed tracing and metrics. Covers ActivitySource and Meter instrumentation, health check endpoints, Kubernetes probe configuration, Prometheus and Grafana integration, the `/doctor` diagnostic command, and log configuration.

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -1,0 +1,126 @@
+---
+title: Kubernetes Deployment
+description: "Deploy JD.AI Gateway and Daemon to Kubernetes with Helm, autoscaling, disruption budgets, health probes, and SBOM-backed container images."
+---
+
+# Kubernetes Deployment
+
+JD.AI ships container and Helm assets for cloud-native deployment:
+
+- Multi-stage Dockerfiles for `JD.AI.Gateway`, `JD.AI.Daemon`, and `JD.AI` (TUI)
+- Helm chart at `deploy/helm/jdai`
+- CI image publishing to GitHub Container Registry (GHCR)
+- SBOM generation + attestation for every published container image
+
+## Container images
+
+Published images:
+
+- `ghcr.io/jerrettdavis/jd.ai-gateway`
+- `ghcr.io/jerrettdavis/jd.ai-daemon`
+- `ghcr.io/jerrettdavis/jd.ai-tui`
+
+The workflow `.github/workflows/containers.yml` builds and pushes images on `main` and `v*` tags.
+
+## Helm quick start
+
+```bash
+kubectl create namespace jdai
+
+helm upgrade --install jdai ./deploy/helm/jdai \
+  --namespace jdai
+```
+
+## Common overrides
+
+```yaml
+gateway:
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-gateway
+    tag: v1.0.0
+  hpa:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+  pdb:
+    enabled: true
+    minAvailable: 1
+
+daemon:
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-daemon
+    tag: v1.0.0
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: jdai.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Apply:
+
+```bash
+helm upgrade --install jdai ./deploy/helm/jdai \
+  --namespace jdai \
+  -f values-prod.yaml
+```
+
+## Probes and availability
+
+Gateway probes default to:
+
+- startup: `GET /health/live`
+- readiness: `GET /health/ready`
+- liveness: `GET /health/live`
+
+Daemon probes default to:
+
+- startup/readiness/liveness: `GET /health`
+
+The chart also includes:
+
+- `HorizontalPodAutoscaler` for gateway
+- `PodDisruptionBudget` for gateway
+
+## Config and secrets
+
+Use chart values:
+
+- `config.data` -> ConfigMap
+- `config.secretData` -> Secret
+
+Both are injected as `envFrom` into gateway and daemon pods.
+
+## Service mesh compatibility
+
+Use pod annotations for sidecar injection or mesh-specific settings:
+
+```yaml
+gateway:
+  podAnnotations:
+    sidecar.istio.io/inject: "true"
+
+daemon:
+  podAnnotations:
+    sidecar.istio.io/inject: "true"
+```
+
+No host networking or fixed node ports are required by the chart.
+
+## Local image builds
+
+```bash
+docker build -f deploy/docker/Dockerfile.gateway -t jdai-gateway:local .
+docker build -f deploy/docker/Dockerfile.daemon -t jdai-daemon:local .
+docker build -f deploy/docker/Dockerfile.tui -t jdai-tui:local .
+```
+
+## See also
+
+- [Service Deployment](deployment.md)
+- [Observability](observability.md)
+- [Security](security.md)

--- a/docs/operations/toc.yml
+++ b/docs/operations/toc.yml
@@ -2,6 +2,8 @@
   href: index.md
 - name: Service Deployment
   href: deployment.md
+- name: Kubernetes Deployment
+  href: kubernetes.md
 - name: Observability
   href: observability.md
 - name: Admin Dashboard


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles for Gateway, Daemon, and TUI under `deploy/docker/`
- add GHCR container publish workflow (`.github/workflows/containers.yml`) with matrix builds for all 3 components
- generate SPDX SBOMs for each image and attest SBOMs to image digests
- add a Helm chart (`deploy/helm/jdai`) with Deployments, Service, Ingress, ConfigMap, Secret, PVCs
- include HPA + PodDisruptionBudget for gateway, plus startup/readiness/liveness probes
- document Kubernetes deployment and update operations docs/toc links

## Validation
- `docfx docs/docfx.json`
- `dotnet format --verify-no-changes`

Closes #152
