### PR TITLE
feat(startup): persist model defaults and add onboard fast-path

### DIFF
--- a/docs/plans/2026-03-05-startup-fastpath-onboarding-plan.md
+++ b/docs/plans/2026-03-05-startup-fastpath-onboarding-plan.md
@@ -1,0 +1,8 @@
+# Startup Fast-Path + Onboarding TODO
+
+- [x] Persist selected provider/model defaults on startup selection.
+- [x] Persist provider/model defaults when switching with `/model` and `/provider`.
+- [x] Add startup fast-path that refreshes only the saved/default provider.
+- [x] Fall back to full provider/model discovery when defaults are missing or invalid.
+- [x] Add `jdai onboard` / `jdai wizard` interactive command to set defaults quickly.
+- [x] Keep full-refresh provider/model discovery available on explicit user commands.

--- a/docs/user-guide/provider-setup.md
+++ b/docs/user-guide/provider-setup.md
@@ -339,6 +339,16 @@ Use slash commands to manage providers at any time during a session:
 /model gpt-4.1           # Switch to a specific model
 ```
 
+For faster startup, save a project default provider/model with the onboarding wizard:
+
+```bash
+jdai onboard
+# alias:
+jdai wizard
+```
+
+This stores your selected provider/model as project defaults so startup can refresh only that provider.
+
 When you switch models mid-session, JD.AI prompts you to choose a transition mode:
 
 | Mode | Description |

--- a/src/JD.AI.Core/Providers/ProviderRegistry.cs
+++ b/src/JD.AI.Core/Providers/ProviderRegistry.cs
@@ -21,9 +21,17 @@ public sealed class ProviderRegistry : IProviderRegistry
         _metadataProvider = metadataProvider;
     }
 
+    public Task<IReadOnlyList<ProviderInfo>> DetectProvidersAsync(
+        CancellationToken ct = default)
+        => DetectProvidersAsync(forceRefresh: false, ct);
+
     public async Task<IReadOnlyList<ProviderInfo>> DetectProvidersAsync(
+        bool forceRefresh,
         CancellationToken ct = default)
     {
+        if (!forceRefresh && _cached is not null)
+            return _cached;
+
         // Kick off metadata loading concurrently with detector probes
         var metadataTask = _metadataProvider?.LoadAsync(ct: ct);
 
@@ -65,14 +73,76 @@ public sealed class ProviderRegistry : IProviderRegistry
         return results;
     }
 
+    public Task<IReadOnlyList<ProviderModelInfo>> GetModelsAsync(
+        CancellationToken ct = default)
+        => GetModelsAsync(forceRefresh: false, ct);
+
     public async Task<IReadOnlyList<ProviderModelInfo>> GetModelsAsync(
+        bool forceRefresh,
         CancellationToken ct = default)
     {
-        var providers = _cached ?? await DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = forceRefresh
+            ? await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false)
+            : _cached ?? await DetectProvidersAsync(ct).ConfigureAwait(false);
         return providers
             .Where(p => p.IsAvailable)
             .SelectMany(p => p.Models)
             .ToList();
+    }
+
+    public async Task<ProviderInfo?> DetectProviderAsync(
+        string providerName,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(providerName))
+            return null;
+
+        if (!forceRefresh && _cached is not null)
+        {
+            var cached = _cached.FirstOrDefault(p =>
+                string.Equals(p.Name, providerName, StringComparison.OrdinalIgnoreCase));
+            if (cached is not null)
+                return cached;
+        }
+
+        var detector = _detectors.FirstOrDefault(d =>
+            string.Equals(d.ProviderName, providerName, StringComparison.OrdinalIgnoreCase));
+        if (detector is null)
+            return null;
+
+        ProviderInfo provider;
+        try
+        {
+            provider = await detector.DetectAsync(ct).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // detector failures are non-fatal
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            provider = new ProviderInfo(
+                detector.ProviderName,
+                IsAvailable: false,
+                StatusMessage: ex.Message,
+                Models: []);
+        }
+
+        if (_metadataProvider is not null && provider.IsAvailable && provider.Models.Count > 0)
+        {
+            await _metadataProvider.LoadAsync(ct: ct).ConfigureAwait(false);
+            provider = provider with { Models = _metadataProvider.Enrich(provider.Models) };
+        }
+
+        var updated = _cached?.ToList() ?? [];
+        var existingIndex = updated.FindIndex(p =>
+            string.Equals(p.Name, provider.Name, StringComparison.OrdinalIgnoreCase));
+        if (existingIndex >= 0)
+            updated[existingIndex] = provider;
+        else
+            updated.Add(provider);
+
+        _cached = updated;
+        return provider;
     }
 
     public Kernel BuildKernel(ProviderModelInfo model)

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -180,6 +180,54 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         };
     }
 
+    private async Task<IReadOnlyList<ProviderInfo>> DetectProvidersAsync(
+        bool forceRefresh,
+        CancellationToken ct)
+    {
+        if (forceRefresh && _registry is ProviderRegistry concrete)
+            return await concrete.DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
+
+        return await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<ProviderModelInfo>> GetModelsAsync(
+        bool forceRefresh,
+        CancellationToken ct)
+    {
+        if (forceRefresh && _registry is ProviderRegistry concrete)
+            return await concrete.GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
+
+        return await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task SwitchModelAndPersistAsync(ProviderModelInfo model, CancellationToken ct)
+    {
+        _session.SwitchModel(model);
+        await PersistProjectDefaultsAsync(model, ct).ConfigureAwait(false);
+    }
+
+    private async Task PersistProjectDefaultsAsync(ProviderModelInfo model, CancellationToken ct)
+    {
+        if (_configStore is null)
+            return;
+
+        var projectPath = _session.SessionInfo?.ProjectPath ?? Directory.GetCurrentDirectory();
+
+        try
+        {
+            await _configStore.SetDefaultProviderAsync(model.ProviderName, projectPath, ct)
+                .ConfigureAwait(false);
+            await _configStore.SetDefaultModelAsync(model.Id, projectPath, ct)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // preference persistence is best-effort
+        catch
+#pragma warning restore CA1031
+        {
+            // Ignore persistence failures during model switches.
+        }
+    }
+
     private static string GetHelp() => """
         Available commands (all accept /jdai- prefix, e.g. /jdai-config):
           /help           — Show this help
@@ -268,7 +316,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
     private async Task<string> ListModelsAsync(CancellationToken ct)
     {
-        var models = await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+        var models = await GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
         if (models.Count == 0)
         {
             return "No models available. Check provider authentication.";
@@ -277,7 +325,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         var selected = ModelPicker.Pick(models, _session.CurrentModel);
         if (selected != null && !string.Equals(selected.Id, _session.CurrentModel?.Id, StringComparison.Ordinal))
         {
-            _session.SwitchModel(selected);
+            await SwitchModelAndPersistAsync(selected, ct).ConfigureAwait(false);
             return $"Switched to {selected.DisplayName} ({selected.ProviderName})";
         }
 
@@ -306,7 +354,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             }
         }
 
-        var models = await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+        var models = await GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
 
         // No argument: show interactive picker
         if (string.IsNullOrWhiteSpace(modelId))
@@ -319,7 +367,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             var selected = ModelPicker.Pick(models, _session.CurrentModel);
             if (selected != null)
             {
-                _session.SwitchModel(selected);
+                await SwitchModelAndPersistAsync(selected, ct).ConfigureAwait(false);
                 return $"Switched to {selected.DisplayName} ({selected.ProviderName})";
             }
 
@@ -335,7 +383,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             return $"Model '{modelId}' not found. Use /models to browse interactively.";
         }
 
-        _session.SwitchModel(model);
+        await SwitchModelAndPersistAsync(model, ct).ConfigureAwait(false);
         return $"Switched to {model.DisplayName} ({model.ProviderName})";
     }
 
@@ -411,12 +459,12 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         if (string.Equals(selected.Status, "Installed", StringComparison.Ordinal))
         {
             // Already installed — switch to it
-            var models = await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+            var models = await GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
             var match = models.FirstOrDefault(m =>
                 m.Id.Contains(selected.Id, StringComparison.OrdinalIgnoreCase));
             if (match is not null)
             {
-                _session.SwitchModel(match);
+                await SwitchModelAndPersistAsync(match, ct).ConfigureAwait(false);
                 return $"Switched to {match.DisplayName} ({match.ProviderName})";
             }
 
@@ -491,13 +539,13 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                 : $"Failed to pull '{selected.DisplayName}'. The provider may not support pulling.";
 
         // Re-detect providers and find the newly pulled model
-        var models = await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+        var models = await GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
         var match = models.FirstOrDefault(m =>
             m.Id.Contains(selected.Id, StringComparison.OrdinalIgnoreCase));
 
         if (match is not null)
         {
-            _session.SwitchModel(match);
+            await SwitchModelAndPersistAsync(match, ct).ConfigureAwait(false);
             return $"Pulled and switched to {match.DisplayName} ({match.ProviderName})";
         }
 
@@ -524,7 +572,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
     private async Task<string> ListProvidersAsync(CancellationToken ct)
     {
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
         var lines = providers.Select(p =>
         {
             var status = p.IsAvailable ? "✓" : "✗";
@@ -560,7 +608,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
     private async Task<string> ProviderListAsync(CancellationToken ct)
     {
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
         var activeProviderName = _session.CurrentModel?.ProviderName;
 
         var table = new Table()
@@ -607,7 +655,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
     private async Task<string> ProviderPickerAsync(CancellationToken ct)
     {
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
         if (providers.Count == 0)
             return "No providers detected. Use /provider add <name> to configure one.";
 
@@ -683,7 +731,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
         if (selected.Models.Count == 1)
         {
-            _session.SwitchModel(selected.Models[0]);
+            await SwitchModelAndPersistAsync(selected.Models[0], ct).ConfigureAwait(false);
             return $"Switched to {selected.Models[0].DisplayName} ({selected.Name})";
         }
 
@@ -692,7 +740,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         if (model is null)
             return "Model selection cancelled.";
 
-        _session.SwitchModel(model);
+        await SwitchModelAndPersistAsync(model, ct).ConfigureAwait(false);
         return $"Switched to {model.DisplayName} ({selected.Name})";
     }
 
@@ -813,7 +861,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
     private async Task<string> ProviderTestAsync(string? providerName, CancellationToken ct)
     {
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
 
         IEnumerable<ProviderInfo> toTest = providers;
         if (!string.IsNullOrWhiteSpace(providerName))
@@ -1865,7 +1913,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         var subArg = parts.Length > 1 ? parts[1] : null;
 
         // Find the LocalModelDetector in our registry
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
         var localProvider = providers.FirstOrDefault(p =>
             string.Equals(p.Name, "Local", StringComparison.OrdinalIgnoreCase));
 
@@ -2322,11 +2370,11 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         sb.AppendLine($"OS: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");
         sb.AppendLine($"CWD: {Directory.GetCurrentDirectory()}");
 
-        var providers = await _registry.DetectProvidersAsync(ct).ConfigureAwait(false);
+        var providers = await DetectProvidersAsync(forceRefresh: true, ct).ConfigureAwait(false);
         var providerList = providers.ToList();
         sb.AppendLine($"Providers: {providerList.Count(p => p.IsAvailable)} available / {providerList.Count} total");
 
-        var allModels = await _registry.GetModelsAsync(ct).ConfigureAwait(false);
+        var allModels = await GetModelsAsync(forceRefresh: true, ct).ConfigureAwait(false);
         sb.AppendLine($"Models: {allModels.Count}");
         sb.AppendLine($"Current: {_session.CurrentModel?.ProviderName ?? "?"} / {_session.CurrentModel?.Id ?? "?"}");
         sb.AppendLine($"Plugins: {_session.Kernel.Plugins.Count}");

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -46,13 +46,14 @@ Console.InputEncoding = System.Text.Encoding.UTF8;
 // Parse CLI flags
 var opts = await CliArgumentParser.ParseAsync(args).ConfigureAwait(false);
 
-// Handle 'mcp' / 'plugin' subcommands early (before provider detection)
+// Handle CLI subcommands early (before provider detection)
 if (opts.Subcommand != null)
 {
     return opts.Subcommand switch
     {
         "mcp" => await McpCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "plugin" => await PluginCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
+        "onboard" or "wizard" => await OnboardingCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         _ => 1,
     };
 }

--- a/src/JD.AI/Startup/CliOptions.cs
+++ b/src/JD.AI/Startup/CliOptions.cs
@@ -70,7 +70,7 @@ internal static class CliArgumentParser
         var gatewayMode = args.Contains("--gateway");
         var gatewayPort = GetFlagValue(args, "--gateway-port");
 
-        // Subcommand interception (mcp, plugin)
+        // Subcommand interception (mcp, plugin, onboard/wizard)
         var firstNonOptionIndex = Array.FindIndex(args, a => !a.StartsWith('-'));
         string? subcommand = null;
         string[] subcommandArgs = [];
@@ -78,7 +78,9 @@ internal static class CliArgumentParser
         {
             var candidate = args[firstNonOptionIndex];
             if (string.Equals(candidate, "mcp", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(candidate, "plugin", StringComparison.OrdinalIgnoreCase))
+                string.Equals(candidate, "plugin", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate, "onboard", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate, "wizard", StringComparison.OrdinalIgnoreCase))
             {
                 subcommand = candidate.ToLowerInvariant();
                 subcommandArgs = args.Skip(firstNonOptionIndex + 1).ToArray();

--- a/src/JD.AI/Startup/OnboardingCliHandler.cs
+++ b/src/JD.AI/Startup/OnboardingCliHandler.cs
@@ -1,0 +1,121 @@
+using JD.AI.Core.Config;
+using JD.AI.Core.Providers;
+using JD.AI.Rendering;
+using Spectre.Console;
+
+namespace JD.AI.Startup;
+
+internal static class OnboardingCliHandler
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var useGlobalDefaults = args.Any(a =>
+            string.Equals(a, "--global", StringComparison.OrdinalIgnoreCase));
+        var providerArg = GetFlagValue(args, "--provider");
+        var modelArg = GetFlagValue(args, "--model");
+
+        using var configStore = new AtomicConfigStore();
+        var projectPath = Directory.GetCurrentDirectory();
+        var (registry, _, _) = ProviderOrchestrator.CreateRegistry();
+
+        AnsiConsole.MarkupLine("[bold]JD.AI Onboarding[/]");
+        AnsiConsole.MarkupLine("[dim]Detecting providers and models...[/]");
+
+        var providers = await registry
+            .DetectProvidersAsync(forceRefresh: true)
+            .ConfigureAwait(false);
+
+        var available = providers
+            .Where(p => p.IsAvailable && p.Models.Count > 0)
+            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (available.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[red]No available providers with models were detected.[/]");
+            AnsiConsole.MarkupLine("[dim]Run `/provider add <name>` inside JD.AI to configure one, then rerun `jdai onboard`.[/]");
+            return 1;
+        }
+
+        var provider = ResolveProvider(available, providerArg);
+        if (provider is null)
+        {
+            AnsiConsole.MarkupLine($"[red]Provider '{Markup.Escape(providerArg!)}' was not found or has no models.[/]");
+            return 1;
+        }
+
+        var model = ResolveModel(provider.Models, modelArg);
+        if (model is null)
+        {
+            AnsiConsole.MarkupLine($"[red]Model '{Markup.Escape(modelArg!)}' was not found in provider '{Markup.Escape(provider.Name)}'.[/]");
+            return 1;
+        }
+
+        await configStore.SetDefaultProviderAsync(provider.Name, projectPath).ConfigureAwait(false);
+        await configStore.SetDefaultModelAsync(model.Id, projectPath).ConfigureAwait(false);
+
+        if (useGlobalDefaults)
+        {
+            await configStore.SetDefaultProviderAsync(provider.Name).ConfigureAwait(false);
+            await configStore.SetDefaultModelAsync(model.Id).ConfigureAwait(false);
+        }
+
+        AnsiConsole.MarkupLine(
+            $"[green]Saved startup defaults:[/] {Markup.Escape(provider.Name)} / {Markup.Escape(model.Id)}");
+        AnsiConsole.MarkupLine(
+            $"[dim]Scope: {(useGlobalDefaults ? "project + global" : "project")} ({Markup.Escape(projectPath)})[/]");
+        AnsiConsole.MarkupLine("[dim]Tip: run `jdai wizard` (alias) anytime to switch quickly.[/]");
+        return 0;
+    }
+
+    private static ProviderInfo? ResolveProvider(
+        IReadOnlyList<ProviderInfo> providers,
+        string? providerArg)
+    {
+        if (!string.IsNullOrWhiteSpace(providerArg))
+        {
+            return providers.FirstOrDefault(p =>
+                p.Name.Contains(providerArg, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return AnsiConsole.Prompt(
+            new SelectionPrompt<ProviderInfo>()
+                .Title("[bold]Select provider[/]")
+                .PageSize(12)
+                .UseConverter(p => $"{Markup.Escape(p.Name)} [dim]({p.Models.Count} models)[/]")
+                .AddChoices(providers));
+    }
+
+    private static ProviderModelInfo? ResolveModel(
+        IReadOnlyList<ProviderModelInfo> models,
+        string? modelArg)
+    {
+        if (!string.IsNullOrWhiteSpace(modelArg))
+        {
+            return models.FirstOrDefault(m =>
+                m.Id.Contains(modelArg, StringComparison.OrdinalIgnoreCase)
+                || m.DisplayName.Contains(modelArg, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return AnsiConsole.Prompt(
+            new SelectionPrompt<ProviderModelInfo>()
+                .Title("[bold]Select model[/] [dim](💬=Chat 🔧=Tools 👁=Vision 📐=Embed)[/]")
+                .PageSize(15)
+                .UseConverter(m =>
+                {
+                    var badge = m.Capabilities.ToBadge();
+                    return $"{badge} {Markup.Escape(m.DisplayName)} [dim]({Markup.Escape(m.Id)})[/]";
+                })
+                .AddChoices(models));
+    }
+
+    private static string? GetFlagValue(string[] args, string flag)
+    {
+        return args
+            .Select((value, index) => (value, index))
+            .FirstOrDefault(t => string.Equals(t.value, flag, StringComparison.OrdinalIgnoreCase))
+            .index is var idx && idx >= 0 && idx + 1 < args.Length
+            ? args[idx + 1]
+            : null;
+    }
+}

--- a/src/JD.AI/Startup/ProviderOrchestrator.cs
+++ b/src/JD.AI/Startup/ProviderOrchestrator.cs
@@ -26,15 +26,12 @@ internal sealed record ProviderSetup(
 /// </summary>
 internal static class ProviderOrchestrator
 {
-    public static async Task<ProviderSetup?> DetectAndSelectAsync(CliOptions opts, AtomicConfigStore configStore)
+    internal static (ProviderRegistry Registry, ProviderConfigurationManager ProviderConfig, ModelMetadataProvider MetadataProvider)
+        CreateRegistry()
     {
-        if (!opts.PrintMode)
-        {
-            AnsiConsole.MarkupLine("[dim]Detecting providers...[/]");
-        }
-
         var credentialStore = new EncryptedFileStore();
         var providerConfig = new ProviderConfigurationManager(credentialStore);
+        var metadataProvider = new ModelMetadataProvider();
 
         var detectors = new IProviderDetector[]
         {
@@ -53,10 +50,64 @@ internal static class ProviderOrchestrator
             new HuggingFaceDetector(providerConfig),
             new OpenAICompatibleDetector(providerConfig),
         };
-        var metadataProvider = new ModelMetadataProvider();
-        var registry = new ProviderRegistry(detectors, metadataProvider);
 
-        var providers = await registry.DetectProvidersAsync().ConfigureAwait(false);
+        var registry = new ProviderRegistry(detectors, metadataProvider);
+        return (registry, providerConfig, metadataProvider);
+    }
+
+    public static async Task<ProviderSetup?> DetectAndSelectAsync(CliOptions opts, AtomicConfigStore configStore)
+    {
+        var projectPath = Directory.GetCurrentDirectory();
+        var defaultProvider = await configStore.GetDefaultProviderAsync(projectPath).ConfigureAwait(false);
+        var defaultModel = await configStore.GetDefaultModelAsync(projectPath).ConfigureAwait(false);
+
+        if (!opts.PrintMode)
+        {
+            AnsiConsole.MarkupLine("[dim]Detecting providers...[/]");
+        }
+
+        var (registry, providerConfig, metadataProvider) = CreateRegistry();
+
+        // Fast path: prefer the persisted provider/model and refresh auth only for that provider.
+        if (opts.CliModel is null
+            && opts.CliProvider is null
+            && !string.IsNullOrWhiteSpace(defaultProvider))
+        {
+            var preferred = await registry
+                .DetectProviderAsync(defaultProvider, forceRefresh: true)
+                .ConfigureAwait(false);
+
+            if (preferred is { IsAvailable: true } && preferred.Models.Count > 0)
+            {
+                var selected = SelectModel(
+                    opts,
+                    preferred.Models,
+                    defaultProvider,
+                    defaultModel);
+
+                if (selected is not null)
+                {
+                    if (!opts.PrintMode)
+                    {
+                        AnsiConsole.MarkupLine(
+                            $"  [green]✓[/] [bold]{Markup.Escape(preferred.Name)}[/]: " +
+                            $"{Markup.Escape(preferred.StatusMessage ?? "Using saved default")}");
+                    }
+
+                    await PersistSelectionAsync(configStore, projectPath, selected).ConfigureAwait(false);
+                    var kernelFast = registry.BuildKernel(selected);
+                    return new ProviderSetup(
+                        registry,
+                        providerConfig,
+                        metadataProvider,
+                        preferred.Models,
+                        selected,
+                        kernelFast);
+                }
+            }
+        }
+
+        var providers = await registry.DetectProvidersAsync(forceRefresh: true).ConfigureAwait(false);
         if (!opts.PrintMode)
         {
             foreach (var p in providers)
@@ -66,19 +117,20 @@ internal static class ProviderOrchestrator
             }
         }
 
-        var allModels = await registry.GetModelsAsync().ConfigureAwait(false);
+        var allModels = await registry.GetModelsAsync(forceRefresh: true).ConfigureAwait(false);
         if (allModels.Count == 0)
         {
             Console.Error.WriteLine("No AI providers available.");
             return null;
         }
 
-        var selectedModel = SelectModel(opts, allModels, configStore);
+        var selectedModel = SelectModel(opts, allModels, defaultProvider, defaultModel);
         if (selectedModel is null)
         {
             return null;
         }
 
+        await PersistSelectionAsync(configStore, projectPath, selectedModel).ConfigureAwait(false);
         var kernel = registry.BuildKernel(selectedModel);
 
         return new ProviderSetup(registry, providerConfig, metadataProvider, allModels, selectedModel, kernel);
@@ -87,7 +139,8 @@ internal static class ProviderOrchestrator
     private static ProviderModelInfo? SelectModel(
         CliOptions opts,
         IReadOnlyList<ProviderModelInfo> allModels,
-        AtomicConfigStore configStore)
+        string? defaultProvider,
+        string? defaultModel)
     {
         if (opts.CliModel != null)
         {
@@ -126,11 +179,6 @@ internal static class ProviderOrchestrator
                 : PromptForModel(candidates);
         }
 
-        // Check per-project then global defaults
-        var cfgProjectPath = Directory.GetCurrentDirectory();
-        var defaultModel = configStore.GetDefaultModelAsync(cfgProjectPath).GetAwaiter().GetResult();
-        var defaultProvider = configStore.GetDefaultProviderAsync(cfgProjectPath).GetAwaiter().GetResult();
-
         List<ProviderModelInfo>? defaultCandidates = null;
 
         if (defaultModel is not null)
@@ -162,6 +210,28 @@ internal static class ProviderOrchestrator
         }
 
         return PromptForModel(allModels);
+    }
+
+    private static async Task PersistSelectionAsync(
+        AtomicConfigStore configStore,
+        string projectPath,
+        ProviderModelInfo selectedModel)
+    {
+        try
+        {
+            await configStore
+                .SetDefaultProviderAsync(selectedModel.ProviderName, projectPath)
+                .ConfigureAwait(false);
+            await configStore
+                .SetDefaultModelAsync(selectedModel.Id, projectPath)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // selection persistence should never block startup
+        catch
+#pragma warning restore CA1031
+        {
+            // Best-effort persistence
+        }
     }
 
     private static ProviderModelInfo PromptForModel(IReadOnlyList<ProviderModelInfo> models)

--- a/tests/JD.AI.Tests/CliArgumentParserTests.cs
+++ b/tests/JD.AI.Tests/CliArgumentParserTests.cs
@@ -1,0 +1,34 @@
+using JD.AI.Startup;
+
+namespace JD.AI.Tests;
+
+public sealed class CliArgumentParserTests
+{
+    [Fact]
+    public async Task ParseAsync_Onboard_SubcommandIsDetected()
+    {
+        var opts = await CliArgumentParser.ParseAsync(["onboard"]);
+
+        Assert.Equal("onboard", opts.Subcommand);
+        Assert.Empty(opts.SubcommandArgs);
+    }
+
+    [Fact]
+    public async Task ParseAsync_Wizard_SubcommandArgsAreCaptured()
+    {
+        var opts = await CliArgumentParser.ParseAsync(["wizard", "--global", "--provider", "openai"]);
+
+        Assert.Equal("wizard", opts.Subcommand);
+        Assert.Equal(["--global", "--provider", "openai"], opts.SubcommandArgs);
+    }
+
+    [Fact]
+    public async Task ParseAsync_RegularFlags_DoNotBecomeSubcommand()
+    {
+        var opts = await CliArgumentParser.ParseAsync(["--provider", "openai", "--model", "gpt-4.1"]);
+
+        Assert.Null(opts.Subcommand);
+        Assert.Equal("openai", opts.CliProvider);
+        Assert.Equal("gpt-4.1", opts.CliModel);
+    }
+}

--- a/tests/JD.AI.Tests/ProviderRegistryTests.cs
+++ b/tests/JD.AI.Tests/ProviderRegistryTests.cs
@@ -108,4 +108,47 @@ public sealed class ProviderRegistryTests
         Assert.Single(models);
         await _detector1.Received(1).DetectAsync(Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task DetectProviderAsync_RefreshesOnlyRequestedProvider()
+    {
+        _detector1.DetectAsync(Arg.Any<CancellationToken>())
+            .Returns(new ProviderInfo("Provider1", true, "OK", [
+                new ProviderModelInfo("m1", "M1", "Provider1"),
+            ]));
+        _detector2.DetectAsync(Arg.Any<CancellationToken>())
+            .Returns(new ProviderInfo("Provider2", true, "OK", [
+                new ProviderModelInfo("m2", "M2", "Provider2"),
+            ]));
+
+        var registry = new ProviderRegistry([_detector1, _detector2]);
+
+        var provider = await registry.DetectProviderAsync("provider2");
+
+        Assert.NotNull(provider);
+        Assert.Equal("Provider2", provider!.Name);
+        await _detector1.DidNotReceive().DetectAsync(Arg.Any<CancellationToken>());
+        await _detector2.Received(1).DetectAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_ForceRefresh_RefreshesAllDetectors()
+    {
+        _detector1.DetectAsync(Arg.Any<CancellationToken>())
+            .Returns(new ProviderInfo("Provider1", true, "OK", [
+                new ProviderModelInfo("m1", "M1", "Provider1"),
+            ]));
+        _detector2.DetectAsync(Arg.Any<CancellationToken>())
+            .Returns(new ProviderInfo("Provider2", true, "OK", [
+                new ProviderModelInfo("m2", "M2", "Provider2"),
+            ]));
+
+        var registry = new ProviderRegistry([_detector1, _detector2]);
+
+        await registry.GetModelsAsync();
+        await registry.GetModelsAsync(forceRefresh: true);
+
+        await _detector1.Received(2).DetectAsync(Arg.Any<CancellationToken>());
+        await _detector2.Received(2).DetectAsync(Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/JD.AI.Tests/SlashCommandRouterTests.cs
+++ b/tests/JD.AI.Tests/SlashCommandRouterTests.cs
@@ -106,6 +106,39 @@ public sealed class SlashCommandRouterTests
     }
 
     [Fact]
+    public async Task Model_Switch_PersistsProjectDefaults_WhenConfigStoreIsProvided()
+    {
+        var newModel = new ProviderModelInfo("saved-model", "Saved Model", "SavedProvider");
+        _registry.GetModelsAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<ProviderModelInfo> { newModel });
+        _registry.BuildKernel(newModel).Returns(Kernel.CreateBuilder().Build());
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"jdai-defaults-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var originalDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            Directory.SetCurrentDirectory(tempDirectory);
+            var configPath = Path.Combine(tempDirectory, "config.json");
+            using var configStore = new AtomicConfigStore(configPath);
+            var router = new SlashCommandRouter(_session, _registry, configStore: configStore);
+
+            await router.ExecuteAsync("/model saved-model");
+            var config = await configStore.ReadAsync();
+
+            Assert.True(config.ProjectDefaults.TryGetValue(tempDirectory, out var defaults));
+            Assert.Equal("SavedProvider", defaults!.Provider);
+            Assert.Equal("saved-model", defaults.Model);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDirectory);
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Model_ReportsNotFound()
     {
         _registry.GetModelsAsync(Arg.Any<CancellationToken>())


### PR DESCRIPTION
## Summary
- add a startup fast-path that uses persisted project defaults and refreshes only the current provider
- persist provider/model defaults automatically when model/provider selection changes
- add `jdai onboard` (alias `jdai wizard`) to quickly select and save provider/model defaults
- keep full provider/model refresh on explicit discovery commands (`/models`, `/providers`, `/provider*`)
- add tests for parser subcommands, provider registry refresh behavior, and model-switch persistence

## Validation
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj -c Release --filter "FullyQualifiedName~ProviderRegistryTests|FullyQualifiedName~CliArgumentParserTests|FullyQualifiedName~SlashCommandRouterTests" --nologo`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj -c Release --filter "FullyQualifiedName~CliArgumentParserTests|FullyQualifiedName~ProviderRegistryTests|FullyQualifiedName~Model_Switch_PersistsProjectDefaults_WhenConfigStoreIsProvided" --nologo`
