### PR TITLE
feat: harden credential storage with vault and key rotation

### DIFF
--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -16,10 +16,37 @@ JD.AI stores API keys and secrets in an encrypted credential store at `~/.jdai/c
 | Platform | Encryption | Details |
 |----------|-----------|---------|
 | Windows | DPAPI | Per-user encryption tied to the Windows account |
-| Linux | AES-256-GCM | Key derived from machine-specific entropy |
-| macOS | AES-256-GCM | Key derived from machine-specific entropy |
+| Linux | AES-256-GCM | Random local keyring with key IDs and rotation support |
+| macOS | AES-256-GCM | Random local keyring with key IDs and rotation support |
 
 Credentials are never stored in plain text. The `/provider add` wizard automatically encrypts keys before writing them to the store.
+
+### External secret backends
+
+JD.AI supports optional HashiCorp Vault-backed credential storage:
+
+```bash
+export JDAI_VAULT_ADDR="https://vault.example.com"
+export JDAI_VAULT_TOKEN="s.xxxxx"
+export JDAI_VAULT_MOUNT="secret"                 # optional, default: secret
+export JDAI_VAULT_PREFIX="jdai/credentials"      # optional
+```
+
+When Vault is configured, reads/writes are performed against Vault first with encrypted file-store fallback for availability.
+
+For Kubernetes and containerized deployments, mounted secret files can also be used as a read-only fallback:
+
+```bash
+export JDAI_CREDENTIALS_MOUNT_PATH="/var/run/secrets/jdai"
+```
+
+### Access auditing
+
+Credential access operations (get/set/remove/list/rotate) are recorded in:
+
+- `~/.jdai/credentials/access.audit.log`
+
+Entries contain operation type, key hash (not plaintext key), backend (`vault`/`local`/`mounted`), success flag, and timestamp.
 
 ### Credential resolution chain
 
@@ -71,6 +98,8 @@ jdai /provider remove openai
 # Add the new key
 jdai /provider add openai
 ```
+
+On Linux/macOS, the credential store also supports local encryption-key rotation with backward-compatible decryption of previously encrypted entries.
 
 ### Logging protections
 

--- a/src/JD.AI.Core/Providers/Credentials/EncryptedFileStore.cs
+++ b/src/JD.AI.Core/Providers/Credentials/EncryptedFileStore.cs
@@ -5,108 +5,313 @@ using System.Text.Json;
 namespace JD.AI.Core.Providers.Credentials;
 
 /// <summary>
-/// Cross-platform credential store using DPAPI (Windows) or AES with
-/// a machine-specific key derived from the user profile path.
-/// Credentials stored in ~/.jdai/credentials/.
+/// Cross-platform credential store using DPAPI (Windows) or AES-GCM with
+/// locally rotated key material (Linux/macOS).
+/// Credentials are stored in ~/.jdai/credentials/ by default.
 /// </summary>
 public sealed class EncryptedFileStore : ICredentialStore
 {
-    private readonly string _storePath;
+    private static readonly byte[] EnvelopeMagic = Encoding.ASCII.GetBytes("JDAI2");
+    private const byte EnvelopeVersion = 1;
+    private const int NonceLength = 12;
+    private const int TagLength = 16;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
     private static readonly System.Threading.Lock Lock = new();
 
-    public EncryptedFileStore(string? basePath = null)
+    private readonly string _storePath;
+    private readonly string _keyMapPath;
+    private readonly string _keyRingPath;
+    private readonly string _auditLogPath;
+    private readonly string? _mountedSecretsPath;
+    private readonly VaultCredentialBackend? _vaultBackend;
+
+    public EncryptedFileStore(
+        string? basePath = null,
+        HttpClient? httpClient = null,
+        EncryptedFileStoreOptions? options = null)
     {
         _storePath = basePath ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".jdai", "credentials");
+
         Directory.CreateDirectory(_storePath);
+
+        _keyMapPath = Path.Combine(_storePath, "keymap.json");
+        _keyRingPath = Path.Combine(_storePath, "keyring.json");
+        _auditLogPath = Path.Combine(_storePath, "access.audit.log");
+
+        var resolved = options ?? EncryptedFileStoreOptions.FromEnvironment();
+        _mountedSecretsPath = resolved.MountedSecretsPath;
+
+        if (resolved.VaultConfigured)
+        {
+            _vaultBackend = new VaultCredentialBackend(httpClient ?? new HttpClient(), resolved);
+        }
     }
 
     public bool IsAvailable => true;
 
-    public string StoreName => OperatingSystem.IsWindows()
-        ? "DPAPI Encrypted File Store"
-        : "AES Encrypted File Store";
-
-    public Task<string?> GetAsync(string key, CancellationToken ct = default)
+    public string StoreName
     {
-        var filePath = GetFilePath(key);
-        if (!File.Exists(filePath))
-            return Task.FromResult<string?>(null);
+        get
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return "DPAPI Encrypted File Store";
+            }
 
-        try
-        {
-            var encrypted = File.ReadAllBytes(filePath);
-            var decrypted = Unprotect(encrypted);
-            return Task.FromResult<string?>(Encoding.UTF8.GetString(decrypted));
-        }
-#pragma warning disable CA1031
-        catch
-#pragma warning restore CA1031
-        {
-            return Task.FromResult<string?>(null);
+            return _vaultBackend is not null
+                ? "Vault + AES-GCM Encrypted File Store"
+                : "AES-GCM Encrypted File Store";
         }
     }
 
-    public Task SetAsync(string key, string value, CancellationToken ct = default)
+    public async Task<string?> GetAsync(string key, CancellationToken ct = default)
     {
-        var filePath = GetFilePath(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ct.ThrowIfCancellationRequested();
+
+        if (_vaultBackend is not null)
+        {
+            try
+            {
+                var fromVault = await _vaultBackend.GetAsync(key, ct).ConfigureAwait(false);
+                if (fromVault is not null)
+                {
+                    AppendAudit("get", key, "vault", success: true);
+                    return fromVault;
+                }
+
+                AppendAudit("get", key, "vault", success: false, detail: "miss");
+            }
+#pragma warning disable CA1031 // Vault failures should not block local fallback
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                AppendAudit("get", key, "vault", success: false, detail: ex.GetType().Name);
+            }
+        }
+
+        var filePath = ResolveFilePath(key, createMapping: false);
+        if (File.Exists(filePath))
+        {
+            try
+            {
+                var encrypted = await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false);
+                var decrypted = Unprotect(encrypted);
+                var value = Encoding.UTF8.GetString(decrypted);
+                AppendAudit("get", key, "local", success: true);
+                return value;
+            }
+#pragma warning disable CA1031 // Return null on corrupted entries and continue fallback chain
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                AppendAudit("get", key, "local", success: false, detail: ex.GetType().Name);
+            }
+        }
+
+        var mountedValue = TryReadMountedSecret(key);
+        if (mountedValue is not null)
+        {
+            AppendAudit("get", key, "mounted", success: true);
+            return mountedValue;
+        }
+
+        AppendAudit("get", key, "local", success: false, detail: "miss");
+        return null;
+    }
+
+    public async Task SetAsync(string key, string value, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+        ct.ThrowIfCancellationRequested();
+
+        if (_vaultBackend is not null)
+        {
+            try
+            {
+                await _vaultBackend.SetAsync(key, value, ct).ConfigureAwait(false);
+                AppendAudit("set", key, "vault", success: true);
+            }
+#pragma warning disable CA1031 // Continue with local storage fallback if vault write fails
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                AppendAudit("set", key, "vault", success: false, detail: ex.GetType().Name);
+            }
+        }
+
+        var filePath = ResolveFilePath(key, createMapping: true);
         var encrypted = Protect(Encoding.UTF8.GetBytes(value));
         lock (Lock)
         {
             File.WriteAllBytes(filePath, encrypted);
+            TrySetFilePermissions(filePath);
         }
 
+        AppendAudit("set", key, "local", success: true);
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ct.ThrowIfCancellationRequested();
+
+        if (_vaultBackend is not null)
+        {
+            try
+            {
+                await _vaultBackend.RemoveAsync(key, ct).ConfigureAwait(false);
+                AppendAudit("remove", key, "vault", success: true);
+            }
+#pragma warning disable CA1031 // Continue local delete even when vault delete fails
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                AppendAudit("remove", key, "vault", success: false, detail: ex.GetType().Name);
+            }
+        }
+
+        var filePath = ResolveFilePath(key, createMapping: false);
+        lock (Lock)
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            var map = ReadKeyMapNoLock();
+            if (map.Remove(key))
+            {
+                WriteKeyMapNoLock(map);
+            }
+        }
+
+        AppendAudit("remove", key, "local", success: true);
+    }
+
+    public async Task<IReadOnlyList<string>> ListKeysAsync(string prefix, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        ct.ThrowIfCancellationRequested();
+
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        lock (Lock)
+        {
+            foreach (var key in ReadKeyMapNoLock().Keys.Where(k =>
+                         k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            {
+                result.Add(key);
+            }
+        }
+
+        if (_vaultBackend is not null)
+        {
+            try
+            {
+                var vaultKeys = await _vaultBackend.ListKeysAsync(ct).ConfigureAwait(false);
+                foreach (var key in vaultKeys.Where(k =>
+                             k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    result.Add(key);
+                }
+
+                AppendAudit("list", prefix, "vault", success: true);
+            }
+#pragma warning disable CA1031 // Non-fatal vault list failure
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                AppendAudit("list", prefix, "vault", success: false, detail: ex.GetType().Name);
+            }
+        }
+
+        AppendAudit("list", prefix, "local", success: true);
+        return [.. result.OrderBy(static k => k, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>
+    /// Rotates the local non-Windows AES-GCM key and marks the previous key as retired.
+    /// Existing secrets remain readable with historical keys.
+    /// </summary>
+    public Task RotateKeyAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (OperatingSystem.IsWindows())
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (Lock)
+        {
+            var keyRing = ReadOrCreateKeyRingNoLock();
+            var active = keyRing.Keys.FirstOrDefault(k =>
+                string.Equals(k.Id, keyRing.ActiveKeyId, StringComparison.OrdinalIgnoreCase));
+            if (active is not null)
+            {
+                active.RetiredAtUtc ??= DateTimeOffset.UtcNow;
+            }
+
+            var next = CreateNewKeyRecord();
+            keyRing.ActiveKeyId = next.Id;
+            keyRing.Keys.Add(next);
+            WriteKeyRingNoLock(keyRing);
+        }
+
+        AppendAudit("rotate", "store", "local", success: true);
         return Task.CompletedTask;
     }
 
-    public Task RemoveAsync(string key, CancellationToken ct = default)
-    {
-        var filePath = GetFilePath(key);
-        if (File.Exists(filePath))
-            File.Delete(filePath);
-
-        return Task.CompletedTask;
-    }
-
-    public Task<IReadOnlyList<string>> ListKeysAsync(string prefix, CancellationToken ct = default)
-    {
-        var mapPath = Path.Combine(_storePath, "keymap.json");
-        if (!File.Exists(mapPath))
-            return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
-
-        var map = JsonSerializer.Deserialize<Dictionary<string, string>>(
-            File.ReadAllText(mapPath)) ?? [];
-        var result = map.Keys
-            .Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        return Task.FromResult<IReadOnlyList<string>>(result);
-    }
-
-    private string GetFilePath(string key)
+    private string ResolveFilePath(string key, bool createMapping)
     {
         var hash = Convert.ToHexString(
             SHA256.HashData(Encoding.UTF8.GetBytes(key)))[..16];
 
-        var mapPath = Path.Combine(_storePath, "keymap.json");
-        Dictionary<string, string> map;
         lock (Lock)
         {
-            map = File.Exists(mapPath)
-                ? JsonSerializer.Deserialize<Dictionary<string, string>>(
-                    File.ReadAllText(mapPath)) ?? []
-                : [];
-            if (!map.ContainsKey(key))
+            var map = ReadKeyMapNoLock();
+            if (map.TryGetValue(key, out var existingHash))
+            {
+                return Path.Combine(_storePath, $"{existingHash}.enc");
+            }
+
+            if (createMapping)
             {
                 map[key] = hash;
-                File.WriteAllText(mapPath, JsonSerializer.Serialize(map));
+                WriteKeyMapNoLock(map);
             }
         }
 
         return Path.Combine(_storePath, $"{hash}.enc");
     }
 
-    private static byte[] Protect(byte[] data)
+    private Dictionary<string, string> ReadKeyMapNoLock()
+    {
+        if (!File.Exists(_keyMapPath))
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(
+                   File.ReadAllText(_keyMapPath), JsonOptions) ??
+               new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private void WriteKeyMapNoLock(Dictionary<string, string> map)
+    {
+        File.WriteAllText(_keyMapPath, JsonSerializer.Serialize(map, JsonOptions));
+        TrySetFilePermissions(_keyMapPath);
+    }
+
+    private byte[] Protect(byte[] data)
     {
 #pragma warning disable CA1416 // Platform compatibility — guarded by OperatingSystem.IsWindows()
         if (OperatingSystem.IsWindows())
@@ -115,24 +320,49 @@ public sealed class EncryptedFileStore : ICredentialStore
         }
 #pragma warning restore CA1416
 
-        // Non-Windows: AES with a deterministic key derived from username + machine
-        using var aes = Aes.Create();
-        var keyMaterial = Encoding.UTF8.GetBytes(
-            $"{Environment.UserName}:{Environment.MachineName}:jdai-credential-store");
-        aes.Key = SHA256.HashData(keyMaterial);
-        aes.GenerateIV();
-
-        using var ms = new MemoryStream();
-        ms.Write(aes.IV, 0, aes.IV.Length);
-        using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        string keyId;
+        byte[] keyMaterial;
+        lock (Lock)
         {
-            cs.Write(data, 0, data.Length);
+            var keyRing = ReadOrCreateKeyRingNoLock();
+            var active = keyRing.Keys.FirstOrDefault(k =>
+                             string.Equals(k.Id, keyRing.ActiveKeyId, StringComparison.OrdinalIgnoreCase))
+                         ?? throw new CryptographicException("Active credential key not found.");
+            keyId = active.Id;
+            keyMaterial = Convert.FromBase64String(active.KeyMaterialBase64);
         }
 
-        return ms.ToArray();
+        var nonce = RandomNumberGenerator.GetBytes(NonceLength);
+        var ciphertext = new byte[data.Length];
+        var tag = new byte[TagLength];
+
+        using (var aes = new AesGcm(keyMaterial, TagLength))
+        {
+            aes.Encrypt(nonce, data, ciphertext, tag);
+        }
+
+        var envelope = new byte[EnvelopeMagic.Length + 1 + 16 + NonceLength + TagLength + ciphertext.Length];
+        var offset = 0;
+        Buffer.BlockCopy(EnvelopeMagic, 0, envelope, offset, EnvelopeMagic.Length);
+        offset += EnvelopeMagic.Length;
+
+        envelope[offset++] = EnvelopeVersion;
+
+        var keyIdBytes = Guid.Parse(keyId).ToByteArray();
+        Buffer.BlockCopy(keyIdBytes, 0, envelope, offset, keyIdBytes.Length);
+        offset += keyIdBytes.Length;
+
+        Buffer.BlockCopy(nonce, 0, envelope, offset, nonce.Length);
+        offset += nonce.Length;
+
+        Buffer.BlockCopy(tag, 0, envelope, offset, tag.Length);
+        offset += tag.Length;
+
+        Buffer.BlockCopy(ciphertext, 0, envelope, offset, ciphertext.Length);
+        return envelope;
     }
 
-    private static byte[] Unprotect(byte[] data)
+    private byte[] Unprotect(byte[] data)
     {
 #pragma warning disable CA1416 // Platform compatibility — guarded by OperatingSystem.IsWindows()
         if (OperatingSystem.IsWindows())
@@ -141,14 +371,88 @@ public sealed class EncryptedFileStore : ICredentialStore
         }
 #pragma warning restore CA1416
 
-        // Non-Windows: AES decrypt
+        if (TryUnprotectEnvelopeV2(data, out var decrypted))
+        {
+            return decrypted;
+        }
+
+        return LegacyUnprotect(data);
+    }
+
+    private bool TryUnprotectEnvelopeV2(byte[] data, out byte[] decrypted)
+    {
+        decrypted = [];
+        var minimum = EnvelopeMagic.Length + 1 + 16 + NonceLength + TagLength;
+        if (data.Length <= minimum)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < EnvelopeMagic.Length; i++)
+        {
+            if (data[i] != EnvelopeMagic[i])
+            {
+                return false;
+            }
+        }
+
+        var offset = EnvelopeMagic.Length;
+        var version = data[offset++];
+        if (version != EnvelopeVersion)
+        {
+            throw new CryptographicException($"Unsupported credential envelope version '{version}'.");
+        }
+
+        var keyIdBytes = new byte[16];
+        Buffer.BlockCopy(data, offset, keyIdBytes, 0, keyIdBytes.Length);
+        offset += keyIdBytes.Length;
+        var keyId = new Guid(keyIdBytes).ToString("D");
+
+        var nonce = new byte[NonceLength];
+        Buffer.BlockCopy(data, offset, nonce, 0, nonce.Length);
+        offset += nonce.Length;
+
+        var tag = new byte[TagLength];
+        Buffer.BlockCopy(data, offset, tag, 0, tag.Length);
+        offset += tag.Length;
+
+        var ciphertext = new byte[data.Length - offset];
+        Buffer.BlockCopy(data, offset, ciphertext, 0, ciphertext.Length);
+
+        byte[] keyMaterial;
+        lock (Lock)
+        {
+            var keyRing = ReadOrCreateKeyRingNoLock();
+            var key = keyRing.Keys.FirstOrDefault(k =>
+                string.Equals(k.Id, keyId, StringComparison.OrdinalIgnoreCase));
+            if (key is null)
+            {
+                throw new CryptographicException(
+                    $"Credential key '{keyId}' not found in keyring. " +
+                    "Rotate keys only after migrating encrypted secrets.");
+            }
+
+            keyMaterial = Convert.FromBase64String(key.KeyMaterialBase64);
+        }
+
+        decrypted = new byte[ciphertext.Length];
+        using (var aes = new AesGcm(keyMaterial, TagLength))
+        {
+            aes.Decrypt(nonce, ciphertext, tag, decrypted);
+        }
+
+        return true;
+    }
+
+    private static byte[] LegacyUnprotect(byte[] data)
+    {
         using var aes = Aes.Create();
         var keyMaterial = Encoding.UTF8.GetBytes(
             $"{Environment.UserName}:{Environment.MachineName}:jdai-credential-store");
         aes.Key = SHA256.HashData(keyMaterial);
 
         var iv = new byte[16];
-        Array.Copy(data, 0, iv, 0, 16);
+        Array.Copy(data, 0, iv, 0, iv.Length);
         aes.IV = iv;
 
         using var ms = new MemoryStream();
@@ -158,5 +462,125 @@ public sealed class EncryptedFileStore : ICredentialStore
         }
 
         return ms.ToArray();
+    }
+
+    private KeyRingDocument ReadOrCreateKeyRingNoLock()
+    {
+        if (File.Exists(_keyRingPath))
+        {
+            var existing = JsonSerializer.Deserialize<KeyRingDocument>(
+                File.ReadAllText(_keyRingPath), JsonOptions);
+            if (existing?.Keys.Count > 0 &&
+                existing.Keys.Any(k => string.Equals(k.Id, existing.ActiveKeyId, StringComparison.OrdinalIgnoreCase)))
+            {
+                return existing;
+            }
+        }
+
+        var key = CreateNewKeyRecord();
+        var created = new KeyRingDocument
+        {
+            ActiveKeyId = key.Id,
+            Keys = [key],
+        };
+        WriteKeyRingNoLock(created);
+        return created;
+    }
+
+    private void WriteKeyRingNoLock(KeyRingDocument keyRing)
+    {
+        File.WriteAllText(_keyRingPath, JsonSerializer.Serialize(keyRing, JsonOptions));
+        TrySetFilePermissions(_keyRingPath);
+    }
+
+    private static KeyRecord CreateNewKeyRecord()
+    {
+        return new KeyRecord
+        {
+            Id = Guid.NewGuid().ToString("D"),
+            KeyMaterialBase64 = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)),
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        };
+    }
+
+    private string? TryReadMountedSecret(string key)
+    {
+        if (string.IsNullOrWhiteSpace(_mountedSecretsPath) ||
+            !Directory.Exists(_mountedSecretsPath))
+        {
+            return null;
+        }
+
+        var candidates = new[]
+        {
+            key,
+            key.Replace(':', '_'),
+            key.Replace(":", "__", StringComparison.Ordinal),
+        };
+
+        foreach (var candidate in candidates)
+        {
+            var path = Path.Combine(_mountedSecretsPath, candidate);
+            if (File.Exists(path))
+            {
+                return File.ReadAllText(path).Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private void AppendAudit(string action, string keyOrPrefix, string backend, bool success, string? detail = null)
+    {
+        var keyHash = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(keyOrPrefix)))[..12];
+
+        var line =
+            $"{DateTimeOffset.UtcNow:O} action={action} keyHash={keyHash} backend={backend} success={success}";
+        if (!string.IsNullOrWhiteSpace(detail))
+        {
+            line += $" detail={detail}";
+        }
+
+        lock (Lock)
+        {
+            File.AppendAllText(_auditLogPath, line + Environment.NewLine);
+            TrySetFilePermissions(_auditLogPath);
+        }
+    }
+
+    private static void TrySetFilePermissions(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+#pragma warning disable CA1416 // Guarded by OS check
+        try
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+#pragma warning disable CA1031 // Best-effort permissions hardening
+        catch
+#pragma warning restore CA1031
+        {
+            // Best effort permissions hardening.
+        }
+#pragma warning restore CA1416
+    }
+
+    private sealed record KeyRingDocument
+    {
+        public string ActiveKeyId { get; set; } = string.Empty;
+        public List<KeyRecord> Keys { get; set; } = [];
+    }
+
+    private sealed record KeyRecord
+    {
+        public string Id { get; set; } = string.Empty;
+        public string KeyMaterialBase64 { get; set; } = string.Empty;
+        public DateTimeOffset CreatedAtUtc { get; set; }
+        public DateTimeOffset? RetiredAtUtc { get; set; }
     }
 }

--- a/src/JD.AI.Core/Providers/Credentials/EncryptedFileStoreOptions.cs
+++ b/src/JD.AI.Core/Providers/Credentials/EncryptedFileStoreOptions.cs
@@ -1,0 +1,39 @@
+namespace JD.AI.Core.Providers.Credentials;
+
+/// <summary>
+/// Configuration options for <see cref="EncryptedFileStore"/>.
+/// </summary>
+public sealed record EncryptedFileStoreOptions
+{
+    public const string VaultAddressEnvVar = "JDAI_VAULT_ADDR";
+    public const string VaultTokenEnvVar = "JDAI_VAULT_TOKEN";
+    public const string VaultMountEnvVar = "JDAI_VAULT_MOUNT";
+    public const string VaultPrefixEnvVar = "JDAI_VAULT_PREFIX";
+    public const string MountedSecretsPathEnvVar = "JDAI_CREDENTIALS_MOUNT_PATH";
+
+    public string? VaultAddress { get; init; }
+    public string? VaultToken { get; init; }
+    public string VaultMount { get; init; } = "secret";
+    public string VaultPrefix { get; init; } = "jdai/credentials";
+    public string? MountedSecretsPath { get; init; }
+
+    internal bool VaultConfigured =>
+        !string.IsNullOrWhiteSpace(VaultAddress) &&
+        !string.IsNullOrWhiteSpace(VaultToken);
+
+    public static EncryptedFileStoreOptions FromEnvironment()
+    {
+        return new EncryptedFileStoreOptions
+        {
+            VaultAddress = Environment.GetEnvironmentVariable(VaultAddressEnvVar),
+            VaultToken = Environment.GetEnvironmentVariable(VaultTokenEnvVar),
+            VaultMount = Environment.GetEnvironmentVariable(VaultMountEnvVar) is { Length: > 0 } mount
+                ? mount
+                : "secret",
+            VaultPrefix = Environment.GetEnvironmentVariable(VaultPrefixEnvVar) is { Length: > 0 } prefix
+                ? prefix
+                : "jdai/credentials",
+            MountedSecretsPath = Environment.GetEnvironmentVariable(MountedSecretsPathEnvVar),
+        };
+    }
+}

--- a/src/JD.AI.Core/Providers/Credentials/VaultCredentialBackend.cs
+++ b/src/JD.AI.Core/Providers/Credentials/VaultCredentialBackend.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace JD.AI.Core.Providers.Credentials;
+
+internal sealed class VaultCredentialBackend
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly string _vaultAddress;
+    private readonly string _vaultToken;
+    private readonly string _mount;
+    private readonly string _prefix;
+
+    public VaultCredentialBackend(HttpClient httpClient, EncryptedFileStoreOptions options)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _vaultAddress = options.VaultAddress!.TrimEnd('/');
+        _vaultToken = options.VaultToken!;
+        _mount = options.VaultMount.Trim('/');
+        _prefix = options.VaultPrefix.Trim('/');
+    }
+
+    public async Task<string?> GetAsync(string key, CancellationToken ct)
+    {
+        var encodedKey = EncodeKey(key);
+        var url = $"{_vaultAddress}/v1/{_mount}/data/{_prefix}/{encodedKey}";
+
+        using var request = CreateRequest(HttpMethod.Get, url);
+        using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        using var json = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false),
+            cancellationToken: ct).ConfigureAwait(false);
+
+        return json.RootElement
+            .GetProperty("data")
+            .GetProperty("data")
+            .GetProperty("value")
+            .GetString();
+    }
+
+    public async Task SetAsync(string key, string value, CancellationToken ct)
+    {
+        var encodedKey = EncodeKey(key);
+        var url = $"{_vaultAddress}/v1/{_mount}/data/{_prefix}/{encodedKey}";
+
+        using var request = CreateRequest(HttpMethod.Post, url);
+        request.Content = JsonContent.Create(new
+        {
+            data = new { value },
+        }, options: JsonOptions);
+
+        using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken ct)
+    {
+        var encodedKey = EncodeKey(key);
+        var url = $"{_vaultAddress}/v1/{_mount}/metadata/{_prefix}/{encodedKey}";
+
+        using var request = CreateRequest(HttpMethod.Delete, url);
+        using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return;
+        }
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<string>> ListKeysAsync(CancellationToken ct)
+    {
+        var url = $"{_vaultAddress}/v1/{_mount}/metadata/{_prefix}?list=true";
+
+        using var request = CreateRequest(new HttpMethod("LIST"), url);
+        using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return [];
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        using var json = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false),
+            cancellationToken: ct).ConfigureAwait(false);
+
+        if (!json.RootElement.TryGetProperty("data", out var data) ||
+            !data.TryGetProperty("keys", out var keysElement))
+        {
+            return [];
+        }
+
+        var keys = new List<string>();
+        foreach (var encoded in keysElement.EnumerateArray())
+        {
+            var key = DecodeKey(encoded.GetString());
+            if (!string.IsNullOrWhiteSpace(key))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    private HttpRequestMessage CreateRequest(HttpMethod method, string url)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.Add("X-Vault-Token", _vaultToken);
+        return request;
+    }
+
+    private static string EncodeKey(string key)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(key))
+            .TrimEnd('=')
+            .Replace("+", "-", StringComparison.Ordinal)
+            .Replace("/", "_", StringComparison.Ordinal);
+    }
+
+    private static string? DecodeKey(string? encoded)
+    {
+        if (string.IsNullOrWhiteSpace(encoded))
+        {
+            return null;
+        }
+
+        var payload = encoded
+            .Replace("-", "+", StringComparison.Ordinal)
+            .Replace("_", "/", StringComparison.Ordinal);
+
+        switch (payload.Length % 4)
+        {
+            case 2:
+                payload += "==";
+                break;
+            case 3:
+                payload += "=";
+                break;
+        }
+
+        var bytes = Convert.FromBase64String(payload);
+        return Encoding.UTF8.GetString(bytes);
+    }
+}

--- a/tests/JD.AI.Tests/Providers/Credentials/EncryptedFileStoreTests.cs
+++ b/tests/JD.AI.Tests/Providers/Credentials/EncryptedFileStoreTests.cs
@@ -1,3 +1,8 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using FluentAssertions;
 using JD.AI.Core.Providers.Credentials;
 
@@ -17,8 +22,14 @@ public sealed class EncryptedFileStoreTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup.
+        }
     }
 
     [Fact]
@@ -73,5 +84,191 @@ public sealed class EncryptedFileStoreTests : IDisposable
 
         var result = await _store.GetAsync("overwrite-key");
         result.Should().Be("new-value");
+    }
+
+    [Fact]
+    public async Task RotateKeyAsync_PreservesExistingSecrets()
+    {
+        await _store.SetAsync("key-one", "value-one");
+
+        await _store.RotateKeyAsync();
+        await _store.SetAsync("key-two", "value-two");
+
+        (await _store.GetAsync("key-one")).Should().Be("value-one");
+        (await _store.GetAsync("key-two")).Should().Be("value-two");
+    }
+
+    [Fact]
+    public async Task GetAsync_MountedSecretFallback_ReturnsValue()
+    {
+        var mountDir = Path.Combine(_tempDir, "mounted");
+        Directory.CreateDirectory(mountDir);
+        await File.WriteAllTextAsync(Path.Combine(mountDir, "provider__token"), "mounted-token-value");
+
+        var store = new EncryptedFileStore(
+            basePath: _tempDir,
+            options: new EncryptedFileStoreOptions
+            {
+                MountedSecretsPath = mountDir,
+            });
+
+        var value = await store.GetAsync("provider:token");
+
+        value.Should().Be("mounted-token-value");
+    }
+
+    [Fact]
+    public async Task GetAsync_LegacyCiphertext_RemainsReadable_OnNonWindows()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        const string Key = "legacy-key";
+        const string Plaintext = "legacy-value";
+
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Key)))[..16];
+        var mapPath = Path.Combine(_tempDir, "keymap.json");
+        var payloadPath = Path.Combine(_tempDir, $"{hash}.enc");
+        await File.WriteAllTextAsync(mapPath, JsonSerializer.Serialize(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [Key] = hash,
+        }));
+        await File.WriteAllBytesAsync(payloadPath, LegacyProtect(Encoding.UTF8.GetBytes(Plaintext)));
+
+        var value = await _store.GetAsync(Key);
+
+        value.Should().Be(Plaintext);
+    }
+
+    [Fact]
+    public async Task VaultBackend_StoresReadsAndListsCredentials()
+    {
+        var handler = new FakeVaultHandler();
+        var httpClient = new HttpClient(handler);
+
+        var store = new EncryptedFileStore(
+            basePath: _tempDir,
+            httpClient: httpClient,
+            options: new EncryptedFileStoreOptions
+            {
+                VaultAddress = "https://vault.example.test",
+                VaultToken = "test-token",
+                VaultMount = "secret",
+                VaultPrefix = "jdai/credentials",
+            });
+
+        await store.SetAsync("vault:key", "vault-value");
+        var value = await store.GetAsync("vault:key");
+        var keys = await store.ListKeysAsync("vault:");
+
+        value.Should().Be("vault-value");
+        keys.Should().Contain("vault:key");
+
+        await store.RemoveAsync("vault:key");
+        (await store.GetAsync("vault:key")).Should().BeNull();
+    }
+
+    private static byte[] LegacyProtect(byte[] data)
+    {
+        using var aes = Aes.Create();
+        var keyMaterial = Encoding.UTF8.GetBytes(
+            $"{Environment.UserName}:{Environment.MachineName}:jdai-credential-store");
+        aes.Key = SHA256.HashData(keyMaterial);
+        aes.GenerateIV();
+
+        using var ms = new MemoryStream();
+        ms.Write(aes.IV, 0, aes.IV.Length);
+
+        using (var cs = new CryptoStream(ms, aes.CreateEncryptor(), CryptoStreamMode.Write))
+        {
+            cs.Write(data, 0, data.Length);
+        }
+
+        return ms.ToArray();
+    }
+
+    private sealed class FakeVaultHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+            var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            var method = request.Method.Method.ToUpperInvariant();
+
+            if (segments.Length < 5)
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            var endpointType = segments[2];
+            var encodedKey = segments.Length > 5
+                ? segments[^1]
+                : string.Empty;
+
+            if (string.Equals(method, "LIST", StringComparison.Ordinal))
+            {
+                return Json(new
+                {
+                    data = new
+                    {
+                        keys = _values.Keys.ToArray(),
+                    },
+                });
+            }
+
+            if (string.Equals(method, "GET", StringComparison.Ordinal) &&
+                string.Equals(endpointType, "data", StringComparison.Ordinal))
+            {
+                if (!_values.TryGetValue(encodedKey, out var value))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+                }
+
+                return Json(new
+                {
+                    data = new
+                    {
+                        data = new
+                        {
+                            value,
+                        },
+                    },
+                });
+            }
+
+            if (string.Equals(method, "POST", StringComparison.Ordinal) &&
+                string.Equals(endpointType, "data", StringComparison.Ordinal))
+            {
+                var json = await request.Content!
+                    .ReadFromJsonAsync<JsonElement>(cancellationToken)
+                    .ConfigureAwait(false);
+                var value = json.GetProperty("data").GetProperty("value").GetString() ?? string.Empty;
+                _values[encodedKey] = value;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            if (string.Equals(method, "DELETE", StringComparison.Ordinal) &&
+                string.Equals(endpointType, "metadata", StringComparison.Ordinal))
+            {
+                _values.Remove(encodedKey);
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private static HttpResponseMessage Json(object payload)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(payload),
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace non-Windows deterministic key derivation with AES-GCM envelope encryption backed by a local keyring (`keyring.json`)
- add local key rotation support (`RotateKeyAsync`) while preserving decryption of previously encrypted values
- keep backward compatibility by decrypting legacy AES payloads from prior store format
- add optional HashiCorp Vault integration (`JDAI_VAULT_*`) with local fallback behavior
- add mounted secret-file fallback support (`JDAI_CREDENTIALS_MOUNT_PATH`) for container/Kubernetes usage
- add credential access auditing (`~/.jdai/credentials/access.audit.log`) with hashed key identifiers
- update security documentation for external secret backends and credential audit logging
- expand `EncryptedFileStore` tests for rotation, legacy compatibility, mounted secrets, and Vault behavior

## Validation
- `dotnet format --verify-no-changes`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter "FullyQualifiedName~EncryptedFileStoreTests|FullyQualifiedName~ProviderConfigurationManagerTests|FullyQualifiedName~ApiKeyDetectorTests"`
- `docfx docs/docfx.json`

Closes #145
