### PR TITLE
feat(multi-tenancy): tenant context, data filtering, and per-tenant quotas

### DIFF
--- a/src/JD.AI.Core/MultiTenancy/HeaderTenantResolver.cs
+++ b/src/JD.AI.Core/MultiTenancy/HeaderTenantResolver.cs
@@ -1,0 +1,44 @@
+namespace JD.AI.Core.MultiTenancy;
+
+/// <summary>
+/// Resolves tenant from the <c>X-Tenant-Id</c> request header.
+/// Falls back to a default tenant when no header is present.
+/// </summary>
+public sealed class HeaderTenantResolver : ITenantResolver
+{
+    /// <summary>Standard header name for tenant identification.</summary>
+    public const string TenantHeader = "X-Tenant-Id";
+
+    private readonly string? _defaultTenantId;
+
+    /// <param name="defaultTenantId">
+    /// Optional default tenant for requests without a tenant header.
+    /// When null, unresolved requests have no tenant context.
+    /// </param>
+    public HeaderTenantResolver(string? defaultTenantId = null)
+    {
+        _defaultTenantId = defaultTenantId;
+    }
+
+    public Task<TenantInfo?> ResolveAsync(TenantResolutionContext context, CancellationToken ct = default)
+    {
+        if (context.Headers.TryGetValue(TenantHeader, out var tenantId)
+            && !string.IsNullOrWhiteSpace(tenantId))
+        {
+            return Task.FromResult<TenantInfo?>(new TenantInfo
+            {
+                TenantId = tenantId.Trim(),
+            });
+        }
+
+        if (_defaultTenantId is not null)
+        {
+            return Task.FromResult<TenantInfo?>(new TenantInfo
+            {
+                TenantId = _defaultTenantId,
+            });
+        }
+
+        return Task.FromResult<TenantInfo?>(null);
+    }
+}

--- a/src/JD.AI.Core/MultiTenancy/ITenantResolver.cs
+++ b/src/JD.AI.Core/MultiTenancy/ITenantResolver.cs
@@ -1,0 +1,40 @@
+namespace JD.AI.Core.MultiTenancy;
+
+/// <summary>
+/// Resolves the current tenant from request context (header, token claim, API key, etc.).
+/// Implementations are used by middleware to populate <see cref="TenantContext"/>.
+/// </summary>
+public interface ITenantResolver
+{
+    /// <summary>
+    /// Attempts to resolve a tenant from the given request headers/claims.
+    /// Returns <c>null</c> if no tenant can be determined.
+    /// </summary>
+    Task<TenantInfo?> ResolveAsync(TenantResolutionContext context, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Resolved tenant information.
+/// </summary>
+public sealed class TenantInfo
+{
+    public required string TenantId { get; init; }
+    public string? TenantName { get; init; }
+}
+
+/// <summary>
+/// Input context for tenant resolution, abstracted from HTTP specifics
+/// so the resolver can be used in non-HTTP contexts (CLI, daemon).
+/// </summary>
+public sealed class TenantResolutionContext
+{
+    /// <summary>Request headers (case-insensitive key lookup).</summary>
+    public IDictionary<string, string> Headers { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Authenticated user identity, if available.</summary>
+    public string? UserId { get; init; }
+
+    /// <summary>API key used for authentication, if available.</summary>
+    public string? ApiKey { get; init; }
+}

--- a/src/JD.AI.Core/MultiTenancy/TenantContext.cs
+++ b/src/JD.AI.Core/MultiTenancy/TenantContext.cs
@@ -1,0 +1,17 @@
+namespace JD.AI.Core.MultiTenancy;
+
+/// <summary>
+/// Holds the current tenant identity for the request scope.
+/// Flows through DI as a scoped service.
+/// </summary>
+public sealed class TenantContext
+{
+    /// <summary>Unique tenant identifier.</summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>Human-readable tenant/organization name.</summary>
+    public string? TenantName { get; set; }
+
+    /// <summary>Whether a valid tenant has been resolved for this request.</summary>
+    public bool IsResolved => !string.IsNullOrWhiteSpace(TenantId);
+}

--- a/src/JD.AI.Core/MultiTenancy/TenantDataFilter.cs
+++ b/src/JD.AI.Core/MultiTenancy/TenantDataFilter.cs
@@ -1,0 +1,55 @@
+namespace JD.AI.Core.MultiTenancy;
+
+/// <summary>
+/// Provides tenant-scoped data filtering. Services use this to ensure
+/// queries only return data belonging to the current tenant.
+/// </summary>
+public sealed class TenantDataFilter
+{
+    private readonly TenantContext _context;
+
+    public TenantDataFilter(TenantContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>Current tenant ID, or null if no tenant is resolved.</summary>
+    public string? CurrentTenantId => _context.TenantId;
+
+    /// <summary>Whether multi-tenant filtering is active.</summary>
+    public bool IsActive => _context.IsResolved;
+
+    /// <summary>
+    /// Filters a collection to only include items belonging to the current tenant.
+    /// Items with a null tenant ID are included (shared/global items).
+    /// </summary>
+    public IEnumerable<T> Filter<T>(IEnumerable<T> items, Func<T, string?> tenantIdSelector)
+    {
+        if (!IsActive)
+            return items; // No tenant context — return all
+
+        return items.Where(item =>
+        {
+            var itemTenant = tenantIdSelector(item);
+            return itemTenant is null // Shared/global item
+                   || string.Equals(itemTenant, _context.TenantId, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    /// <summary>
+    /// Checks if an item belongs to the current tenant (or is shared).
+    /// </summary>
+    public bool BelongsToCurrentTenant(string? itemTenantId)
+    {
+        if (!IsActive) return true; // No filtering active
+        if (itemTenantId is null) return true; // Shared item
+
+        return string.Equals(itemTenantId, _context.TenantId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the current tenant ID to stamp on new data entities.
+    /// Returns null if no tenant context is active.
+    /// </summary>
+    public string? GetTenantStamp() => _context.TenantId;
+}

--- a/src/JD.AI.Core/MultiTenancy/TenantQuota.cs
+++ b/src/JD.AI.Core/MultiTenancy/TenantQuota.cs
@@ -1,0 +1,101 @@
+using System.Collections.Concurrent;
+
+namespace JD.AI.Core.MultiTenancy;
+
+/// <summary>
+/// Per-tenant resource quotas and rate limits. Tracks usage
+/// per tenant within a configurable time window.
+/// </summary>
+public sealed class TenantQuota
+{
+    private readonly ConcurrentDictionary<string, TenantUsage> _usage = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TenantQuotaConfig _config;
+
+    public TenantQuota(TenantQuotaConfig? config = null)
+    {
+        _config = config ?? new TenantQuotaConfig();
+    }
+
+    /// <summary>
+    /// Checks if the tenant has exceeded their request quota.
+    /// </summary>
+    public bool IsOverQuota(string tenantId)
+    {
+        if (!_usage.TryGetValue(tenantId, out var usage))
+            return false;
+
+        usage.PruneExpired(_config.WindowDuration);
+
+        return _config.MaxRequestsPerWindow > 0
+               && usage.RequestCount >= _config.MaxRequestsPerWindow;
+    }
+
+    /// <summary>
+    /// Records a request for the given tenant.
+    /// </summary>
+    public void RecordRequest(string tenantId)
+    {
+        var usage = _usage.GetOrAdd(tenantId, _ => new TenantUsage());
+        usage.AddRequest();
+    }
+
+    /// <summary>
+    /// Gets current usage stats for a tenant.
+    /// </summary>
+    public TenantUsageStats GetUsage(string tenantId)
+    {
+        if (!_usage.TryGetValue(tenantId, out var usage))
+            return new TenantUsageStats(0, _config.MaxRequestsPerWindow, _config.WindowDuration);
+
+        usage.PruneExpired(_config.WindowDuration);
+        return new TenantUsageStats(
+            usage.RequestCount,
+            _config.MaxRequestsPerWindow,
+            _config.WindowDuration);
+    }
+}
+
+/// <summary>Configuration for per-tenant quotas.</summary>
+public sealed class TenantQuotaConfig
+{
+    /// <summary>Maximum requests per tenant per window. 0 = unlimited.</summary>
+    public int MaxRequestsPerWindow { get; init; } = 1000;
+
+    /// <summary>Rolling window duration for quota tracking.</summary>
+    public TimeSpan WindowDuration { get; init; } = TimeSpan.FromHours(1);
+}
+
+/// <summary>Current usage stats for a tenant.</summary>
+public sealed record TenantUsageStats(
+    int CurrentRequests,
+    int MaxRequests,
+    TimeSpan WindowDuration);
+
+/// <summary>Thread-safe per-tenant usage tracker.</summary>
+internal sealed class TenantUsage
+{
+    private readonly Lock _lock = new();
+    private readonly List<DateTimeOffset> _timestamps = [];
+
+    public int RequestCount
+    {
+        get { lock (_lock) return _timestamps.Count; }
+    }
+
+    public void AddRequest()
+    {
+        lock (_lock)
+        {
+            _timestamps.Add(DateTimeOffset.UtcNow);
+        }
+    }
+
+    public void PruneExpired(TimeSpan window)
+    {
+        var cutoff = DateTimeOffset.UtcNow - window;
+        lock (_lock)
+        {
+            _timestamps.RemoveAll(t => t < cutoff);
+        }
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/HeaderTenantResolverTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/HeaderTenantResolverTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using JD.AI.Core.MultiTenancy;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class HeaderTenantResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_WithTenantHeader_ReturnsTenantInfo()
+    {
+        var resolver = new HeaderTenantResolver();
+        var context = new TenantResolutionContext
+        {
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [HeaderTenantResolver.TenantHeader] = "tenant-abc",
+            },
+        };
+
+        var result = await resolver.ResolveAsync(context);
+
+        result.Should().NotBeNull();
+        result!.TenantId.Should().Be("tenant-abc");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoHeader_ReturnsNull()
+    {
+        var resolver = new HeaderTenantResolver();
+        var context = new TenantResolutionContext();
+
+        var result = await resolver.ResolveAsync(context);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoHeader_WithDefault_ReturnsDefault()
+    {
+        var resolver = new HeaderTenantResolver(defaultTenantId: "default-tenant");
+        var context = new TenantResolutionContext();
+
+        var result = await resolver.ResolveAsync(context);
+
+        result.Should().NotBeNull();
+        result!.TenantId.Should().Be("default-tenant");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_EmptyHeader_ReturnsNull()
+    {
+        var resolver = new HeaderTenantResolver();
+        var context = new TenantResolutionContext
+        {
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [HeaderTenantResolver.TenantHeader] = "  ",
+            },
+        };
+
+        var result = await resolver.ResolveAsync(context);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_TrimsWhitespace()
+    {
+        var resolver = new HeaderTenantResolver();
+        var context = new TenantResolutionContext
+        {
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [HeaderTenantResolver.TenantHeader] = "  tenant-123  ",
+            },
+        };
+
+        var result = await resolver.ResolveAsync(context);
+
+        result!.TenantId.Should().Be("tenant-123");
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/TenantDataFilterTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantDataFilterTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using JD.AI.Core.MultiTenancy;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class TenantDataFilterTests
+{
+    private sealed record Item(string Name, string? TenantId);
+
+    [Fact]
+    public void Filter_WithActiveTenant_ReturnsOnlyTenantItems()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var filter = new TenantDataFilter(ctx);
+
+        var items = new[]
+        {
+            new Item("a1", "tenant-a"),
+            new Item("b1", "tenant-b"),
+            new Item("shared", null),
+        };
+
+        var result = filter.Filter(items, i => i.TenantId).ToList();
+
+        result.Should().HaveCount(2);
+        result.Select(i => i.Name).Should().Contain("a1").And.Contain("shared");
+    }
+
+    [Fact]
+    public void Filter_NoTenantContext_ReturnsAll()
+    {
+        var ctx = new TenantContext();
+        var filter = new TenantDataFilter(ctx);
+
+        var items = new[]
+        {
+            new Item("a1", "tenant-a"),
+            new Item("b1", "tenant-b"),
+        };
+
+        var result = filter.Filter(items, i => i.TenantId).ToList();
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BelongsToCurrentTenant_MatchingTenant_ReturnsTrue()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var filter = new TenantDataFilter(ctx);
+
+        filter.BelongsToCurrentTenant("tenant-a").Should().BeTrue();
+    }
+
+    [Fact]
+    public void BelongsToCurrentTenant_DifferentTenant_ReturnsFalse()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var filter = new TenantDataFilter(ctx);
+
+        filter.BelongsToCurrentTenant("tenant-b").Should().BeFalse();
+    }
+
+    [Fact]
+    public void BelongsToCurrentTenant_NullItemTenant_ReturnsTrue()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var filter = new TenantDataFilter(ctx);
+
+        filter.BelongsToCurrentTenant(null).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BelongsToCurrentTenant_NoContext_AlwaysTrue()
+    {
+        var ctx = new TenantContext();
+        var filter = new TenantDataFilter(ctx);
+
+        filter.BelongsToCurrentTenant("any-tenant").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetTenantStamp_WithTenant_ReturnsTenantId()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var filter = new TenantDataFilter(ctx);
+
+        filter.GetTenantStamp().Should().Be("tenant-a");
+    }
+
+    [Fact]
+    public void GetTenantStamp_NoTenant_ReturnsNull()
+    {
+        var ctx = new TenantContext();
+        var filter = new TenantDataFilter(ctx);
+
+        filter.GetTenantStamp().Should().BeNull();
+    }
+
+    [Fact]
+    public void Filter_CaseInsensitive()
+    {
+        var ctx = new TenantContext { TenantId = "Tenant-A" };
+        var filter = new TenantDataFilter(ctx);
+
+        var items = new[] { new Item("match", "tenant-a") };
+        var result = filter.Filter(items, i => i.TenantId).ToList();
+
+        result.Should().HaveCount(1);
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/TenantQuotaTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantQuotaTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using JD.AI.Core.MultiTenancy;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class TenantQuotaTests
+{
+    [Fact]
+    public void IsOverQuota_NoRequests_ReturnsFalse()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 10 });
+
+        quota.IsOverQuota("tenant-a").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOverQuota_UnderLimit_ReturnsFalse()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 5 });
+
+        for (var i = 0; i < 3; i++)
+            quota.RecordRequest("tenant-a");
+
+        quota.IsOverQuota("tenant-a").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOverQuota_AtLimit_ReturnsTrue()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 3 });
+
+        for (var i = 0; i < 3; i++)
+            quota.RecordRequest("tenant-a");
+
+        quota.IsOverQuota("tenant-a").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsOverQuota_Unlimited_NeverTrue()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 0 });
+
+        for (var i = 0; i < 100; i++)
+            quota.RecordRequest("tenant-a");
+
+        quota.IsOverQuota("tenant-a").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsOverQuota_IsolatedPerTenant()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 2 });
+
+        quota.RecordRequest("tenant-a");
+        quota.RecordRequest("tenant-a");
+        quota.RecordRequest("tenant-b");
+
+        quota.IsOverQuota("tenant-a").Should().BeTrue();
+        quota.IsOverQuota("tenant-b").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetUsage_ReturnsCorrectStats()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig
+        {
+            MaxRequestsPerWindow = 100,
+            WindowDuration = TimeSpan.FromMinutes(5),
+        });
+
+        quota.RecordRequest("tenant-a");
+        quota.RecordRequest("tenant-a");
+
+        var usage = quota.GetUsage("tenant-a");
+
+        usage.CurrentRequests.Should().Be(2);
+        usage.MaxRequests.Should().Be(100);
+        usage.WindowDuration.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public void GetUsage_UnknownTenant_ReturnsZero()
+    {
+        var quota = new TenantQuota();
+        var usage = quota.GetUsage("unknown");
+
+        usage.CurrentRequests.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary
- **TenantContext** — scoped service holding current tenant identity for request-scoped DI
- **ITenantResolver** + **HeaderTenantResolver** — pluggable tenant resolution from `X-Tenant-Id` header with optional default tenant fallback
- **TenantDataFilter** — row-level data isolation with support for shared/global items (null tenant), case-insensitive matching, and tenant stamping for new entities
- **TenantQuota** — per-tenant rate limiting with configurable sliding window and request counting; isolated quota tracking per tenant

## Test plan
- [x] 5 tests for `HeaderTenantResolver` (header resolution, empty, default, whitespace)
- [x] 9 tests for `TenantDataFilter` (filtering, belongs-to, stamps, no-context passthrough, case-insensitive)
- [x] 7 tests for `TenantQuota` (under/over limit, unlimited, per-tenant isolation, usage stats)
- [x] All 1819 unit tests pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)