### PR TITLE
Daemon: provision OpenClaw gateway tasks during install/update

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -36,6 +36,11 @@ This creates a Windows Service named **JDAIDaemon** with:
 - **Automatic startup** — starts with Windows
 - **Recovery policy** — restarts on failure (5s, 10s, 30s backoff)
 - **Display name** — "JD.AI Gateway Daemon"
+- **OpenClaw gateway task** — scheduled task `\OpenClaw Gateway` (runs as `SYSTEM` at startup)
+- **OpenClaw watchdog task** — scheduled task `\OpenClaw Gateway Watchdog` (runs every minute)
+- **OpenClaw launcher scripts** — `~/.openclaw/gateway-service.cmd` and `~/.openclaw/gateway-watchdog.cmd`
+
+`jdai-daemon install` is idempotent on Windows: running it again updates the existing service definition and re-applies scheduled task configuration.
 
 ## Linux (systemd)
 
@@ -138,7 +143,7 @@ Caddy automatically provisions TLS certificates and handles WebSocket upgrades.
 | `jdai-daemon start` | Start the installed service |
 | `jdai-daemon stop` | Stop the running service |
 | `jdai-daemon status` | Show service state, version, uptime |
-| `jdai-daemon update` | Check for and apply NuGet updates |
+| `jdai-daemon update` | Check/apply NuGet updates and refresh installed service/task config |
 | `jdai-daemon update --check-only` | Check for updates without applying |
 | `jdai-daemon logs [-n 50]` | Show recent service logs |
 
@@ -178,7 +183,8 @@ Add an `Updates` section to your `appsettings.json`:
 2. **Notification** — If `NotifyChannels` is true, connected channels receive an update alert
 3. **Drain** — Active agents finish in-flight work (up to `DrainTimeout`)
 4. **Apply** — Runs `dotnet tool update -g JD.AI.Daemon`
-5. **Restart** — The service exits; Windows Service recovery or systemd restart brings it back on the new version
+5. **Reconcile** — If the daemon service is installed, `jdai-daemon update` re-applies service/task definitions
+6. **Restart** — The service exits; Windows Service recovery or systemd restart brings it back on the new version
 
 ### Manual update
 
@@ -217,6 +223,12 @@ sudo jdai-daemon uninstall
 ```
 
 This stops the service (if running), removes the Windows Service entry or systemd unit file, and reloads the daemon.
+
+On Windows, uninstall also removes:
+
+- Scheduled tasks `\OpenClaw Gateway` and `\OpenClaw Gateway Watchdog`
+- `~/.openclaw/gateway-service.cmd`
+- `~/.openclaw/gateway-watchdog.cmd`
 
 ## Troubleshooting
 

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -406,6 +406,19 @@ static void RunDaemon(string[] args)
 
 static async Task RunUpdateCommandAsync(bool checkOnly)
 {
+    IServiceManager? serviceManager = null;
+    var shouldReconcileService = false;
+    try
+    {
+        serviceManager = CreateServiceManager();
+        var status = await serviceManager.GetStatusAsync();
+        shouldReconcileService = status.State != ServiceState.NotInstalled;
+    }
+    catch (PlatformNotSupportedException)
+    {
+        // Update checks are supported on all platforms, but service reconciliation is Windows/Linux only.
+    }
+
     // Build a minimal host just for the update checker
     var builder = Host.CreateApplicationBuilder([]);
     builder.Services.Configure<UpdateConfig>(
@@ -448,7 +461,20 @@ static async Task RunUpdateCommandAsync(bool checkOnly)
     process.Start();
     await process.WaitForExitAsync();
 
-    Console.WriteLine(process.ExitCode == 0
-        ? $"✓ Updated to {update.LatestVersion}. Restart the service to apply."
-        : "✗ Update failed. Check the output above.");
+    if (process.ExitCode != 0)
+    {
+        Console.WriteLine("✗ Update failed. Check the output above.");
+        return;
+    }
+
+    if (shouldReconcileService && serviceManager is not null)
+    {
+        var reconcileResult = await serviceManager.InstallAsync();
+        if (reconcileResult.Success)
+            Console.WriteLine("Service configuration refreshed.");
+        else
+            Console.WriteLine($"Warning: package updated, but failed to refresh service/task config: {reconcileResult.Message}");
+    }
+
+    Console.WriteLine($"✓ Updated to {update.LatestVersion}. Restart the service to apply.");
 }

--- a/src/JD.AI.Daemon/Properties/AssemblyInfo.cs
+++ b/src/JD.AI.Daemon/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("JD.AI.Tests")]

--- a/src/JD.AI.Daemon/Services/WindowsServiceManager.cs
+++ b/src/JD.AI.Daemon/Services/WindowsServiceManager.cs
@@ -11,7 +11,14 @@ public sealed class WindowsServiceManager : IServiceManager
 {
     private const string ServiceName = "JDAIDaemon";
     private const string DisplayName = "JD.AI Gateway Daemon";
-    private const string Description = "JD.AI AI Gateway — manages AI agents, channels, and routing.";
+    private const string Description = "JD.AI AI Gateway - manages AI agents, channels, and routing.";
+
+    private const string OpenClawTaskName = "\\OpenClaw Gateway";
+    private const string OpenClawWatchdogTaskName = "\\OpenClaw Gateway Watchdog";
+    private const string OpenClawStateDirName = ".openclaw";
+    private const string OpenClawGatewayScriptFile = "gateway-service.cmd";
+    private const string OpenClawWatchdogScriptFile = "gateway-watchdog.cmd";
+    private const int OpenClawGatewayPort = 18789;
 
     public async Task<ServiceResult> InstallAsync(CancellationToken ct = default)
     {
@@ -19,33 +26,50 @@ public sealed class WindowsServiceManager : IServiceManager
         if (toolPath is null)
             return new ServiceResult(false, "Cannot locate jdai-daemon executable. Is it installed as a dotnet tool?");
 
-        // Create the service
-        var (exitCode, output) = await RunScAsync(
-            $"create {ServiceName} binPath=\"{toolPath} run\" start=auto DisplayName=\"{DisplayName}\"", ct);
+        var serviceBinPath = BuildServiceBinPath(toolPath);
+        var serviceExists = await ServiceExistsAsync(ct);
+
+        var (exitCode, output) = serviceExists
+            ? await RunScAsync($"config {ServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DisplayName}\"", ct)
+            : await RunScAsync($"create {ServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DisplayName}\"", ct);
 
         if (exitCode != 0)
-            return new ServiceResult(false, $"sc create failed: {output}");
+        {
+            var verb = serviceExists ? "config" : "create";
+            return new ServiceResult(false, $"sc {verb} failed: {output}");
+        }
 
-        // Set description
+        // Best effort metadata configuration
         await RunScAsync($"description {ServiceName} \"{Description}\"", ct);
-
-        // Configure recovery: restart on failure
         await RunScAsync($"failure {ServiceName} reset=86400 actions=restart/5000/restart/10000/restart/30000", ct);
 
-        return new ServiceResult(true, $"Service '{ServiceName}' installed. Run 'jdai-daemon start' to begin.");
+        var taskProvisioning = await EnsureOpenClawGatewayTasksAsync(ct);
+        if (!taskProvisioning.Success)
+            return taskProvisioning;
+
+        var action = serviceExists ? "updated" : "installed";
+        return new ServiceResult(true,
+            $"Service '{ServiceName}' {action}. OpenClaw gateway tasks are configured. Run 'jdai-daemon start' to begin.");
     }
 
     public async Task<ServiceResult> UninstallAsync(CancellationToken ct = default)
     {
-        // Stop first if running
         var status = await GetStatusAsync(ct);
         if (status.State == ServiceState.Running)
             await StopAsync(ct);
 
-        var (exitCode, output) = await RunScAsync($"delete {ServiceName}", ct);
-        return exitCode == 0
-            ? new ServiceResult(true, $"Service '{ServiceName}' uninstalled.")
-            : new ServiceResult(false, $"sc delete failed: {output}");
+        if (status.State != ServiceState.NotInstalled)
+        {
+            var (exitCode, output) = await RunScAsync($"delete {ServiceName}", ct);
+            if (exitCode != 0)
+                return new ServiceResult(false, $"sc delete failed: {output}");
+        }
+
+        var cleanupResult = await CleanupOpenClawGatewayArtifactsAsync(ct);
+        if (!cleanupResult.Success)
+            return cleanupResult;
+
+        return new ServiceResult(true, $"Service '{ServiceName}' uninstalled and OpenClaw gateway tasks removed.");
     }
 
     public async Task<ServiceResult> StartAsync(CancellationToken ct = default)
@@ -94,7 +118,51 @@ public sealed class WindowsServiceManager : IServiceManager
 
         return exitCode == 0
             ? new ServiceResult(true, output)
-            : new ServiceResult(true, "No event log entries found. The service may use file-based logging — check ~/.jdai/logs/.");
+            : new ServiceResult(true, "No event log entries found. The service may use file-based logging - check ~/.jdai/logs/.");
+    }
+
+    internal static string BuildOpenClawGatewayScript(
+        string stateDir,
+        string configPath,
+        string userHome,
+        string openClawMainPath,
+        int port = OpenClawGatewayPort)
+    {
+        return $"""
+            @echo off
+            setlocal
+
+            set "OPENCLAW_STATE_DIR={stateDir}"
+            set "OPENCLAW_CONFIG_PATH={configPath}"
+            set "USERPROFILE={userHome}"
+            set "HOME={userHome}"
+
+            set "OPENCLAW_MAIN={openClawMainPath}"
+            if not exist "%OPENCLAW_MAIN%" (
+              echo OpenClaw entrypoint not found: %OPENCLAW_MAIN%
+              exit /b 1
+            )
+
+            set "NODE_EXE=%ProgramFiles%\nodejs\node.exe"
+            if exist "%NODE_EXE%" goto run_gateway
+
+            for %%I in (node.exe) do set "NODE_EXE=%%~$PATH:I"
+            if not defined NODE_EXE (
+              echo node.exe not found. Install Node.js and openclaw.
+              exit /b 1
+            )
+
+            :run_gateway
+            "%NODE_EXE%" "%OPENCLAW_MAIN%" gateway --port {port}
+            """;
+    }
+
+    internal static string BuildOpenClawWatchdogScript(string gatewayTaskName = OpenClawTaskName)
+    {
+        return $"""
+            @echo off
+            schtasks /run /tn "{gatewayTaskName}" >nul 2>&1
+            """;
     }
 
     private static string? GetToolPath()
@@ -104,8 +172,102 @@ public sealed class WindowsServiceManager : IServiceManager
         return File.Exists(toolPath) ? toolPath : null;
     }
 
-    private static async Task<(int ExitCode, string Output)> RunScAsync(string arguments, CancellationToken ct)
-        => await RunProcessAsync("sc.exe", arguments, ct);
+    private static string BuildServiceBinPath(string toolPath)
+        => $"\"{toolPath}\" run";
+
+    private static async Task<bool> ServiceExistsAsync(CancellationToken ct)
+    {
+        var (exitCode, output) = await RunScAsync($"query {ServiceName}", ct);
+        return exitCode == 0 && !output.Contains("FAILED 1060", StringComparison.Ordinal);
+    }
+
+    private static async Task<ServiceResult> EnsureOpenClawGatewayTasksAsync(CancellationToken ct)
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return new ServiceResult(false, "Cannot resolve user profile path for OpenClaw task setup.");
+
+        var stateDir = Path.Combine(home, OpenClawStateDirName);
+        Directory.CreateDirectory(stateDir);
+
+        var configPath = Path.Combine(stateDir, "openclaw.json");
+        var openClawMainPath = Path.Combine(home, "AppData", "Roaming", "npm", "node_modules", "openclaw", "dist", "index.js");
+
+        var gatewayScriptPath = Path.Combine(stateDir, OpenClawGatewayScriptFile);
+        var watchdogScriptPath = Path.Combine(stateDir, OpenClawWatchdogScriptFile);
+
+        await File.WriteAllTextAsync(
+            gatewayScriptPath,
+            BuildOpenClawGatewayScript(stateDir, configPath, home, openClawMainPath),
+            ct);
+
+        await File.WriteAllTextAsync(
+            watchdogScriptPath,
+            BuildOpenClawWatchdogScript(),
+            ct);
+
+        var (taskExitCode, taskOutput) = await RunSchtasksAsync(
+            $"/create /tn \"{OpenClawTaskName}\" /sc onstart /ru SYSTEM /RL HIGHEST /TR \"{gatewayScriptPath}\" /F", ct);
+        if (taskExitCode != 0)
+            return new ServiceResult(false, $"Failed to register '{OpenClawTaskName}' task: {taskOutput}");
+
+        var (watchdogExitCode, watchdogOutput) = await RunSchtasksAsync(
+            $"/create /tn \"{OpenClawWatchdogTaskName}\" /sc minute /mo 1 /ru SYSTEM /RL HIGHEST /TR \"{watchdogScriptPath}\" /F", ct);
+        if (watchdogExitCode != 0)
+            return new ServiceResult(false, $"Failed to register '{OpenClawWatchdogTaskName}' task: {watchdogOutput}");
+
+        return new ServiceResult(true, "OpenClaw gateway tasks configured.");
+    }
+
+    private static async Task<ServiceResult> CleanupOpenClawGatewayArtifactsAsync(CancellationToken ct)
+    {
+        var errors = new List<string>();
+
+        await TryDeleteScheduledTaskAsync(OpenClawWatchdogTaskName, errors, ct);
+        await TryDeleteScheduledTaskAsync(OpenClawTaskName, errors, ct);
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+        {
+            var stateDir = Path.Combine(home, OpenClawStateDirName);
+            TryDeleteFile(Path.Combine(stateDir, OpenClawGatewayScriptFile), errors);
+            TryDeleteFile(Path.Combine(stateDir, OpenClawWatchdogScriptFile), errors);
+        }
+
+        return errors.Count == 0
+            ? new ServiceResult(true, "OpenClaw gateway artifacts removed.")
+            : new ServiceResult(false, string.Join(Environment.NewLine, errors));
+    }
+
+    private static async Task TryDeleteScheduledTaskAsync(string taskName, List<string> errors, CancellationToken ct)
+    {
+        var (queryExitCode, queryOutput) = await RunSchtasksAsync($"/query /tn \"{taskName}\"", ct);
+        if (queryExitCode != 0 && queryOutput.Contains("cannot find", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var (deleteExitCode, deleteOutput) = await RunSchtasksAsync($"/delete /tn \"{taskName}\" /F", ct);
+        if (deleteExitCode != 0)
+            errors.Add($"Failed to delete task '{taskName}': {deleteOutput}");
+    }
+
+    private static void TryDeleteFile(string path, List<string> errors)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Failed to delete file '{path}': {ex.Message}");
+        }
+    }
+
+    private static Task<(int ExitCode, string Output)> RunScAsync(string arguments, CancellationToken ct)
+        => RunProcessAsync("sc.exe", arguments, ct);
+
+    private static Task<(int ExitCode, string Output)> RunSchtasksAsync(string arguments, CancellationToken ct)
+        => RunProcessAsync("schtasks.exe", arguments, ct);
 
     private static async Task<(int ExitCode, string Output)> RunProcessAsync(
         string fileName, string arguments, CancellationToken ct)

--- a/tests/JD.AI.Tests/DaemonServiceTests.cs
+++ b/tests/JD.AI.Tests/DaemonServiceTests.cs
@@ -222,6 +222,36 @@ public sealed class DaemonServiceTests
 
     // ── Windows ServiceManager logs ────────────────────────────────
     [Fact]
+    public void WindowsServiceManager_BuildOpenClawGatewayScript_ContainsExpectedValues()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var script = WindowsServiceManager.BuildOpenClawGatewayScript(
+            @"C:\Users\jd\.openclaw",
+            @"C:\Users\jd\.openclaw\openclaw.json",
+            @"C:\Users\jd",
+            @"C:\Users\jd\AppData\Roaming\npm\node_modules\openclaw\dist\index.js",
+            port: 18789);
+
+        Assert.Contains("OPENCLAW_STATE_DIR=C:\\Users\\jd\\.openclaw", script, StringComparison.Ordinal);
+        Assert.Contains("OPENCLAW_CONFIG_PATH=C:\\Users\\jd\\.openclaw\\openclaw.json", script, StringComparison.Ordinal);
+        Assert.Contains("USERPROFILE=C:\\Users\\jd", script, StringComparison.Ordinal);
+        Assert.Contains("\"%NODE_EXE%\" \"%OPENCLAW_MAIN%\" gateway --port 18789", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WindowsServiceManager_BuildOpenClawWatchdogScript_TargetsGatewayTask()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var script = WindowsServiceManager.BuildOpenClawWatchdogScript();
+        Assert.Contains("schtasks /run /tn \"\\OpenClaw Gateway\"", script, StringComparison.Ordinal);
+    }
+
+    // ── Windows ServiceManager logs ────────────────────────────────
+    [Fact]
     public async Task WindowsServiceManager_ShowLogs_DoesNotThrow()
     {
         if (!OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary\n- make Windows daemon install idempotent (create-or-update service)\n- provision OpenClaw gateway + watchdog scripts and scheduled tasks during install\n- remove OpenClaw tasks/scripts during uninstall\n- refresh service/task definitions after successful \jdai-daemon update\ when service is installed\n- document install/update/uninstall behavior and add daemon tests for generated scripts\n\n## Validation\n- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter DaemonServiceTests