### PR TITLE
feat(workflows): workflow signing, trusted publishers, and integrity validation

### DIFF
--- a/src/JD.AI.Workflows/Security/TrustedPublisherRegistry.cs
+++ b/src/JD.AI.Workflows/Security/TrustedPublisherRegistry.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using JD.AI.Core.Infrastructure;
+using Microsoft.Extensions.Logging;
+
+namespace JD.AI.Workflows.Security;
+
+/// <summary>
+/// Manages a registry of trusted workflow publishers. Only workflows
+/// from trusted publishers can be installed and executed when trust
+/// enforcement is enabled.
+/// </summary>
+public sealed class TrustedPublisherRegistry
+{
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.Options;
+
+    private readonly string _registryPath;
+    private readonly ILogger? _logger;
+    private readonly object _lock = new();
+    private TrustRegistryData _data;
+
+    /// <param name="registryPath">Path to the trust registry JSON file.</param>
+    /// <param name="logger">Optional logger.</param>
+    public TrustedPublisherRegistry(string registryPath, ILogger? logger = null)
+    {
+        _registryPath = registryPath ?? throw new ArgumentNullException(nameof(registryPath));
+        _logger = logger;
+        _data = Load();
+    }
+
+    /// <summary>Number of trusted publishers.</summary>
+    public int Count
+    {
+        get { lock (_lock) return _data.Publishers.Count; }
+    }
+
+    /// <summary>
+    /// Checks if a publisher (author name) is trusted.
+    /// </summary>
+    public bool IsTrusted(string author)
+    {
+        if (string.IsNullOrWhiteSpace(author)) return false;
+
+        lock (_lock)
+        {
+            return _data.Publishers.Any(
+                p => string.Equals(p.Name, author, StringComparison.OrdinalIgnoreCase)
+                     && !p.Revoked);
+        }
+    }
+
+    /// <summary>
+    /// Adds a publisher to the trusted registry.
+    /// </summary>
+    public void Trust(string name, string? fingerprint = null)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        lock (_lock)
+        {
+            if (_data.Publishers.Any(
+                    p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger?.LogDebug("Publisher '{Name}' is already trusted", name);
+                return;
+            }
+
+            _data.Publishers.Add(new TrustedPublisher
+            {
+                Name = name,
+                Fingerprint = fingerprint,
+                TrustedAt = DateTimeOffset.UtcNow,
+            });
+
+            Save();
+            _logger?.LogInformation("Trusted publisher added: {Name}", name);
+        }
+    }
+
+    /// <summary>
+    /// Revokes trust for a publisher without removing the record (for audit trail).
+    /// </summary>
+    public void Revoke(string name)
+    {
+        lock (_lock)
+        {
+            var pub = _data.Publishers.FirstOrDefault(
+                p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
+
+            if (pub is null)
+            {
+                _logger?.LogWarning("Publisher '{Name}' not found in registry", name);
+                return;
+            }
+
+            pub.Revoked = true;
+            pub.RevokedAt = DateTimeOffset.UtcNow;
+            Save();
+            _logger?.LogInformation("Publisher trust revoked: {Name}", name);
+        }
+    }
+
+    /// <summary>Returns all registered publishers (including revoked).</summary>
+    public IReadOnlyList<TrustedPublisher> GetAll()
+    {
+        lock (_lock)
+        {
+            return _data.Publishers.ToList().AsReadOnly();
+        }
+    }
+
+    private TrustRegistryData Load()
+    {
+        if (!File.Exists(_registryPath))
+            return new TrustRegistryData();
+
+        try
+        {
+            var json = File.ReadAllText(_registryPath);
+            return JsonSerializer.Deserialize<TrustRegistryData>(json, JsonOptions)
+                   ?? new TrustRegistryData();
+        }
+        catch (Exception ex) when (ex is JsonException or IOException)
+        {
+            _logger?.LogWarning(ex, "Failed to load trust registry, starting fresh");
+            return new TrustRegistryData();
+        }
+    }
+
+    private void Save()
+    {
+        var dir = Path.GetDirectoryName(_registryPath);
+        if (dir is not null) Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(_data, JsonOptions);
+        File.WriteAllText(_registryPath, json);
+    }
+}
+
+/// <summary>Root container for trust registry file.</summary>
+public sealed class TrustRegistryData
+{
+    public List<TrustedPublisher> Publishers { get; set; } = [];
+}
+
+/// <summary>A trusted workflow publisher entry.</summary>
+public sealed class TrustedPublisher
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Fingerprint { get; set; }
+    public DateTimeOffset TrustedAt { get; set; }
+    public bool Revoked { get; set; }
+    public DateTimeOffset? RevokedAt { get; set; }
+}

--- a/src/JD.AI.Workflows/Security/WorkflowIntegrityValidator.cs
+++ b/src/JD.AI.Workflows/Security/WorkflowIntegrityValidator.cs
@@ -1,0 +1,117 @@
+namespace JD.AI.Workflows.Security;
+
+/// <summary>
+/// Validates workflow integrity by checking signatures and publisher trust.
+/// Used as a gate before workflow execution or installation.
+/// </summary>
+public sealed class WorkflowIntegrityValidator
+{
+    private readonly TrustedPublisherRegistry? _trustRegistry;
+    private readonly byte[]? _signingKey;
+
+    /// <param name="signingKey">HMAC key for signature verification. Null to skip signature checks.</param>
+    /// <param name="trustRegistry">Publisher trust registry. Null to skip trust checks.</param>
+    public WorkflowIntegrityValidator(
+        byte[]? signingKey = null,
+        TrustedPublisherRegistry? trustRegistry = null)
+    {
+        _signingKey = signingKey;
+        _trustRegistry = trustRegistry;
+    }
+
+    /// <summary>
+    /// Validates a workflow definition and its metadata.
+    /// Returns a result indicating whether the workflow is safe to execute.
+    /// </summary>
+    public WorkflowValidationResult Validate(
+        AgentWorkflowDefinition definition,
+        string? author = null,
+        string? signature = null)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        var issues = new List<string>();
+
+        // Schema validation
+        if (string.IsNullOrWhiteSpace(definition.Name))
+            issues.Add("Workflow name is required");
+
+        if (string.IsNullOrWhiteSpace(definition.Version))
+            issues.Add("Workflow version is required");
+
+        if (definition.Steps.Count == 0)
+            issues.Add("Workflow must have at least one step");
+
+        // Validate step integrity
+        ValidateSteps(definition.Steps, issues, depth: 0);
+
+        // Signature verification
+        if (_signingKey is not null)
+        {
+            if (string.IsNullOrWhiteSpace(signature))
+            {
+                issues.Add("Workflow is unsigned but signature verification is required");
+            }
+            else if (!WorkflowSignature.Verify(definition, _signingKey, signature))
+            {
+                issues.Add("Workflow signature is invalid — content may have been tampered with");
+            }
+        }
+
+        // Publisher trust check
+        if (_trustRegistry is not null && !string.IsNullOrWhiteSpace(author))
+        {
+            if (!_trustRegistry.IsTrusted(author))
+                issues.Add($"Publisher '{author}' is not in the trusted publisher registry");
+        }
+
+        return new WorkflowValidationResult
+        {
+            IsValid = issues.Count == 0,
+            Issues = issues.AsReadOnly(),
+            WorkflowName = definition.Name,
+            WorkflowVersion = definition.Version,
+        };
+    }
+
+    private static void ValidateSteps(
+        IList<AgentStepDefinition> steps, List<string> issues, int depth)
+    {
+        if (depth > 10)
+        {
+            issues.Add("Workflow step nesting exceeds maximum depth of 10");
+            return;
+        }
+
+        foreach (var step in steps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Name))
+                issues.Add($"Step at depth {depth} has no name");
+
+            if (step.Kind is AgentStepKind.Tool or AgentStepKind.Skill or AgentStepKind.Nested
+                && string.IsNullOrWhiteSpace(step.Target))
+            {
+                issues.Add($"Step '{step.Name}' of kind {step.Kind} requires a target");
+            }
+
+            if (step.Kind is AgentStepKind.Loop or AgentStepKind.Conditional
+                && string.IsNullOrWhiteSpace(step.Condition))
+            {
+                issues.Add($"Step '{step.Name}' of kind {step.Kind} requires a condition");
+            }
+
+            if (step.SubSteps.Count > 0)
+                ValidateSteps(step.SubSteps, issues, depth + 1);
+        }
+    }
+}
+
+/// <summary>
+/// Result of workflow integrity validation.
+/// </summary>
+public sealed class WorkflowValidationResult
+{
+    public required bool IsValid { get; init; }
+    public required IReadOnlyList<string> Issues { get; init; }
+    public string? WorkflowName { get; init; }
+    public string? WorkflowVersion { get; init; }
+}

--- a/src/JD.AI.Workflows/Security/WorkflowSignature.cs
+++ b/src/JD.AI.Workflows/Security/WorkflowSignature.cs
@@ -1,0 +1,80 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using JD.AI.Core.Infrastructure;
+
+namespace JD.AI.Workflows.Security;
+
+/// <summary>
+/// Signs and verifies workflow definitions using HMAC-SHA256.
+/// Signatures cover the canonical JSON representation of the workflow,
+/// ensuring that any modification (steps, metadata, version) is detected.
+/// </summary>
+public static class WorkflowSignature
+{
+    private static readonly JsonSerializerOptions CanonicalOptions = new(JsonDefaults.Options)
+    {
+        WriteIndented = false,
+    };
+
+    /// <summary>
+    /// Computes an HMAC-SHA256 signature of the workflow definition.
+    /// </summary>
+    /// <returns>Lowercase hex signature string.</returns>
+    public static string Sign(AgentWorkflowDefinition definition, byte[] key)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(key);
+
+        var canonical = Canonicalize(definition);
+        var hash = HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(canonical));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Verifies that a signature matches the workflow definition.
+    /// </summary>
+    public static bool Verify(AgentWorkflowDefinition definition, byte[] key, string signature)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(signature);
+
+        var expected = Sign(definition, key);
+        return string.Equals(expected, signature, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Produces a canonical JSON representation of the workflow for signing.
+    /// Excludes volatile fields (CreatedAt, UpdatedAt) so signatures are stable.
+    /// </summary>
+    internal static string Canonicalize(AgentWorkflowDefinition definition)
+    {
+        var signable = new
+        {
+            definition.Name,
+            definition.Version,
+            definition.Description,
+            definition.IsDeprecated,
+            definition.MigrationGuidance,
+            definition.BreakingChanges,
+            definition.Tags,
+            Steps = CanonicalizeSteps(definition.Steps),
+        };
+
+        return JsonSerializer.Serialize(signable, CanonicalOptions);
+    }
+
+    private static object[] CanonicalizeSteps(IList<AgentStepDefinition> steps)
+    {
+        return steps.Select(s => (object)new
+        {
+            s.Name,
+            Kind = s.Kind.ToString(),
+            s.Target,
+            s.Condition,
+            s.AllowedPlugins,
+            SubSteps = CanonicalizeSteps(s.SubSteps),
+        }).ToArray();
+    }
+}

--- a/tests/JD.AI.Tests/Workflows/Security/TrustedPublisherRegistryTests.cs
+++ b/tests/JD.AI.Tests/Workflows/Security/TrustedPublisherRegistryTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using JD.AI.Workflows.Security;
+
+namespace JD.AI.Tests.Workflows.Security;
+
+public sealed class TrustedPublisherRegistryTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _registryPath;
+
+    public TrustedPublisherRegistryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-tpr-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _registryPath = Path.Combine(_tempDir, "trusted-publishers.json");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Trust_AddsPublisher()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+
+        registry.Trust("alice");
+
+        registry.IsTrusted("alice").Should().BeTrue();
+        registry.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void IsTrusted_UnknownPublisher_ReturnsFalse()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+
+        registry.IsTrusted("unknown").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsTrusted_CaseInsensitive()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+        registry.Trust("Alice");
+
+        registry.IsTrusted("alice").Should().BeTrue();
+        registry.IsTrusted("ALICE").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Revoke_RevokesTrust()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+        registry.Trust("alice");
+        registry.Revoke("alice");
+
+        registry.IsTrusted("alice").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Revoke_PreservesRecord()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+        registry.Trust("alice");
+        registry.Revoke("alice");
+
+        var all = registry.GetAll();
+        all.Should().HaveCount(1);
+        all[0].Revoked.Should().BeTrue();
+        all[0].RevokedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Trust_Duplicate_DoesNotAddTwice()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+        registry.Trust("alice");
+        registry.Trust("alice");
+
+        registry.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void PersistsAcrossInstances()
+    {
+        var reg1 = new TrustedPublisherRegistry(_registryPath);
+        reg1.Trust("alice");
+        reg1.Trust("bob");
+
+        var reg2 = new TrustedPublisherRegistry(_registryPath);
+
+        reg2.IsTrusted("alice").Should().BeTrue();
+        reg2.IsTrusted("bob").Should().BeTrue();
+        reg2.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void IsTrusted_NullOrEmpty_ReturnsFalse()
+    {
+        var registry = new TrustedPublisherRegistry(_registryPath);
+
+        registry.IsTrusted("").Should().BeFalse();
+        registry.IsTrusted(null!).Should().BeFalse();
+    }
+}

--- a/tests/JD.AI.Tests/Workflows/Security/WorkflowIntegrityValidatorTests.cs
+++ b/tests/JD.AI.Tests/Workflows/Security/WorkflowIntegrityValidatorTests.cs
@@ -1,0 +1,168 @@
+using System.Text;
+using FluentAssertions;
+using JD.AI.Workflows;
+using JD.AI.Workflows.Security;
+
+namespace JD.AI.Tests.Workflows.Security;
+
+public sealed class WorkflowIntegrityValidatorTests : IDisposable
+{
+    private static readonly byte[] TestKey = Encoding.UTF8.GetBytes("test-integrity-key-exactly-32b!");
+    private readonly string _tempDir;
+
+    public WorkflowIntegrityValidatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-wiv-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    private static AgentWorkflowDefinition ValidWorkflow() => new()
+    {
+        Name = "test-workflow",
+        Version = "1.0.0",
+        Description = "Test",
+        Steps = [AgentStepDefinition.RunSkill("step1")],
+    };
+
+    [Fact]
+    public void Validate_ValidWorkflow_ReturnsValid()
+    {
+        var validator = new WorkflowIntegrityValidator();
+        var result = validator.Validate(ValidWorkflow());
+
+        result.IsValid.Should().BeTrue();
+        result.Issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_EmptyName_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator();
+        var workflow = ValidWorkflow();
+        workflow.Name = "";
+
+        var result = validator.Validate(workflow);
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("name"));
+    }
+
+    [Fact]
+    public void Validate_NoSteps_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator();
+        var workflow = new AgentWorkflowDefinition
+        {
+            Name = "empty", Version = "1.0.0",
+        };
+
+        var result = validator.Validate(workflow);
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("step"));
+    }
+
+    [Fact]
+    public void Validate_WithValidSignature_ReturnsValid()
+    {
+        var validator = new WorkflowIntegrityValidator(signingKey: TestKey);
+        var workflow = ValidWorkflow();
+        var sig = WorkflowSignature.Sign(workflow, TestKey);
+
+        var result = validator.Validate(workflow, signature: sig);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_MissingSignature_WhenRequired_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator(signingKey: TestKey);
+        var workflow = ValidWorkflow();
+
+        var result = validator.Validate(workflow);
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("unsigned"));
+    }
+
+    [Fact]
+    public void Validate_InvalidSignature_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator(signingKey: TestKey);
+        var workflow = ValidWorkflow();
+
+        var result = validator.Validate(workflow, signature: "deadbeef".PadRight(64, '0'));
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("invalid"));
+    }
+
+    [Fact]
+    public void Validate_TrustedPublisher_ReturnsValid()
+    {
+        var registryPath = Path.Combine(_tempDir, "trust.json");
+        var registry = new TrustedPublisherRegistry(registryPath);
+        registry.Trust("alice");
+
+        var validator = new WorkflowIntegrityValidator(trustRegistry: registry);
+        var workflow = ValidWorkflow();
+
+        var result = validator.Validate(workflow, author: "alice");
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_UntrustedPublisher_ReportsIssue()
+    {
+        var registryPath = Path.Combine(_tempDir, "trust.json");
+        var registry = new TrustedPublisherRegistry(registryPath);
+
+        var validator = new WorkflowIntegrityValidator(trustRegistry: registry);
+        var workflow = ValidWorkflow();
+
+        var result = validator.Validate(workflow, author: "evil-user");
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("trusted"));
+    }
+
+    [Fact]
+    public void Validate_ToolStepWithoutTarget_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator();
+        var workflow = new AgentWorkflowDefinition
+        {
+            Name = "bad-tool", Version = "1.0.0",
+            Steps = [new AgentStepDefinition { Name = "step", Kind = AgentStepKind.Tool }],
+        };
+
+        var result = validator.Validate(workflow);
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("target"));
+    }
+
+    [Fact]
+    public void Validate_LoopWithoutCondition_ReportsIssue()
+    {
+        var validator = new WorkflowIntegrityValidator();
+        var workflow = new AgentWorkflowDefinition
+        {
+            Name = "bad-loop", Version = "1.0.0",
+            Steps = [new AgentStepDefinition { Name = "loop", Kind = AgentStepKind.Loop }],
+        };
+
+        var result = validator.Validate(workflow);
+
+        result.IsValid.Should().BeFalse();
+        result.Issues.Should().Contain(i => i.Contains("condition"));
+    }
+}

--- a/tests/JD.AI.Tests/Workflows/Security/WorkflowSignatureTests.cs
+++ b/tests/JD.AI.Tests/Workflows/Security/WorkflowSignatureTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using FluentAssertions;
+using JD.AI.Workflows;
+using JD.AI.Workflows.Security;
+
+namespace JD.AI.Tests.Workflows.Security;
+
+public sealed class WorkflowSignatureTests
+{
+    private static readonly byte[] TestKey = Encoding.UTF8.GetBytes("test-workflow-signing-key-32b!!");
+
+    private static AgentWorkflowDefinition CreateSampleWorkflow() => new()
+    {
+        Name = "build-pipeline",
+        Version = "1.0.0",
+        Description = "Build and test pipeline",
+        Steps =
+        [
+            AgentStepDefinition.RunSkill("run-tests"),
+            AgentStepDefinition.InvokeTool("build", "dotnet-build"),
+        ],
+    };
+
+    [Fact]
+    public void Sign_ProducesHexString()
+    {
+        var workflow = CreateSampleWorkflow();
+
+        var signature = WorkflowSignature.Sign(workflow, TestKey);
+
+        signature.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Verify_ValidSignature_ReturnsTrue()
+    {
+        var workflow = CreateSampleWorkflow();
+        var signature = WorkflowSignature.Sign(workflow, TestKey);
+
+        WorkflowSignature.Verify(workflow, TestKey, signature).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Verify_WrongKey_ReturnsFalse()
+    {
+        var workflow = CreateSampleWorkflow();
+        var signature = WorkflowSignature.Sign(workflow, TestKey);
+        var wrongKey = Encoding.UTF8.GetBytes("wrong-key-definitely-not-right!");
+
+        WorkflowSignature.Verify(workflow, wrongKey, signature).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Verify_TamperedWorkflow_ReturnsFalse()
+    {
+        var workflow = CreateSampleWorkflow();
+        var signature = WorkflowSignature.Sign(workflow, TestKey);
+
+        workflow.Name = "evil-pipeline";
+
+        WorkflowSignature.Verify(workflow, TestKey, signature).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Verify_ModifiedSteps_ReturnsFalse()
+    {
+        var workflow = CreateSampleWorkflow();
+        var signature = WorkflowSignature.Sign(workflow, TestKey);
+
+        workflow.Steps.Add(AgentStepDefinition.InvokeTool("backdoor"));
+
+        WorkflowSignature.Verify(workflow, TestKey, signature).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Sign_IgnoresTimestampChanges()
+    {
+        var workflow = CreateSampleWorkflow();
+        var sig1 = WorkflowSignature.Sign(workflow, TestKey);
+
+        workflow.CreatedAt = DateTime.UtcNow.AddDays(-1);
+        workflow.UpdatedAt = DateTime.UtcNow.AddDays(-1);
+        var sig2 = WorkflowSignature.Sign(workflow, TestKey);
+
+        sig1.Should().Be(sig2);
+    }
+
+    [Fact]
+    public void Sign_DeterministicForSameContent()
+    {
+        var w1 = CreateSampleWorkflow();
+        var w2 = CreateSampleWorkflow();
+
+        WorkflowSignature.Sign(w1, TestKey)
+            .Should().Be(WorkflowSignature.Sign(w2, TestKey));
+    }
+
+    [Fact]
+    public void Sign_NullDefinition_Throws()
+    {
+        var act = () => WorkflowSignature.Sign(null!, TestKey);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary
- **WorkflowSignature** — HMAC-SHA256 signing/verification of workflow definitions using canonical JSON (excludes volatile timestamps)
- **TrustedPublisherRegistry** — persistent JSON-backed registry of trusted workflow publishers with revocation support and audit trail
- **WorkflowIntegrityValidator** — pre-execution gate that validates schema (name, version, steps, targets, conditions), verifies signatures, and checks publisher trust

## Test plan
- [x] 8 tests for `WorkflowSignature` (sign, verify, tamper detection, timestamp stability, determinism, null guards)
- [x] 8 tests for `TrustedPublisherRegistry` (trust, revoke, persistence, case-insensitive, duplicates)
- [x] 10 tests for `WorkflowIntegrityValidator` (schema checks, signature verification, publisher trust, step validation)
- [x] All 1824 unit tests pass

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)