### PR TITLE
feat(security): JWT auth, API key rotation, and composite auth provider

### DIFF
--- a/src/JD.AI.Core/Security/ApiKeyRotation.cs
+++ b/src/JD.AI.Core/Security/ApiKeyRotation.cs
@@ -1,0 +1,144 @@
+using System.Security.Cryptography;
+
+namespace JD.AI.Core.Security;
+
+/// <summary>
+/// Manages API key lifecycle: generation, rotation, and expiry tracking.
+/// </summary>
+public sealed class ApiKeyRotation
+{
+    private readonly Dictionary<string, ApiKeyRecord> _keys = new(StringComparer.Ordinal);
+    private readonly Lock _lock = new();
+
+    /// <summary>Number of active (non-expired, non-revoked) keys.</summary>
+    public int ActiveKeyCount
+    {
+        get
+        {
+            lock (_lock)
+                return _keys.Values.Count(k => !k.IsRevoked && !k.IsExpired);
+        }
+    }
+
+    /// <summary>
+    /// Generates a new API key with optional expiry.
+    /// </summary>
+    /// <returns>The generated API key string.</returns>
+    public string GenerateKey(string name, GatewayRole role = GatewayRole.User, TimeSpan? expiry = null)
+    {
+        var key = GenerateSecureKey();
+        var record = new ApiKeyRecord
+        {
+            Key = key,
+            Name = name,
+            Role = role,
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = expiry.HasValue ? DateTimeOffset.UtcNow + expiry.Value : null,
+        };
+
+        lock (_lock)
+        {
+            _keys[key] = record;
+        }
+
+        return key;
+    }
+
+    /// <summary>
+    /// Rotates a key: generates a new key and revokes the old one.
+    /// Returns the new key, or null if the old key was not found.
+    /// </summary>
+    public string? RotateKey(string oldKey, TimeSpan? newExpiry = null)
+    {
+        lock (_lock)
+        {
+            if (!_keys.TryGetValue(oldKey, out var oldRecord))
+                return null;
+
+            // Revoke old key
+            oldRecord.IsRevoked = true;
+            oldRecord.RevokedAt = DateTimeOffset.UtcNow;
+
+            // Generate replacement
+            var newKey = GenerateSecureKey();
+            _keys[newKey] = new ApiKeyRecord
+            {
+                Key = newKey,
+                Name = oldRecord.Name,
+                Role = oldRecord.Role,
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = newExpiry.HasValue ? DateTimeOffset.UtcNow + newExpiry.Value : null,
+                PreviousKey = oldKey,
+            };
+
+            return newKey;
+        }
+    }
+
+    /// <summary>
+    /// Validates and retrieves a key record. Returns null if key is invalid,
+    /// expired, or revoked.
+    /// </summary>
+    public ApiKeyRecord? Validate(string key)
+    {
+        lock (_lock)
+        {
+            if (!_keys.TryGetValue(key, out var record))
+                return null;
+
+            if (record.IsRevoked || record.IsExpired)
+                return null;
+
+            return record;
+        }
+    }
+
+    /// <summary>
+    /// Explicitly revokes a key.
+    /// </summary>
+    public bool RevokeKey(string key)
+    {
+        lock (_lock)
+        {
+            if (!_keys.TryGetValue(key, out var record))
+                return false;
+
+            record.IsRevoked = true;
+            record.RevokedAt = DateTimeOffset.UtcNow;
+            return true;
+        }
+    }
+
+    /// <summary>Gets all key records (for admin/audit purposes).</summary>
+    public IReadOnlyList<ApiKeyRecord> GetAllKeys()
+    {
+        lock (_lock)
+        {
+            return _keys.Values.ToList().AsReadOnly();
+        }
+    }
+
+    private static string GenerateSecureKey()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return $"jdai_{Convert.ToHexString(bytes).ToLowerInvariant()}";
+    }
+}
+
+/// <summary>
+/// Metadata for an API key.
+/// </summary>
+public sealed class ApiKeyRecord
+{
+    public required string Key { get; init; }
+    public required string Name { get; init; }
+    public GatewayRole Role { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? ExpiresAt { get; init; }
+    public bool IsRevoked { get; set; }
+    public DateTimeOffset? RevokedAt { get; set; }
+    public string? PreviousKey { get; init; }
+
+    /// <summary>Whether this key has passed its expiry date.</summary>
+    public bool IsExpired => ExpiresAt.HasValue && DateTimeOffset.UtcNow > ExpiresAt.Value;
+}

--- a/src/JD.AI.Core/Security/CompositeAuthProvider.cs
+++ b/src/JD.AI.Core/Security/CompositeAuthProvider.cs
@@ -1,0 +1,36 @@
+namespace JD.AI.Core.Security;
+
+/// <summary>
+/// Chains multiple <see cref="IAuthProvider"/> implementations, trying each
+/// in order until one succeeds. Enables API key + JWT + future auth methods
+/// to coexist.
+/// </summary>
+public sealed class CompositeAuthProvider : IAuthProvider
+{
+    private readonly IReadOnlyList<IAuthProvider> _providers;
+
+    public CompositeAuthProvider(params IAuthProvider[] providers)
+    {
+        _providers = providers ?? throw new ArgumentNullException(nameof(providers));
+    }
+
+    public CompositeAuthProvider(IEnumerable<IAuthProvider> providers)
+    {
+        _providers = providers?.ToList() ?? throw new ArgumentNullException(nameof(providers));
+    }
+
+    /// <summary>Number of registered auth providers.</summary>
+    public int ProviderCount => _providers.Count;
+
+    public async Task<GatewayIdentity?> AuthenticateAsync(string credential, CancellationToken ct = default)
+    {
+        foreach (var provider in _providers)
+        {
+            var identity = await provider.AuthenticateAsync(credential, ct).ConfigureAwait(false);
+            if (identity is not null)
+                return identity;
+        }
+
+        return null;
+    }
+}

--- a/src/JD.AI.Core/Security/JwtAuthProvider.cs
+++ b/src/JD.AI.Core/Security/JwtAuthProvider.cs
@@ -1,0 +1,159 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using JD.AI.Core.Infrastructure;
+
+namespace JD.AI.Core.Security;
+
+/// <summary>
+/// JWT bearer token authentication provider. Validates HMAC-SHA256 signed
+/// JWT tokens and extracts identity claims.
+/// </summary>
+public sealed class JwtAuthProvider : IAuthProvider
+{
+    private static readonly JsonSerializerOptions JsonOptions = JsonDefaults.Options;
+
+    private readonly byte[] _signingKey;
+    private readonly string _issuer;
+    private readonly TimeSpan _clockSkew;
+
+    /// <param name="signingKey">HMAC-SHA256 signing key (minimum 32 bytes).</param>
+    /// <param name="issuer">Expected issuer claim. Tokens with different issuers are rejected.</param>
+    /// <param name="clockSkew">Tolerance for clock differences. Default 5 minutes.</param>
+    public JwtAuthProvider(byte[] signingKey, string issuer = "jdai", TimeSpan? clockSkew = null)
+    {
+        ArgumentNullException.ThrowIfNull(signingKey);
+        if (signingKey.Length < 32)
+            throw new ArgumentException("Signing key must be at least 32 bytes", nameof(signingKey));
+
+        _signingKey = signingKey;
+        _issuer = issuer;
+        _clockSkew = clockSkew ?? TimeSpan.FromMinutes(5);
+    }
+
+    /// <summary>
+    /// Issues a JWT token for the given identity.
+    /// </summary>
+    public string IssueToken(string subject, string displayName, GatewayRole role, TimeSpan? expiry = null)
+    {
+        var exp = DateTimeOffset.UtcNow + (expiry ?? TimeSpan.FromHours(1));
+
+        var header = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(
+            new { alg = "HS256", typ = "JWT" }, JsonOptions));
+
+        var payload = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(new JwtPayload
+        {
+            Sub = subject,
+            Name = displayName,
+            Role = role.ToString(),
+            Iss = _issuer,
+            Iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Exp = exp.ToUnixTimeSeconds(),
+        }, JsonOptions));
+
+        var signature = ComputeSignature($"{header}.{payload}");
+        return $"{header}.{payload}.{signature}";
+    }
+
+    public Task<GatewayIdentity?> AuthenticateAsync(string credential, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(credential))
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Strip "Bearer " prefix if present
+        var token = credential.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+            ? credential["Bearer ".Length..]
+            : credential;
+
+        var parts = token.Split('.');
+        if (parts.Length != 3)
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Verify signature
+        var expectedSig = ComputeSignature($"{parts[0]}.{parts[1]}");
+        if (!string.Equals(parts[2], expectedSig, StringComparison.Ordinal))
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Decode payload
+        JwtPayload? payload;
+        try
+        {
+            var json = Base64UrlDecode(parts[1]);
+            payload = JsonSerializer.Deserialize<JwtPayload>(json, JsonOptions);
+        }
+        catch
+        {
+            return Task.FromResult<GatewayIdentity?>(null);
+        }
+
+        if (payload is null)
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Validate issuer
+        if (!string.Equals(payload.Iss, _issuer, StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Validate expiry
+        var now = DateTimeOffset.UtcNow;
+        var expiry = DateTimeOffset.FromUnixTimeSeconds(payload.Exp);
+        if (now > expiry + _clockSkew)
+            return Task.FromResult<GatewayIdentity?>(null);
+
+        // Parse role
+        if (!Enum.TryParse<GatewayRole>(payload.Role, ignoreCase: true, out var role))
+            role = GatewayRole.User;
+
+        var identity = new GatewayIdentity(
+            payload.Sub ?? "unknown",
+            payload.Name ?? payload.Sub ?? "unknown",
+            role,
+            DateTimeOffset.FromUnixTimeSeconds(payload.Iat))
+        {
+            Claims = new Dictionary<string, string>
+            {
+                ["iss"] = payload.Iss ?? "",
+                ["sub"] = payload.Sub ?? "",
+                ["role"] = role.ToString(),
+            },
+        };
+
+        return Task.FromResult<GatewayIdentity?>(identity);
+    }
+
+    private string ComputeSignature(string input)
+    {
+        var hash = HMACSHA256.HashData(_signingKey, Encoding.UTF8.GetBytes(input));
+        return Base64UrlEncode(hash);
+    }
+
+    private static string Base64UrlEncode(byte[] data)
+    {
+        return Convert.ToBase64String(data)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var padded = input.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+
+        return Convert.FromBase64String(padded);
+    }
+}
+
+/// <summary>JWT payload claims.</summary>
+internal sealed class JwtPayload
+{
+    public string? Sub { get; set; }
+    public string? Name { get; set; }
+    public string? Role { get; set; }
+    public string? Iss { get; set; }
+    public long Iat { get; set; }
+    public long Exp { get; set; }
+}

--- a/tests/JD.AI.Tests/Security/ApiKeyRotationTests.cs
+++ b/tests/JD.AI.Tests/Security/ApiKeyRotationTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using JD.AI.Core.Security;
+
+namespace JD.AI.Tests.Security;
+
+public sealed class ApiKeyRotationTests
+{
+    [Fact]
+    public void GenerateKey_CreatesValidKey()
+    {
+        var rotation = new ApiKeyRotation();
+        var key = rotation.GenerateKey("test-app");
+
+        key.Should().StartWith("jdai_");
+        key.Length.Should().BeGreaterThan(10);
+    }
+
+    [Fact]
+    public void Validate_GeneratedKey_ReturnsRecord()
+    {
+        var rotation = new ApiKeyRotation();
+        var key = rotation.GenerateKey("test-app", GatewayRole.Admin);
+
+        var record = rotation.Validate(key);
+
+        record.Should().NotBeNull();
+        record!.Name.Should().Be("test-app");
+        record.Role.Should().Be(GatewayRole.Admin);
+    }
+
+    [Fact]
+    public void Validate_UnknownKey_ReturnsNull()
+    {
+        var rotation = new ApiKeyRotation();
+
+        rotation.Validate("unknown-key").Should().BeNull();
+    }
+
+    [Fact]
+    public void RotateKey_ReturnsNewKey_RevokesOld()
+    {
+        var rotation = new ApiKeyRotation();
+        var oldKey = rotation.GenerateKey("app");
+
+        var newKey = rotation.RotateKey(oldKey);
+
+        newKey.Should().NotBeNull();
+        newKey.Should().NotBe(oldKey);
+        rotation.Validate(oldKey).Should().BeNull("old key should be revoked");
+        rotation.Validate(newKey!).Should().NotBeNull("new key should be valid");
+    }
+
+    [Fact]
+    public void RotateKey_PreservesNameAndRole()
+    {
+        var rotation = new ApiKeyRotation();
+        var oldKey = rotation.GenerateKey("admin-app", GatewayRole.Admin);
+
+        var newKey = rotation.RotateKey(oldKey)!;
+        var record = rotation.Validate(newKey);
+
+        record!.Name.Should().Be("admin-app");
+        record.Role.Should().Be(GatewayRole.Admin);
+    }
+
+    [Fact]
+    public void RotateKey_UnknownKey_ReturnsNull()
+    {
+        var rotation = new ApiKeyRotation();
+
+        rotation.RotateKey("nonexistent").Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeKey_RevokesSuccessfully()
+    {
+        var rotation = new ApiKeyRotation();
+        var key = rotation.GenerateKey("app");
+
+        rotation.RevokeKey(key).Should().BeTrue();
+        rotation.Validate(key).Should().BeNull();
+    }
+
+    [Fact]
+    public void RevokeKey_UnknownKey_ReturnsFalse()
+    {
+        var rotation = new ApiKeyRotation();
+
+        rotation.RevokeKey("unknown").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_ExpiredKey_ReturnsNull()
+    {
+        var rotation = new ApiKeyRotation();
+        var key = rotation.GenerateKey("app", expiry: TimeSpan.FromMilliseconds(-1));
+
+        // Key was created with already-expired expiry
+        Thread.Sleep(10);
+        rotation.Validate(key).Should().BeNull();
+    }
+
+    [Fact]
+    public void ActiveKeyCount_TracksCorrectly()
+    {
+        var rotation = new ApiKeyRotation();
+        rotation.GenerateKey("a");
+        rotation.GenerateKey("b");
+        var keyC = rotation.GenerateKey("c");
+        rotation.RevokeKey(keyC);
+
+        rotation.ActiveKeyCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void GetAllKeys_ReturnsAllIncludingRevoked()
+    {
+        var rotation = new ApiKeyRotation();
+        var k1 = rotation.GenerateKey("a");
+        rotation.GenerateKey("b");
+        rotation.RevokeKey(k1);
+
+        rotation.GetAllKeys().Should().HaveCount(2);
+    }
+}

--- a/tests/JD.AI.Tests/Security/CompositeAuthProviderTests.cs
+++ b/tests/JD.AI.Tests/Security/CompositeAuthProviderTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using FluentAssertions;
+using JD.AI.Core.Security;
+
+namespace JD.AI.Tests.Security;
+
+public sealed class CompositeAuthProviderTests
+{
+    [Fact]
+    public async Task Authenticate_FirstProviderSucceeds_ReturnsImmediately()
+    {
+        var apiKeyProvider = new ApiKeyAuthProvider();
+        apiKeyProvider.RegisterKey("test-key", "Test", GatewayRole.User);
+
+        var composite = new CompositeAuthProvider(apiKeyProvider);
+
+        var identity = await composite.AuthenticateAsync("test-key");
+
+        identity.Should().NotBeNull();
+        identity!.DisplayName.Should().Be("Test");
+    }
+
+    [Fact]
+    public async Task Authenticate_FallsThrough_ToSecondProvider()
+    {
+        var apiKeyProvider = new ApiKeyAuthProvider();
+        var jwtKey = Encoding.UTF8.GetBytes("a-32-byte-jwt-signing-key-here!!");
+        var jwtProvider = new JwtAuthProvider(jwtKey);
+        var token = jwtProvider.IssueToken("user-1", "JWT User", GatewayRole.Admin);
+
+        var composite = new CompositeAuthProvider(apiKeyProvider, jwtProvider);
+
+        var identity = await composite.AuthenticateAsync(token);
+
+        identity.Should().NotBeNull();
+        identity!.DisplayName.Should().Be("JWT User");
+    }
+
+    [Fact]
+    public async Task Authenticate_NoProviderSucceeds_ReturnsNull()
+    {
+        var apiKeyProvider = new ApiKeyAuthProvider();
+        var composite = new CompositeAuthProvider(apiKeyProvider);
+
+        var identity = await composite.AuthenticateAsync("invalid-credential");
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProviderCount_ReturnsCorrectCount()
+    {
+        var composite = new CompositeAuthProvider(
+            new ApiKeyAuthProvider(),
+            new ApiKeyAuthProvider());
+
+        composite.ProviderCount.Should().Be(2);
+    }
+}

--- a/tests/JD.AI.Tests/Security/JwtAuthProviderTests.cs
+++ b/tests/JD.AI.Tests/Security/JwtAuthProviderTests.cs
@@ -1,0 +1,128 @@
+using System.Text;
+using FluentAssertions;
+using JD.AI.Core.Security;
+
+namespace JD.AI.Tests.Security;
+
+public sealed class JwtAuthProviderTests
+{
+    private static readonly byte[] TestKey = Encoding.UTF8.GetBytes("this-is-a-32-byte-signing-key!!!");
+
+    [Fact]
+    public async Task IssueAndAuthenticate_ValidToken_ReturnsIdentity()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+        var token = provider.IssueToken("user-123", "Alice", GatewayRole.Admin);
+
+        var identity = await provider.AuthenticateAsync(token);
+
+        identity.Should().NotBeNull();
+        identity!.Id.Should().Be("user-123");
+        identity.DisplayName.Should().Be("Alice");
+        identity.Role.Should().Be(GatewayRole.Admin);
+    }
+
+    [Fact]
+    public async Task Authenticate_WithBearerPrefix_Works()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+        var token = provider.IssueToken("user-1", "Bob", GatewayRole.User);
+
+        var identity = await provider.AuthenticateAsync($"Bearer {token}");
+
+        identity.Should().NotBeNull();
+        identity!.Id.Should().Be("user-1");
+    }
+
+    [Fact]
+    public async Task Authenticate_ExpiredToken_ReturnsNull()
+    {
+        var provider = new JwtAuthProvider(TestKey, clockSkew: TimeSpan.Zero);
+        var token = provider.IssueToken("user-1", "Alice", GatewayRole.User,
+            expiry: TimeSpan.FromMilliseconds(-1000)); // Already expired
+
+        var identity = await provider.AuthenticateAsync(token);
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Authenticate_WrongKey_ReturnsNull()
+    {
+        var provider1 = new JwtAuthProvider(TestKey);
+        var otherKey = Encoding.UTF8.GetBytes("different-32-byte-key-for-test!!");
+        var provider2 = new JwtAuthProvider(otherKey);
+
+        var token = provider1.IssueToken("user-1", "Alice", GatewayRole.User);
+        var identity = await provider2.AuthenticateAsync(token);
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Authenticate_WrongIssuer_ReturnsNull()
+    {
+        var issuer1 = new JwtAuthProvider(TestKey, issuer: "app-a");
+        var issuer2 = new JwtAuthProvider(TestKey, issuer: "app-b");
+
+        var token = issuer1.IssueToken("user-1", "Alice", GatewayRole.User);
+        var identity = await issuer2.AuthenticateAsync(token);
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Authenticate_MalformedToken_ReturnsNull()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+
+        var identity = await provider.AuthenticateAsync("not.a.valid.token");
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Authenticate_EmptyString_ReturnsNull()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+
+        var identity = await provider.AuthenticateAsync("");
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Authenticate_TamperedPayload_ReturnsNull()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+        var token = provider.IssueToken("user-1", "Alice", GatewayRole.User);
+
+        // Tamper with the payload (middle part)
+        var parts = token.Split('.');
+        var tampered = $"{parts[0]}.dGFtcGVyZWQ.{parts[2]}";
+
+        var identity = await provider.AuthenticateAsync(tampered);
+
+        identity.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShortKey_ThrowsArgumentException()
+    {
+        var act = () => new JwtAuthProvider("short"u8.ToArray());
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Authenticate_IncludesClaims()
+    {
+        var provider = new JwtAuthProvider(TestKey);
+        var token = provider.IssueToken("user-1", "Alice", GatewayRole.Admin);
+
+        var identity = await provider.AuthenticateAsync(token);
+
+        identity!.Claims.Should().ContainKey("sub").WhoseValue.Should().Be("user-1");
+        identity.Claims.Should().ContainKey("role").WhoseValue.Should().Be("Admin");
+    }
+}


### PR DESCRIPTION
## Summary
- **JwtAuthProvider** — HMAC-SHA256 JWT token issuance and validation with configurable issuer, expiry, and clock skew; supports `Bearer` prefix; extracts sub/name/role claims
- **ApiKeyRotation** — API key lifecycle management with secure key generation (`jdai_` prefix), rotation (revoke old + issue new), explicit revocation, and expiry tracking
- **CompositeAuthProvider** — chains multiple `IAuthProvider` implementations to support API key + JWT coexistence with ordered fallthrough

## Test plan
- [x] 10 tests for `JwtAuthProvider` (issue/validate, Bearer prefix, expiry, wrong key, wrong issuer, tamper detection, claims)
- [x] 11 tests for `ApiKeyRotation` (generate, validate, rotate, revoke, expiry, active count)
- [x] 4 tests for `CompositeAuthProvider` (first match, fallthrough, no match, count)
- [x] All 1823 unit tests pass

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)