### PR TITLE
feat(config): remote config sources, polling, and schema versioning

### DIFF
--- a/src/JD.AI.Core/Config/ConfigSchemaVersion.cs
+++ b/src/JD.AI.Core/Config/ConfigSchemaVersion.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using JD.AI.Core.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace JD.AI.Core.Config;
+
+/// <summary>
+/// Tracks configuration schema versions and provides migration support.
+/// Schema versions are stored alongside config files and checked on load
+/// to detect when migration is needed.
+/// </summary>
+public sealed class ConfigSchemaVersion
+{
+    /// <summary>Current schema version for JD.AI configuration.</summary>
+    public const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.Options;
+
+    private readonly string _versionFilePath;
+    private readonly ILogger? _logger;
+
+    /// <param name="dataDir">Directory where version metadata is stored (typically ~/.jdai/).</param>
+    /// <param name="logger">Optional logger.</param>
+    public ConfigSchemaVersion(string dataDir, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(dataDir);
+        _versionFilePath = Path.Combine(dataDir, "schema-version.json");
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Reads the stored schema version, or returns 0 if no version file exists
+    /// (indicating a pre-versioning installation).
+    /// </summary>
+    public int GetStoredVersion()
+    {
+        if (!File.Exists(_versionFilePath))
+            return 0;
+
+        try
+        {
+            var json = File.ReadAllText(_versionFilePath);
+            var meta = JsonSerializer.Deserialize<SchemaVersionMeta>(json, JsonOptions);
+            return meta?.Version ?? 0;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            _logger?.LogWarning(ex, "Failed to read schema version file");
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Checks if migration is needed by comparing stored version to current.
+    /// </summary>
+    public bool NeedsMigration() => GetStoredVersion() < CurrentVersion;
+
+    /// <summary>
+    /// Stamps the current schema version after a successful migration or fresh install.
+    /// </summary>
+    public void StampCurrentVersion()
+    {
+        var dir = Path.GetDirectoryName(_versionFilePath);
+        if (dir is not null) Directory.CreateDirectory(dir);
+
+        var meta = new SchemaVersionMeta
+        {
+            Version = CurrentVersion,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            UpdatedBy = Environment.UserName,
+        };
+
+        var json = JsonSerializer.Serialize(meta, JsonOptions);
+        File.WriteAllText(_versionFilePath, json);
+
+        _logger?.LogInformation(
+            "Config schema version stamped: v{Version}", CurrentVersion);
+    }
+
+    /// <summary>
+    /// Runs all pending migrations from stored version to current version.
+    /// Returns the number of migrations applied.
+    /// </summary>
+    public int ApplyMigrations()
+    {
+        var stored = GetStoredVersion();
+        if (stored >= CurrentVersion)
+            return 0;
+
+        var applied = 0;
+
+        // Migration v0 → v1: initial schema version stamp (no data changes needed)
+        if (stored < 1)
+        {
+            _logger?.LogInformation("Applying config migration v0 → v1: initial version stamp");
+            applied++;
+        }
+
+        // Future migrations would go here:
+        // if (stored < 2) { MigrateV1ToV2(); applied++; }
+
+        StampCurrentVersion();
+        return applied;
+    }
+}
+
+/// <summary>
+/// Schema version metadata stored in <c>schema-version.json</c>.
+/// </summary>
+public sealed class SchemaVersionMeta
+{
+    public int Version { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public string? UpdatedBy { get; set; }
+}

--- a/src/JD.AI.Core/Config/FileRemoteConfigSource.cs
+++ b/src/JD.AI.Core/Config/FileRemoteConfigSource.cs
@@ -1,0 +1,68 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace JD.AI.Core.Config;
+
+/// <summary>
+/// Reads configuration from a file on disk, designed for Kubernetes ConfigMap
+/// volume mounts or any mounted config file that may be updated externally.
+/// Detects changes via SHA-256 content hashing.
+/// </summary>
+public sealed class FileRemoteConfigSource : IRemoteConfigSource
+{
+    private readonly string _filePath;
+    private readonly ILogger? _logger;
+    private string? _lastHash;
+
+    public string Name => "file";
+
+    /// <param name="filePath">Path to the configuration file.</param>
+    /// <param name="logger">Optional logger.</param>
+    public FileRemoteConfigSource(string filePath, ILogger? logger = null)
+    {
+        _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        _logger = logger;
+    }
+
+    public async Task<RemoteConfigResult?> FetchAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                _logger?.LogDebug("Config file not found: {Path}", _filePath);
+                return null;
+            }
+
+            var content = await File.ReadAllTextAsync(_filePath, ct).ConfigureAwait(false);
+            var hash = ComputeHash(content);
+
+            if (string.Equals(hash, _lastHash, StringComparison.OrdinalIgnoreCase))
+                return null; // No change
+
+            _lastHash = hash;
+
+            var lastWrite = File.GetLastWriteTimeUtc(_filePath);
+            var ext = Path.GetExtension(_filePath).ToLowerInvariant();
+
+            return new RemoteConfigResult
+            {
+                Content = content,
+                Version = hash,
+                ContentType = ext is ".yaml" or ".yml" ? "yaml" : ext is ".json" ? "json" : null,
+                LastModified = new DateTimeOffset(lastWrite, TimeSpan.Zero),
+            };
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogWarning(ex, "Failed to read config file: {Path}", _filePath);
+            return null;
+        }
+    }
+
+    private static string ComputeHash(string content)
+    {
+        var bytes = SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/JD.AI.Core/Config/HttpRemoteConfigSource.cs
+++ b/src/JD.AI.Core/Config/HttpRemoteConfigSource.cs
@@ -1,0 +1,91 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+
+namespace JD.AI.Core.Config;
+
+/// <summary>
+/// Fetches configuration from an HTTP endpoint. Compatible with Consul KV,
+/// Azure App Configuration REST API, Spring Cloud Config, or any endpoint
+/// that returns YAML/JSON configuration content.
+/// </summary>
+public sealed class HttpRemoteConfigSource : IRemoteConfigSource, IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly Uri _endpoint;
+    private readonly ILogger? _logger;
+    private readonly bool _ownsClient;
+    private string? _lastETag;
+
+    public string Name => "http";
+
+    /// <param name="endpoint">URL to fetch configuration from.</param>
+    /// <param name="httpClient">Optional pre-configured HttpClient (e.g. with auth headers).</param>
+    /// <param name="logger">Optional logger.</param>
+    public HttpRemoteConfigSource(
+        Uri endpoint,
+        HttpClient? httpClient = null,
+        ILogger? logger = null)
+    {
+        _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+        _logger = logger;
+
+        if (httpClient is not null)
+        {
+            _http = httpClient;
+            _ownsClient = false;
+        }
+        else
+        {
+            _http = new HttpClient();
+            _ownsClient = true;
+        }
+    }
+
+    public async Task<RemoteConfigResult?> FetchAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, _endpoint);
+
+            if (_lastETag is not null)
+                request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue($"\"{_lastETag}\""));
+
+            using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
+                return null; // No change since last fetch
+
+            response.EnsureSuccessStatusCode();
+
+            var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var etag = response.Headers.ETag?.Tag?.Trim('"');
+            _lastETag = etag;
+
+            var contentType = response.Content.Headers.ContentType?.MediaType switch
+            {
+                "application/x-yaml" or "text/yaml" => "yaml",
+                "application/json" or "text/json" => "json",
+                _ => null,
+            };
+
+            return new RemoteConfigResult
+            {
+                Content = content,
+                Version = etag ?? response.Content.Headers.LastModified?.ToString("O"),
+                ContentType = contentType,
+                LastModified = response.Content.Headers.LastModified,
+            };
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger?.LogWarning(ex, "Failed to fetch remote config from {Endpoint}", _endpoint);
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_ownsClient)
+            _http.Dispose();
+    }
+}

--- a/src/JD.AI.Core/Config/IRemoteConfigSource.cs
+++ b/src/JD.AI.Core/Config/IRemoteConfigSource.cs
@@ -1,0 +1,39 @@
+namespace JD.AI.Core.Config;
+
+/// <summary>
+/// Abstraction for retrieving configuration from a remote source.
+/// Implementations may connect to Consul, Azure App Configuration,
+/// Kubernetes ConfigMaps, or any HTTP-based config service.
+/// </summary>
+public interface IRemoteConfigSource
+{
+    /// <summary>Human-readable name of this config source (e.g. "consul", "http", "k8s-configmap").</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Fetches the current configuration content from the remote source.
+    /// Returns <c>null</c> if the source is unreachable or has no content.
+    /// </summary>
+    Task<RemoteConfigResult?> FetchAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of fetching configuration from a remote source.
+/// </summary>
+public sealed class RemoteConfigResult
+{
+    /// <summary>The raw configuration content (YAML or JSON).</summary>
+    public required string Content { get; init; }
+
+    /// <summary>
+    /// An opaque version identifier (e.g. HTTP ETag, Consul ModifyIndex, file hash).
+    /// Used for change detection without full content comparison.
+    /// </summary>
+    public string? Version { get; init; }
+
+    /// <summary>Content type hint: "yaml", "json", or null for auto-detect.</summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>When this content was last modified at the source.</summary>
+    public DateTimeOffset? LastModified { get; init; }
+}

--- a/src/JD.AI.Core/Config/RemoteConfigPoller.cs
+++ b/src/JD.AI.Core/Config/RemoteConfigPoller.cs
@@ -1,0 +1,127 @@
+using Microsoft.Extensions.Logging;
+
+namespace JD.AI.Core.Config;
+
+/// <summary>
+/// Periodically polls <see cref="IRemoteConfigSource"/> instances for changes
+/// and invokes a callback when new configuration is detected. Falls back to
+/// local config when remote sources are unavailable.
+/// </summary>
+public sealed class RemoteConfigPoller : IDisposable
+{
+    private readonly List<IRemoteConfigSource> _sources;
+    private readonly Func<string, string, Task> _onConfigChanged;
+    private readonly ILogger? _logger;
+    private readonly TimeSpan _interval;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _pollTask;
+    private bool _disposed;
+
+    /// <summary>Tracks the last known version per source for change detection.</summary>
+    private readonly Dictionary<string, string> _lastVersions = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <param name="sources">Remote config sources to poll.</param>
+    /// <param name="onConfigChanged">
+    /// Callback invoked when config changes. Receives (sourceName, newContent).
+    /// </param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="pollInterval">How often to poll. Defaults to 30 seconds.</param>
+    public RemoteConfigPoller(
+        IEnumerable<IRemoteConfigSource> sources,
+        Func<string, string, Task> onConfigChanged,
+        ILogger? logger = null,
+        TimeSpan? pollInterval = null)
+    {
+        _sources = sources?.ToList() ?? throw new ArgumentNullException(nameof(sources));
+        _onConfigChanged = onConfigChanged ?? throw new ArgumentNullException(nameof(onConfigChanged));
+        _logger = logger;
+        _interval = pollInterval ?? TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>Number of registered config sources.</summary>
+    public int SourceCount => _sources.Count;
+
+    /// <summary>Whether the poller is actively running.</summary>
+    public bool IsRunning => _pollTask is not null && !_pollTask.IsCompleted;
+
+    /// <summary>Starts the polling loop.</summary>
+    public void Start()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_pollTask is not null) return;
+
+        _pollTask = Task.Run(() => PollLoopAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Performs a single poll cycle across all sources. Useful for testing
+    /// or for on-demand refresh.
+    /// </summary>
+    public async Task PollOnceAsync(CancellationToken ct = default)
+    {
+        foreach (var source in _sources)
+        {
+            try
+            {
+                var result = await source.FetchAsync(ct).ConfigureAwait(false);
+                if (result is null) continue;
+
+                var versionKey = source.Name;
+                if (_lastVersions.TryGetValue(versionKey, out var lastVersion)
+                    && string.Equals(lastVersion, result.Version, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue; // No change
+                }
+
+                _lastVersions[versionKey] = result.Version ?? string.Empty;
+
+                _logger?.LogInformation(
+                    "Config change detected from source '{Source}' (version: {Version})",
+                    source.Name, result.Version ?? "unknown");
+
+                await _onConfigChanged(source.Name, result.Content).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger?.LogError(ex, "Error polling config source '{Source}'", source.Name);
+            }
+        }
+    }
+
+    private async Task PollLoopAsync(CancellationToken ct)
+    {
+        _logger?.LogInformation(
+            "Remote config poller started with {Count} source(s), polling every {Interval}s",
+            _sources.Count, _interval.TotalSeconds);
+
+        while (!ct.IsCancellationRequested)
+        {
+            await PollOnceAsync(ct).ConfigureAwait(false);
+
+            try
+            {
+                await Task.Delay(_interval, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _cts.Cancel();
+        _cts.Dispose();
+
+        // Dispose any sources that are disposable
+        foreach (var source in _sources)
+        {
+            if (source is IDisposable disposable)
+                disposable.Dispose();
+        }
+    }
+}

--- a/tests/JD.AI.Tests/Config/ConfigSchemaVersionTests.cs
+++ b/tests/JD.AI.Tests/Config/ConfigSchemaVersionTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Config;
+
+public sealed class ConfigSchemaVersionTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ConfigSchemaVersionTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-csv-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void GetStoredVersion_NoFile_ReturnsZero()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+
+        sv.GetStoredVersion().Should().Be(0);
+    }
+
+    [Fact]
+    public void StampCurrentVersion_WritesFile()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+
+        sv.StampCurrentVersion();
+
+        File.Exists(Path.Combine(_tempDir, "schema-version.json")).Should().BeTrue();
+        sv.GetStoredVersion().Should().Be(ConfigSchemaVersion.CurrentVersion);
+    }
+
+    [Fact]
+    public void NeedsMigration_NoVersionFile_ReturnsTrue()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+
+        sv.NeedsMigration().Should().BeTrue();
+    }
+
+    [Fact]
+    public void NeedsMigration_AfterStamp_ReturnsFalse()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+        sv.StampCurrentVersion();
+
+        sv.NeedsMigration().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyMigrations_FreshInstall_AppliesAndStamps()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+
+        var applied = sv.ApplyMigrations();
+
+        applied.Should().BeGreaterThan(0);
+        sv.NeedsMigration().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ApplyMigrations_AlreadyCurrent_ReturnsZero()
+    {
+        var sv = new ConfigSchemaVersion(_tempDir);
+        sv.StampCurrentVersion();
+
+        var applied = sv.ApplyMigrations();
+
+        applied.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetStoredVersion_CorruptFile_ReturnsZero()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "schema-version.json"), "not valid json");
+
+        var sv = new ConfigSchemaVersion(_tempDir);
+
+        sv.GetStoredVersion().Should().Be(0);
+    }
+}

--- a/tests/JD.AI.Tests/Config/FileRemoteConfigSourceTests.cs
+++ b/tests/JD.AI.Tests/Config/FileRemoteConfigSourceTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Config;
+
+public sealed class FileRemoteConfigSourceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FileRemoteConfigSourceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-frcs-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task FetchAsync_ExistingFile_ReturnsContent()
+    {
+        var path = Path.Combine(_tempDir, "config.yaml");
+        await File.WriteAllTextAsync(path, "apiVersion: jdai/v1");
+
+        var source = new FileRemoteConfigSource(path);
+        var result = await source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.Content.Should().Be("apiVersion: jdai/v1");
+    }
+
+    [Fact]
+    public async Task FetchAsync_NonExistentFile_ReturnsNull()
+    {
+        var source = new FileRemoteConfigSource(Path.Combine(_tempDir, "missing.yaml"));
+        var result = await source.FetchAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchAsync_UnchangedFile_ReturnsNullOnSecondCall()
+    {
+        var path = Path.Combine(_tempDir, "config.yaml");
+        await File.WriteAllTextAsync(path, "content: stable");
+
+        var source = new FileRemoteConfigSource(path);
+        var first = await source.FetchAsync();
+        var second = await source.FetchAsync();
+
+        first.Should().NotBeNull();
+        second.Should().BeNull("content has not changed");
+    }
+
+    [Fact]
+    public async Task FetchAsync_ChangedFile_ReturnsNewContent()
+    {
+        var path = Path.Combine(_tempDir, "config.yaml");
+        await File.WriteAllTextAsync(path, "version: 1");
+
+        var source = new FileRemoteConfigSource(path);
+        await source.FetchAsync(); // First read
+
+        await File.WriteAllTextAsync(path, "version: 2");
+        var result = await source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.Content.Should().Be("version: 2");
+    }
+
+    [Fact]
+    public async Task FetchAsync_YamlExtension_SetsContentType()
+    {
+        var path = Path.Combine(_tempDir, "config.yaml");
+        await File.WriteAllTextAsync(path, "key: value");
+
+        var source = new FileRemoteConfigSource(path);
+        var result = await source.FetchAsync();
+
+        result!.ContentType.Should().Be("yaml");
+    }
+
+    [Fact]
+    public async Task FetchAsync_JsonExtension_SetsContentType()
+    {
+        var path = Path.Combine(_tempDir, "config.json");
+        await File.WriteAllTextAsync(path, "{}");
+
+        var source = new FileRemoteConfigSource(path);
+        var result = await source.FetchAsync();
+
+        result!.ContentType.Should().Be("json");
+    }
+
+    [Fact]
+    public async Task FetchAsync_SetsVersionAsHash()
+    {
+        var path = Path.Combine(_tempDir, "config.yaml");
+        await File.WriteAllTextAsync(path, "data: test");
+
+        var source = new FileRemoteConfigSource(path);
+        var result = await source.FetchAsync();
+
+        result!.Version.Should().NotBeNullOrEmpty();
+        result.Version.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Name_ReturnsFile()
+    {
+        var source = new FileRemoteConfigSource("/tmp/test.yaml");
+        source.Name.Should().Be("file");
+    }
+}

--- a/tests/JD.AI.Tests/Config/HttpRemoteConfigSourceTests.cs
+++ b/tests/JD.AI.Tests/Config/HttpRemoteConfigSourceTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using FluentAssertions;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Config;
+
+public sealed class HttpRemoteConfigSourceTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly HttpRemoteConfigSource _source;
+
+    public HttpRemoteConfigSourceTests()
+    {
+        _httpClient = new HttpClient(_handler);
+        _source = new HttpRemoteConfigSource(
+            new Uri("https://config.example.com/api/v1/config"),
+            _httpClient);
+    }
+
+    public void Dispose()
+    {
+        _source.Dispose();
+        _httpClient.Dispose();
+        _handler.Dispose();
+    }
+
+    [Fact]
+    public async Task FetchAsync_SuccessfulResponse_ReturnsContent()
+    {
+        _handler.SetResponse("apiVersion: jdai/v1", HttpStatusCode.OK);
+
+        var result = await _source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.Content.Should().Be("apiVersion: jdai/v1");
+    }
+
+    [Fact]
+    public async Task FetchAsync_WithETag_SetsVersion()
+    {
+        _handler.SetResponse("content", HttpStatusCode.OK, etag: "abc123");
+
+        var result = await _source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.Version.Should().Be("abc123");
+    }
+
+    [Fact]
+    public async Task FetchAsync_NotModified_ReturnsNull()
+    {
+        _handler.SetResponse("content", HttpStatusCode.OK, etag: "v1");
+        await _source.FetchAsync(); // First fetch stores ETag
+
+        _handler.SetResponse("", HttpStatusCode.NotModified);
+        var result = await _source.FetchAsync(); // Second fetch with If-None-Match
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchAsync_ServerError_ReturnsNull()
+    {
+        _handler.SetResponse("", HttpStatusCode.InternalServerError);
+
+        var result = await _source.FetchAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FetchAsync_YamlContentType_DetectsYaml()
+    {
+        _handler.SetResponse("key: value", HttpStatusCode.OK, contentType: "application/x-yaml");
+
+        var result = await _source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.ContentType.Should().Be("yaml");
+    }
+
+    [Fact]
+    public async Task FetchAsync_JsonContentType_DetectsJson()
+    {
+        _handler.SetResponse("{}", HttpStatusCode.OK, contentType: "application/json");
+
+        var result = await _source.FetchAsync();
+
+        result.Should().NotBeNull();
+        result!.ContentType.Should().Be("json");
+    }
+
+    [Fact]
+    public void Name_ReturnsHttp()
+    {
+        _source.Name.Should().Be("http");
+    }
+
+    /// <summary>Simple mock HTTP handler for testing.</summary>
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private string _content = "";
+        private HttpStatusCode _statusCode = HttpStatusCode.OK;
+        private string? _etag;
+        private string? _contentType;
+
+        public void SetResponse(string content, HttpStatusCode statusCode,
+            string? etag = null, string? contentType = null)
+        {
+            _content = content;
+            _statusCode = statusCode;
+            _etag = etag;
+            _contentType = contentType;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_content),
+            };
+
+            if (_etag is not null)
+                response.Headers.ETag = new System.Net.Http.Headers.EntityTagHeaderValue($"\"{_etag}\"");
+
+            if (_contentType is not null)
+                response.Content.Headers.ContentType =
+                    new System.Net.Http.Headers.MediaTypeHeaderValue(_contentType);
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/tests/JD.AI.Tests/Config/RemoteConfigPollerTests.cs
+++ b/tests/JD.AI.Tests/Config/RemoteConfigPollerTests.cs
@@ -1,0 +1,174 @@
+using FluentAssertions;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Config;
+
+public sealed class RemoteConfigPollerTests
+{
+    [Fact]
+    public async Task PollOnceAsync_WithChangedSource_InvokesCallback()
+    {
+        var callbackInvoked = false;
+        string? receivedSource = null;
+        string? receivedContent = null;
+
+        var source = new InMemoryConfigSource("test-source", "new content", "v1");
+        var poller = new RemoteConfigPoller(
+            [source],
+            (name, content) =>
+            {
+                callbackInvoked = true;
+                receivedSource = name;
+                receivedContent = content;
+                return Task.CompletedTask;
+            });
+
+        await poller.PollOnceAsync();
+
+        callbackInvoked.Should().BeTrue();
+        receivedSource.Should().Be("test-source");
+        receivedContent.Should().Be("new content");
+    }
+
+    [Fact]
+    public async Task PollOnceAsync_SameVersion_DoesNotInvokeCallback()
+    {
+        var callCount = 0;
+        var source = new InMemoryConfigSource("src", "content", "v1");
+        var poller = new RemoteConfigPoller(
+            [source],
+            (_, _) => { callCount++; return Task.CompletedTask; });
+
+        await poller.PollOnceAsync(); // First poll — triggers callback
+        await poller.PollOnceAsync(); // Second poll — same version, no callback
+
+        callCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PollOnceAsync_VersionChanged_InvokesCallbackAgain()
+    {
+        var callCount = 0;
+        var source = new InMemoryConfigSource("src", "content-v1", "v1");
+        var poller = new RemoteConfigPoller(
+            [source],
+            (_, _) => { callCount++; return Task.CompletedTask; });
+
+        await poller.PollOnceAsync();
+
+        source.SetResult("content-v2", "v2");
+        await poller.PollOnceAsync();
+
+        callCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task PollOnceAsync_NullResult_SkipsCallback()
+    {
+        var callCount = 0;
+        var source = new InMemoryConfigSource("src", null, null);
+        var poller = new RemoteConfigPoller(
+            [source],
+            (_, _) => { callCount++; return Task.CompletedTask; });
+
+        await poller.PollOnceAsync();
+
+        callCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void SourceCount_ReturnsCorrectCount()
+    {
+        var sources = new[]
+        {
+            new InMemoryConfigSource("a", "c", "v"),
+            new InMemoryConfigSource("b", "c", "v"),
+        };
+        var poller = new RemoteConfigPoller(sources, (_, _) => Task.CompletedTask);
+
+        poller.SourceCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Start_SetsIsRunning()
+    {
+        var source = new InMemoryConfigSource("src", null, null);
+        using var poller = new RemoteConfigPoller(
+            [source],
+            (_, _) => Task.CompletedTask,
+            pollInterval: TimeSpan.FromHours(1));
+
+        poller.Start();
+
+        poller.IsRunning.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispose_StopsPoller()
+    {
+        var source = new InMemoryConfigSource("src", null, null);
+        var poller = new RemoteConfigPoller(
+            [source],
+            (_, _) => Task.CompletedTask,
+            pollInterval: TimeSpan.FromHours(1));
+
+        poller.Start();
+        poller.Dispose();
+
+        // After dispose, task should complete
+        Thread.Sleep(100);
+        poller.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PollOnceAsync_MultipleSources_PollsAll()
+    {
+        var received = new List<string>();
+        var sources = new[]
+        {
+            new InMemoryConfigSource("source-a", "content-a", "v1"),
+            new InMemoryConfigSource("source-b", "content-b", "v1"),
+        };
+        var poller = new RemoteConfigPoller(
+            sources,
+            (name, _) => { received.Add(name); return Task.CompletedTask; });
+
+        await poller.PollOnceAsync();
+
+        received.Should().Contain("source-a").And.Contain("source-b");
+    }
+
+    /// <summary>Simple in-memory config source for testing.</summary>
+    private sealed class InMemoryConfigSource : IRemoteConfigSource
+    {
+        private string? _content;
+        private string? _version;
+
+        public string Name { get; }
+
+        public InMemoryConfigSource(string name, string? content, string? version)
+        {
+            Name = name;
+            _content = content;
+            _version = version;
+        }
+
+        public void SetResult(string? content, string? version)
+        {
+            _content = content;
+            _version = version;
+        }
+
+        public Task<RemoteConfigResult?> FetchAsync(CancellationToken ct = default)
+        {
+            if (_content is null)
+                return Task.FromResult<RemoteConfigResult?>(null);
+
+            return Task.FromResult<RemoteConfigResult?>(new RemoteConfigResult
+            {
+                Content = _content,
+                Version = _version,
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **IRemoteConfigSource** interface — pluggable remote configuration backends
- **HttpRemoteConfigSource** — HTTP/REST-based config fetching with ETag change detection; compatible with Consul KV, Azure App Config, Spring Cloud Config
- **FileRemoteConfigSource** — File-based config for K8s ConfigMap volume mounts with SHA-256 content hashing for change detection
- **RemoteConfigPoller** — Periodic polling of remote sources with change detection and reload callbacks; configurable interval
- **ConfigSchemaVersion** — Schema versioning with migration support; stamps `schema-version.json` for forward/backward compatibility checks

## Test plan
- [x] 7 tests for `HttpRemoteConfigSource` (fetch, ETag, NotModified, content types, error handling)
- [x] 8 tests for `FileRemoteConfigSource` (read, change detection, content types, hashing)
- [x] 8 tests for `RemoteConfigPoller` (polling, change callback, multi-source, lifecycle)
- [x] 7 tests for `ConfigSchemaVersion` (version read, stamp, migration, corrupt file)
- [x] All 1828 unit tests pass

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)