### PR TITLE
refactor: migrate 24 test files to TempDirectoryFixture (Tier 1d)

### DIFF
--- a/tests/JD.AI.Tests/CheckpointStrategyTests.cs
+++ b/tests/JD.AI.Tests/CheckpointStrategyTests.cs
@@ -1,30 +1,21 @@
 using JD.AI.Core.Agents.Checkpointing;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests;
 
 public sealed class CheckpointStrategyTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public CheckpointStrategyTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-cp-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     // ── DirectoryCheckpointStrategy ────────────────────────
 
     [Fact]
     public async Task Directory_CreateAsync_ReturnsId()
     {
-        var strategy = new DirectoryCheckpointStrategy(_tempDir);
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.cs"), "hello");
+        var strategy = new DirectoryCheckpointStrategy(_fixture.DirectoryPath);
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.cs"), "hello");
 
         var id = await strategy.CreateAsync("test-label");
 
@@ -35,13 +26,13 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Directory_ListAsync_ShowsCreatedCheckpoints()
     {
-        var strategy = new DirectoryCheckpointStrategy(_tempDir);
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.cs"), "v1");
+        var strategy = new DirectoryCheckpointStrategy(_fixture.DirectoryPath);
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.cs"), "v1");
         await strategy.CreateAsync("first");
 
         // Need unique timestamp — wait a tiny bit to get different second
         await Task.Delay(1100);
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.cs"), "v2");
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.cs"), "v2");
         await strategy.CreateAsync("second");
 
         var checkpoints = await strategy.ListAsync();
@@ -52,8 +43,8 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Directory_RestoreAsync_RestoresContent()
     {
-        var strategy = new DirectoryCheckpointStrategy(_tempDir);
-        var filePath = Path.Combine(_tempDir, "test.cs");
+        var strategy = new DirectoryCheckpointStrategy(_fixture.DirectoryPath);
+        var filePath = Path.Combine(_fixture.DirectoryPath, "test.cs");
         await File.WriteAllTextAsync(filePath, "original");
         var id = await strategy.CreateAsync("before-change");
         Assert.NotNull(id);
@@ -68,8 +59,8 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Directory_ClearAsync_RemovesAll()
     {
-        var strategy = new DirectoryCheckpointStrategy(_tempDir);
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.cs"), "hello");
+        var strategy = new DirectoryCheckpointStrategy(_fixture.DirectoryPath);
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.cs"), "hello");
         await strategy.CreateAsync("label");
 
         await strategy.ClearAsync();
@@ -81,7 +72,7 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Directory_RestoreAsync_InvalidId_ReturnsFalse()
     {
-        var strategy = new DirectoryCheckpointStrategy(_tempDir);
+        var strategy = new DirectoryCheckpointStrategy(_fixture.DirectoryPath);
 
         var success = await strategy.RestoreAsync("nonexistent-id");
 
@@ -93,8 +84,8 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Stash_CreateAsync_NoGitRepo_ReturnsNull()
     {
-        // _tempDir is not a git repo, so stash operations should fail gracefully
-        var strategy = new StashCheckpointStrategy(_tempDir);
+        // _fixture.DirectoryPath is not a git repo, so stash operations should fail gracefully
+        var strategy = new StashCheckpointStrategy(_fixture.DirectoryPath);
 
         var id = await strategy.CreateAsync("test");
 
@@ -104,7 +95,7 @@ public sealed class CheckpointStrategyTests : IDisposable
     [Fact]
     public async Task Stash_ListAsync_NoGitRepo_ReturnsEmpty()
     {
-        var strategy = new StashCheckpointStrategy(_tempDir);
+        var strategy = new StashCheckpointStrategy(_fixture.DirectoryPath);
 
         var checkpoints = await strategy.ListAsync();
 

--- a/tests/JD.AI.Tests/Config/AtomicConfigStoreTests.cs
+++ b/tests/JD.AI.Tests/Config/AtomicConfigStoreTests.cs
@@ -1,27 +1,20 @@
 using FluentAssertions;
 using JD.AI.Core.Config;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Config;
 
 public class AtomicConfigStoreTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly string _configPath;
 
     public AtomicConfigStoreTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), "jdai-tests-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(_tempDir);
-        _configPath = Path.Combine(_tempDir, "config.json");
+        _configPath = Path.Combine(_fixture.DirectoryPath, "config.json");
     }
 
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
-
-        GC.SuppressFinalize(this);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task ReadAsync_ReturnsEmptyConfig_WhenFileDoesNotExist()
@@ -39,7 +32,7 @@ public class AtomicConfigStoreTests : IDisposable
     [Fact]
     public async Task WriteAsync_CreatesFileAndDirectories()
     {
-        var nested = Path.Combine(_tempDir, "sub", "dir", "config.json");
+        var nested = Path.Combine(_fixture.DirectoryPath, "sub", "dir", "config.json");
         var store = new AtomicConfigStore(nested);
 
         await store.WriteAsync(cfg => cfg.Defaults.Provider = "openai");

--- a/tests/JD.AI.Tests/Config/ConfigSchemaVersionTests.cs
+++ b/tests/JD.AI.Tests/Config/ConfigSchemaVersionTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.Config;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Config;
 
 public sealed class ConfigSchemaVersionTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public ConfigSchemaVersionTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-csv-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public void GetStoredVersion_NoFile_ReturnsZero()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
 
         sv.GetStoredVersion().Should().Be(0);
     }
@@ -30,18 +21,18 @@ public sealed class ConfigSchemaVersionTests : IDisposable
     [Fact]
     public void StampCurrentVersion_WritesFile()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
 
         sv.StampCurrentVersion();
 
-        File.Exists(Path.Combine(_tempDir, "schema-version.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_fixture.DirectoryPath, "schema-version.json")).Should().BeTrue();
         sv.GetStoredVersion().Should().Be(ConfigSchemaVersion.CurrentVersion);
     }
 
     [Fact]
     public void NeedsMigration_NoVersionFile_ReturnsTrue()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
 
         sv.NeedsMigration().Should().BeTrue();
     }
@@ -49,7 +40,7 @@ public sealed class ConfigSchemaVersionTests : IDisposable
     [Fact]
     public void NeedsMigration_AfterStamp_ReturnsFalse()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
         sv.StampCurrentVersion();
 
         sv.NeedsMigration().Should().BeFalse();
@@ -58,7 +49,7 @@ public sealed class ConfigSchemaVersionTests : IDisposable
     [Fact]
     public void ApplyMigrations_FreshInstall_AppliesAndStamps()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
 
         var applied = sv.ApplyMigrations();
 
@@ -69,7 +60,7 @@ public sealed class ConfigSchemaVersionTests : IDisposable
     [Fact]
     public void ApplyMigrations_AlreadyCurrent_ReturnsZero()
     {
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
         sv.StampCurrentVersion();
 
         var applied = sv.ApplyMigrations();
@@ -80,9 +71,9 @@ public sealed class ConfigSchemaVersionTests : IDisposable
     [Fact]
     public void GetStoredVersion_CorruptFile_ReturnsZero()
     {
-        File.WriteAllText(Path.Combine(_tempDir, "schema-version.json"), "not valid json");
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "schema-version.json"), "not valid json");
 
-        var sv = new ConfigSchemaVersion(_tempDir);
+        var sv = new ConfigSchemaVersion(_fixture.DirectoryPath);
 
         sv.GetStoredVersion().Should().Be(0);
     }

--- a/tests/JD.AI.Tests/Config/FileRemoteConfigSourceTests.cs
+++ b/tests/JD.AI.Tests/Config/FileRemoteConfigSourceTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.Config;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Config;
 
 public sealed class FileRemoteConfigSourceTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public FileRemoteConfigSourceTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-frcs-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task FetchAsync_ExistingFile_ReturnsContent()
     {
-        var path = Path.Combine(_tempDir, "config.yaml");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.yaml");
         await File.WriteAllTextAsync(path, "apiVersion: jdai/v1");
 
         var source = new FileRemoteConfigSource(path);
@@ -35,7 +26,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_NonExistentFile_ReturnsNull()
     {
-        var source = new FileRemoteConfigSource(Path.Combine(_tempDir, "missing.yaml"));
+        var source = new FileRemoteConfigSource(Path.Combine(_fixture.DirectoryPath, "missing.yaml"));
         var result = await source.FetchAsync();
 
         result.Should().BeNull();
@@ -44,7 +35,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_UnchangedFile_ReturnsNullOnSecondCall()
     {
-        var path = Path.Combine(_tempDir, "config.yaml");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.yaml");
         await File.WriteAllTextAsync(path, "content: stable");
 
         var source = new FileRemoteConfigSource(path);
@@ -58,7 +49,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_ChangedFile_ReturnsNewContent()
     {
-        var path = Path.Combine(_tempDir, "config.yaml");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.yaml");
         await File.WriteAllTextAsync(path, "version: 1");
 
         var source = new FileRemoteConfigSource(path);
@@ -74,7 +65,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_YamlExtension_SetsContentType()
     {
-        var path = Path.Combine(_tempDir, "config.yaml");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.yaml");
         await File.WriteAllTextAsync(path, "key: value");
 
         var source = new FileRemoteConfigSource(path);
@@ -86,7 +77,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_JsonExtension_SetsContentType()
     {
-        var path = Path.Combine(_tempDir, "config.json");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.json");
         await File.WriteAllTextAsync(path, "{}");
 
         var source = new FileRemoteConfigSource(path);
@@ -98,7 +89,7 @@ public sealed class FileRemoteConfigSourceTests : IDisposable
     [Fact]
     public async Task FetchAsync_SetsVersionAsHash()
     {
-        var path = Path.Combine(_tempDir, "config.yaml");
+        var path = Path.Combine(_fixture.DirectoryPath, "config.yaml");
         await File.WriteAllTextAsync(path, "data: test");
 
         var source = new FileRemoteConfigSource(path);

--- a/tests/JD.AI.Tests/Config/TuiSettingsTests.cs
+++ b/tests/JD.AI.Tests/Config/TuiSettingsTests.cs
@@ -1,5 +1,6 @@
 using JD.AI.Core.Config;
 using JD.AI.Core.PromptCaching;
+using JD.AI.Tests.Fixtures;
 using Xunit;
 
 namespace JD.AI.Tests.Config;
@@ -7,20 +8,17 @@ namespace JD.AI.Tests.Config;
 [Collection("DataDirectories")]
 public sealed class TuiSettingsTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
     public TuiSettingsTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        DataDirectories.SetRoot(_tempDir);
+        DataDirectories.SetRoot(_fixture.DirectoryPath);
     }
 
     public void Dispose()
     {
         DataDirectories.Reset();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best-effort cleanup */ }
+        _fixture.Dispose();
     }
 
     [Fact]
@@ -55,7 +53,7 @@ public sealed class TuiSettingsTests : IDisposable
     [Fact]
     public void Load_CorruptJson_ReturnsDefaults()
     {
-        File.WriteAllText(Path.Combine(_tempDir, "tui-settings.json"), "{{not valid json}}");
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "tui-settings.json"), "{{not valid json}}");
 
         var settings = TuiSettings.Load();
 
@@ -65,7 +63,7 @@ public sealed class TuiSettingsTests : IDisposable
     [Fact]
     public void Load_EmptyFile_ReturnsDefaults()
     {
-        File.WriteAllText(Path.Combine(_tempDir, "tui-settings.json"), "");
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "tui-settings.json"), "");
 
         var settings = TuiSettings.Load();
 
@@ -78,7 +76,7 @@ public sealed class TuiSettingsTests : IDisposable
         var settings = new TuiSettings { SpinnerStyle = SpinnerStyle.Rich };
         settings.Save();
 
-        var path = Path.Combine(_tempDir, "tui-settings.json");
+        var path = Path.Combine(_fixture.DirectoryPath, "tui-settings.json");
         Assert.True(File.Exists(path));
 
         var json = File.ReadAllText(path);

--- a/tests/JD.AI.Tests/DataDirectoriesTests.cs
+++ b/tests/JD.AI.Tests/DataDirectoriesTests.cs
@@ -1,30 +1,28 @@
 using JD.AI.Core.Config;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests;
 
 [Collection("DataDirectories")]
 public sealed class DataDirectoriesTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
     public DataDirectoriesTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
         DataDirectories.Reset();
     }
 
     public void Dispose()
     {
         DataDirectories.Reset();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
+        _fixture.Dispose();
     }
 
     [Fact]
     public void SetRoot_OverridesResolution()
     {
-        var custom = Path.Combine(_tempDir, "custom");
+        var custom = Path.Combine(_fixture.DirectoryPath, "custom");
         DataDirectories.SetRoot(custom);
 
         Assert.Equal(custom, DataDirectories.Root);
@@ -33,45 +31,45 @@ public sealed class DataDirectoriesTests : IDisposable
     [Fact]
     public void SessionsDb_ReturnsPathUnderRoot()
     {
-        DataDirectories.SetRoot(_tempDir);
+        DataDirectories.SetRoot(_fixture.DirectoryPath);
 
-        Assert.Equal(Path.Combine(_tempDir, "sessions.db"), DataDirectories.SessionsDb);
+        Assert.Equal(Path.Combine(_fixture.DirectoryPath, "sessions.db"), DataDirectories.SessionsDb);
     }
 
     [Fact]
     public void VectorsDb_ReturnsPathUnderRoot()
     {
-        DataDirectories.SetRoot(_tempDir);
+        DataDirectories.SetRoot(_fixture.DirectoryPath);
 
-        Assert.Equal(Path.Combine(_tempDir, "vectors.db"), DataDirectories.VectorsDb);
+        Assert.Equal(Path.Combine(_fixture.DirectoryPath, "vectors.db"), DataDirectories.VectorsDb);
     }
 
     [Fact]
     public void OpenClawWorkspace_ReturnsAgentSubdirectory()
     {
-        DataDirectories.SetRoot(_tempDir);
+        DataDirectories.SetRoot(_fixture.DirectoryPath);
 
         var ws = DataDirectories.OpenClawWorkspace("agent-42");
 
-        Assert.Equal(Path.Combine(_tempDir, "openclaw-workspaces", "agent-42"), ws);
+        Assert.Equal(Path.Combine(_fixture.DirectoryPath, "openclaw-workspaces", "agent-42"), ws);
     }
 
     [Fact]
     public void UpdateCacheDir_ReturnsRoot()
     {
-        DataDirectories.SetRoot(_tempDir);
+        DataDirectories.SetRoot(_fixture.DirectoryPath);
 
-        Assert.Equal(_tempDir, DataDirectories.UpdateCacheDir);
+        Assert.Equal(_fixture.DirectoryPath, DataDirectories.UpdateCacheDir);
     }
 
     [Fact]
     public void Reset_ClearsCache_AllowsReresolution()
     {
-        DataDirectories.SetRoot(Path.Combine(_tempDir, "first"));
+        DataDirectories.SetRoot(Path.Combine(_fixture.DirectoryPath, "first"));
         Assert.Contains("first", DataDirectories.Root);
 
         DataDirectories.Reset();
-        DataDirectories.SetRoot(Path.Combine(_tempDir, "second"));
+        DataDirectories.SetRoot(Path.Combine(_fixture.DirectoryPath, "second"));
 
         Assert.Contains("second", DataDirectories.Root);
     }
@@ -79,7 +77,7 @@ public sealed class DataDirectoriesTests : IDisposable
     [Fact]
     public void EnvVar_OverridesAll()
     {
-        var envDir = Path.Combine(_tempDir, "env-override");
+        var envDir = Path.Combine(_fixture.DirectoryPath, "env-override");
         Environment.SetEnvironmentVariable("JDAI_DATA_DIR", envDir);
         try
         {

--- a/tests/JD.AI.Tests/Governance/Audit/FileAuditSinkTests.cs
+++ b/tests/JD.AI.Tests/Governance/Audit/FileAuditSinkTests.cs
@@ -1,26 +1,24 @@
 using System.Text.Json;
 using FluentAssertions;
 using JD.AI.Core.Governance.Audit;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Governance.Audit;
 
 public sealed class FileAuditSinkTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly FileAuditSink _sink;
 
     public FileAuditSinkTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-audit-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _sink = new FileAuditSink(_tempDir);
+        _sink = new FileAuditSink(_fixture.DirectoryPath);
     }
 
     public void Dispose()
     {
         _sink.Dispose();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
+        _fixture.Dispose();
     }
 
     private static AuditEvent MakeEvent(string action = "test") => new()
@@ -43,7 +41,7 @@ public sealed class FileAuditSinkTests : IDisposable
         await _sink.WriteAsync(evt);
 
         var today = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-        var expectedFile = Path.Combine(_tempDir, $"audit-{today}.jsonl");
+        var expectedFile = Path.Combine(_fixture.DirectoryPath, $"audit-{today}.jsonl");
         File.Exists(expectedFile).Should().BeTrue();
     }
 
@@ -60,7 +58,7 @@ public sealed class FileAuditSinkTests : IDisposable
         await _sink.WriteAsync(evt);
 
         var today = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-        var filePath = Path.Combine(_tempDir, $"audit-{today}.jsonl");
+        var filePath = Path.Combine(_fixture.DirectoryPath, $"audit-{today}.jsonl");
         var lines = await File.ReadAllLinesAsync(filePath);
 
         lines.Should().HaveCount(1);
@@ -80,7 +78,7 @@ public sealed class FileAuditSinkTests : IDisposable
         await _sink.WriteAsync(MakeEvent("event-3"));
 
         var today = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-        var filePath = Path.Combine(_tempDir, $"audit-{today}.jsonl");
+        var filePath = Path.Combine(_fixture.DirectoryPath, $"audit-{today}.jsonl");
         var lines = (await File.ReadAllLinesAsync(filePath))
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .ToList();
@@ -101,8 +99,8 @@ public sealed class FileAuditSinkTests : IDisposable
         await _sink.WriteAsync(evt1);
         await _sink.WriteAsync(evt2);
 
-        var yesterdayFile = Path.Combine(_tempDir, $"audit-{yesterday:yyyy-MM-dd}.jsonl");
-        var todayFile = Path.Combine(_tempDir, $"audit-{today:yyyy-MM-dd}.jsonl");
+        var yesterdayFile = Path.Combine(_fixture.DirectoryPath, $"audit-{yesterday:yyyy-MM-dd}.jsonl");
+        var todayFile = Path.Combine(_fixture.DirectoryPath, $"audit-{today:yyyy-MM-dd}.jsonl");
 
         File.Exists(yesterdayFile).Should().BeTrue();
         File.Exists(todayFile).Should().BeTrue();
@@ -126,7 +124,7 @@ public sealed class FileAuditSinkTests : IDisposable
         await Task.WhenAll(tasks);
 
         var today = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture);
-        var filePath = Path.Combine(_tempDir, $"audit-{today}.jsonl");
+        var filePath = Path.Combine(_fixture.DirectoryPath, $"audit-{today}.jsonl");
         var lines = (await File.ReadAllLinesAsync(filePath))
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .ToList();
@@ -137,7 +135,7 @@ public sealed class FileAuditSinkTests : IDisposable
     [Fact]
     public async Task WriteAsync_CreatesDirectoryIfNotExists()
     {
-        var subDir = Path.Combine(_tempDir, "sub", "dir");
+        var subDir = Path.Combine(_fixture.DirectoryPath, "sub", "dir");
         using var sink = new FileAuditSink(subDir);
 
         await sink.WriteAsync(MakeEvent());

--- a/tests/JD.AI.Tests/Governance/BudgetTrackerTests.cs
+++ b/tests/JD.AI.Tests/Governance/BudgetTrackerTests.cs
@@ -1,25 +1,23 @@
 using FluentAssertions;
 using JD.AI.Core.Governance;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Governance;
 
 public sealed class BudgetTrackerTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly BudgetTracker _tracker;
 
     public BudgetTrackerTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-budget-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _tracker = new BudgetTracker(Path.Combine(_tempDir, "budget.json"));
+        _tracker = new BudgetTracker(Path.Combine(_fixture.DirectoryPath, "budget.json"));
     }
 
     public void Dispose()
     {
         _tracker.Dispose();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
+        _fixture.Dispose();
     }
 
     [Fact]
@@ -133,7 +131,7 @@ public sealed class BudgetTrackerTests : IDisposable
         await _tracker.RecordSpendAsync(3.00m, "openai");
 
         // Create a new tracker pointing to the same file
-        using var tracker2 = new BudgetTracker(Path.Combine(_tempDir, "budget.json"));
+        using var tracker2 = new BudgetTracker(Path.Combine(_fixture.DirectoryPath, "budget.json"));
         var status = await tracker2.GetStatusAsync();
 
         status.TodayUsd.Should().Be(3.00m);

--- a/tests/JD.AI.Tests/Governance/OrgInstructionsTests.cs
+++ b/tests/JD.AI.Tests/Governance/OrgInstructionsTests.cs
@@ -1,20 +1,20 @@
 using JD.AI.Core.Agents;
 using JD.AI.Core.Config;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Governance;
 
 [Collection("DataDirectories")]
 public sealed class OrgInstructionsTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly string _orgDir;
     private readonly string _projectDir;
 
     public OrgInstructionsTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-org-test-{Guid.NewGuid():N}");
-        _orgDir = Path.Combine(_tempDir, "org-config");
-        _projectDir = Path.Combine(_tempDir, "project");
+        _orgDir = Path.Combine(_fixture.DirectoryPath, "org-config");
+        _projectDir = Path.Combine(_fixture.DirectoryPath, "project");
 
         Directory.CreateDirectory(_orgDir);
         Directory.CreateDirectory(_projectDir);
@@ -26,8 +26,7 @@ public sealed class OrgInstructionsTests : IDisposable
     {
         Environment.SetEnvironmentVariable("JDAI_ORG_CONFIG", null);
         DataDirectories.Reset();
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
+        _fixture.Dispose();
     }
 
     [Fact]
@@ -80,7 +79,7 @@ public sealed class OrgInstructionsTests : IDisposable
     public void Load_OrgConfigFromFile_UsedWhenEnvVarNotSet()
     {
         // Set up the DataDirectories root to our temp dir
-        var jdaiRootDir = Path.Combine(_tempDir, "jdai-root");
+        var jdaiRootDir = Path.Combine(_fixture.DirectoryPath, "jdai-root");
         Directory.CreateDirectory(jdaiRootDir);
         DataDirectories.SetRoot(jdaiRootDir);
 
@@ -124,7 +123,7 @@ public sealed class OrgInstructionsTests : IDisposable
     [Fact]
     public void Load_OrgConfigEnvVarPointsToNonExistentDir_OrgInstructionsSkipped()
     {
-        Environment.SetEnvironmentVariable("JDAI_ORG_CONFIG", Path.Combine(_tempDir, "nonexistent"));
+        Environment.SetEnvironmentVariable("JDAI_ORG_CONFIG", Path.Combine(_fixture.DirectoryPath, "nonexistent"));
         File.WriteAllText(Path.Combine(_projectDir, "JDAI.md"), "# Project rules");
 
         var result = InstructionsLoader.Load(_projectDir);

--- a/tests/JD.AI.Tests/Governance/PolicyParserTests.cs
+++ b/tests/JD.AI.Tests/Governance/PolicyParserTests.cs
@@ -1,24 +1,15 @@
 using FluentAssertions;
 using JD.AI.Core.Governance;
+using JD.AI.Tests.Fixtures;
 using YamlDotNet.Core;
 
 namespace JD.AI.Tests.Governance;
 
 public sealed class PolicyParserTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public PolicyParserTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-parser-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     private static string MinimalYaml(string name = "test-policy") => $$"""
         apiVersion: jdai/v1
@@ -176,7 +167,7 @@ public sealed class PolicyParserTests : IDisposable
     [Fact]
     public void ParseFile_ValidFile_ReturnsDocument()
     {
-        var filePath = Path.Combine(_tempDir, "policy.yaml");
+        var filePath = Path.Combine(_fixture.DirectoryPath, "policy.yaml");
         File.WriteAllText(filePath, MinimalYaml("file-test"));
 
         var doc = PolicyParser.ParseFile(filePath);
@@ -187,11 +178,11 @@ public sealed class PolicyParserTests : IDisposable
     [Fact]
     public void ParseDirectory_WithYamlFiles_ReturnsAllDocuments()
     {
-        File.WriteAllText(Path.Combine(_tempDir, "p1.yaml"), MinimalYaml("p1"));
-        File.WriteAllText(Path.Combine(_tempDir, "p2.yml"), MinimalYaml("p2"));
-        File.WriteAllText(Path.Combine(_tempDir, "readme.txt"), "not a policy");
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "p1.yaml"), MinimalYaml("p1"));
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "p2.yml"), MinimalYaml("p2"));
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "readme.txt"), "not a policy");
 
-        var docs = PolicyParser.ParseDirectory(_tempDir).ToList();
+        var docs = PolicyParser.ParseDirectory(_fixture.DirectoryPath).ToList();
 
         docs.Should().HaveCount(2);
         docs.Select(d => d.Metadata.Name).Should().Contain(["p1", "p2"]);
@@ -200,7 +191,7 @@ public sealed class PolicyParserTests : IDisposable
     [Fact]
     public void ParseDirectory_NonExistentDirectory_ReturnsEmpty()
     {
-        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+        var nonExistent = Path.Combine(_fixture.DirectoryPath, "does-not-exist");
 
         var docs = PolicyParser.ParseDirectory(nonExistent).ToList();
 
@@ -210,10 +201,10 @@ public sealed class PolicyParserTests : IDisposable
     [Fact]
     public void ParseDirectory_InvalidFileAmongstValid_SkipsInvalid()
     {
-        File.WriteAllText(Path.Combine(_tempDir, "good.yaml"), MinimalYaml("good"));
-        File.WriteAllText(Path.Combine(_tempDir, "bad.yaml"), "bad:\n  yaml:\n    nope:\n  oops");
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "good.yaml"), MinimalYaml("good"));
+        File.WriteAllText(Path.Combine(_fixture.DirectoryPath, "bad.yaml"), "bad:\n  yaml:\n    nope:\n  oops");
 
-        var docs = PolicyParser.ParseDirectory(_tempDir).ToList();
+        var docs = PolicyParser.ParseDirectory(_fixture.DirectoryPath).ToList();
 
         docs.Should().HaveCount(1);
         docs[0].Metadata.Name.Should().Be("good");

--- a/tests/JD.AI.Tests/Governance/PolicyVersionHistoryTests.cs
+++ b/tests/JD.AI.Tests/Governance/PolicyVersionHistoryTests.cs
@@ -1,25 +1,20 @@
 using FluentAssertions;
 using JD.AI.Core.Governance;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Governance;
 
 public sealed class PolicyVersionHistoryTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly string _historyPath;
 
     public PolicyVersionHistoryTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-pvh-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _historyPath = Path.Combine(_tempDir, "policy-history.jsonl");
+        _historyPath = Path.Combine(_fixture.DirectoryPath, "policy-history.jsonl");
     }
 
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public void Record_CreatesHistoryFile()
@@ -88,7 +83,7 @@ public sealed class PolicyVersionHistoryTests : IDisposable
     [Fact]
     public void GetHistory_NoFile_ReturnsEmpty()
     {
-        var noFilePath = Path.Combine(_tempDir, "nonexistent.jsonl");
+        var noFilePath = Path.Combine(_fixture.DirectoryPath, "nonexistent.jsonl");
         var history = new PolicyVersionHistory(noFilePath);
 
         var entries = history.GetHistory();

--- a/tests/JD.AI.Tests/Governance/PolicyWatcherTests.cs
+++ b/tests/JD.AI.Tests/Governance/PolicyWatcherTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.Governance;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Governance;
 
 public sealed class PolicyWatcherTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public PolicyWatcherTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-pw-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public void Constructor_ValidDirectory_CreatesWatchers()
     {
-        using var watcher = new PolicyWatcher([_tempDir], () => { });
+        using var watcher = new PolicyWatcher([_fixture.DirectoryPath], () => { });
 
         // Two watchers per directory (*.yaml + *.yml)
         watcher.WatcherCount.Should().Be(2);
@@ -31,7 +22,7 @@ public sealed class PolicyWatcherTests : IDisposable
     [Fact]
     public void Constructor_NonExistentDirectory_SkipsIt()
     {
-        var nonExistent = Path.Combine(_tempDir, "does-not-exist");
+        var nonExistent = Path.Combine(_fixture.DirectoryPath, "does-not-exist");
 
         using var watcher = new PolicyWatcher([nonExistent], () => { });
 
@@ -41,10 +32,10 @@ public sealed class PolicyWatcherTests : IDisposable
     [Fact]
     public void Constructor_MultipleDirectories_CreatesWatchersForEach()
     {
-        var dir2 = Path.Combine(_tempDir, "sub");
+        var dir2 = Path.Combine(_fixture.DirectoryPath, "sub");
         Directory.CreateDirectory(dir2);
 
-        using var watcher = new PolicyWatcher([_tempDir, dir2], () => { });
+        using var watcher = new PolicyWatcher([_fixture.DirectoryPath, dir2], () => { });
 
         watcher.WatcherCount.Should().Be(4); // 2 per directory
     }
@@ -55,12 +46,12 @@ public sealed class PolicyWatcherTests : IDisposable
         var reloadTriggered = new TaskCompletionSource<bool>();
 
         using var watcher = new PolicyWatcher(
-            [_tempDir],
+            [_fixture.DirectoryPath],
             () => reloadTriggered.TrySetResult(true),
             debounce: TimeSpan.FromMilliseconds(50));
 
         // Create a yaml file to trigger the watcher
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.yaml"), "content: test");
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.yaml"), "content: test");
 
         var result = await Task.WhenAny(
             reloadTriggered.Task,
@@ -75,11 +66,11 @@ public sealed class PolicyWatcherTests : IDisposable
         var reloadTriggered = new TaskCompletionSource<bool>();
 
         using var watcher = new PolicyWatcher(
-            [_tempDir],
+            [_fixture.DirectoryPath],
             () => reloadTriggered.TrySetResult(true),
             debounce: TimeSpan.FromMilliseconds(50));
 
-        await File.WriteAllTextAsync(Path.Combine(_tempDir, "test.yml"), "content: test");
+        await File.WriteAllTextAsync(Path.Combine(_fixture.DirectoryPath, "test.yml"), "content: test");
 
         var result = await Task.WhenAny(
             reloadTriggered.Task,
@@ -91,7 +82,7 @@ public sealed class PolicyWatcherTests : IDisposable
     [Fact]
     public void Dispose_ClearsWatchers()
     {
-        var watcher = new PolicyWatcher([_tempDir], () => { });
+        var watcher = new PolicyWatcher([_fixture.DirectoryPath], () => { });
         watcher.WatcherCount.Should().Be(2);
 
         watcher.Dispose();
@@ -102,7 +93,7 @@ public sealed class PolicyWatcherTests : IDisposable
     [Fact]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
-        var watcher = new PolicyWatcher([_tempDir], () => { });
+        var watcher = new PolicyWatcher([_fixture.DirectoryPath], () => { });
 
         var act = () =>
         {

--- a/tests/JD.AI.Tests/Governance/WorkflowStore/FileWorkflowStoreTests.cs
+++ b/tests/JD.AI.Tests/Governance/WorkflowStore/FileWorkflowStoreTests.cs
@@ -1,24 +1,20 @@
 using FluentAssertions;
+using JD.AI.Tests.Fixtures;
 using JD.AI.Workflows.Store;
 
 namespace JD.AI.Tests.Governance.WorkflowStore;
 
 public class FileWorkflowStoreTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly FileWorkflowStore _store;
 
     public FileWorkflowStoreTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-store-{Guid.NewGuid():N}");
-        _store = new FileWorkflowStore(_tempDir);
+        _store = new FileWorkflowStore(_fixture.DirectoryPath);
     }
 
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     private static SharedWorkflow MakeWorkflow(
         string name = "test-workflow",
@@ -45,7 +41,7 @@ public class FileWorkflowStoreTests : IDisposable
 
         await _store.PublishAsync(workflow);
 
-        var expectedPath = Path.Combine(_tempDir, "my-workflow", "1.0.0.json");
+        var expectedPath = Path.Combine(_fixture.DirectoryPath, "my-workflow", "1.0.0.json");
         File.Exists(expectedPath).Should().BeTrue();
     }
 
@@ -56,7 +52,7 @@ public class FileWorkflowStoreTests : IDisposable
 
         await _store.PublishAsync(workflow);
 
-        var path = Path.Combine(_tempDir, "json-check", "1.0.0.json");
+        var path = Path.Combine(_fixture.DirectoryPath, "json-check", "1.0.0.json");
         var content = await File.ReadAllTextAsync(path);
         content.Should().Contain("\"name\":");
         content.Should().Contain("json-check");
@@ -68,7 +64,7 @@ public class FileWorkflowStoreTests : IDisposable
         await _store.PublishAsync(MakeWorkflow("multi", "1.0.0"));
         await _store.PublishAsync(MakeWorkflow("multi", "2.0.0"));
 
-        var dir = Path.Combine(_tempDir, "multi");
+        var dir = Path.Combine(_fixture.DirectoryPath, "multi");
         Directory.GetFiles(dir, "*.json").Should().HaveCount(2);
     }
 
@@ -254,7 +250,7 @@ public class FileWorkflowStoreTests : IDisposable
     [Fact]
     public async Task Install_CopiesWorkflowToLocalDirectory()
     {
-        var installDir = Path.Combine(_tempDir, "installed");
+        var installDir = Path.Combine(_fixture.DirectoryPath, "installed");
         await _store.PublishAsync(MakeWorkflow("installable", "1.0.0"));
 
         var result = await _store.InstallAsync("installable", "1.0.0", installDir);
@@ -267,7 +263,7 @@ public class FileWorkflowStoreTests : IDisposable
     [Fact]
     public async Task Install_CreatesLocalDirectory_IfNotExists()
     {
-        var installDir = Path.Combine(_tempDir, "new-install-dir");
+        var installDir = Path.Combine(_fixture.DirectoryPath, "new-install-dir");
         await _store.PublishAsync(MakeWorkflow("installable2", "1.0.0"));
 
         Directory.Exists(installDir).Should().BeFalse();
@@ -280,7 +276,7 @@ public class FileWorkflowStoreTests : IDisposable
     [Fact]
     public async Task Install_NonExistentWorkflow_ReturnsFalse()
     {
-        var installDir = Path.Combine(_tempDir, "install-fail");
+        var installDir = Path.Combine(_fixture.DirectoryPath, "install-fail");
 
         var result = await _store.InstallAsync("nonexistent", "1.0.0", installDir);
 
@@ -290,7 +286,7 @@ public class FileWorkflowStoreTests : IDisposable
     [Fact]
     public async Task Install_InstalledFileContainsWorkflowJson()
     {
-        var installDir = Path.Combine(_tempDir, "install-verify");
+        var installDir = Path.Combine(_fixture.DirectoryPath, "install-verify");
         var workflow = new SharedWorkflow
         {
             Name = "verify-wf",

--- a/tests/JD.AI.Tests/LocalModels/DirectoryModelSourceTests.cs
+++ b/tests/JD.AI.Tests/LocalModels/DirectoryModelSourceTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.LocalModels.Sources;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.LocalModels;
 
 public class DirectoryModelSourceTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public DirectoryModelSourceTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-dirscan-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task ScanAsync_EmptyDir_ReturnsEmpty()
     {
-        var source = new DirectoryModelSource(_tempDir);
+        var source = new DirectoryModelSource(_fixture.DirectoryPath);
         var models = await source.ScanAsync();
         models.Should().BeEmpty();
     }
@@ -30,11 +21,11 @@ public class DirectoryModelSourceTests : IDisposable
     [Fact]
     public async Task ScanAsync_FindsGgufFiles()
     {
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "model-a-Q4_K_M.gguf"), new byte[128]);
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "model-b.gguf"), new byte[64]);
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "readme.txt"), new byte[32]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "model-a-Q4_K_M.gguf"), new byte[128]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "model-b.gguf"), new byte[64]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "readme.txt"), new byte[32]);
 
-        var source = new DirectoryModelSource(_tempDir);
+        var source = new DirectoryModelSource(_fixture.DirectoryPath);
         var models = await source.ScanAsync();
 
         models.Should().HaveCount(2);
@@ -43,9 +34,9 @@ public class DirectoryModelSourceTests : IDisposable
     [Fact]
     public async Task ScanAsync_ParsesQuantization()
     {
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "llama-7b-Q4_K_M.gguf"), new byte[128]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "llama-7b-Q4_K_M.gguf"), new byte[128]);
 
-        var source = new DirectoryModelSource(_tempDir);
+        var source = new DirectoryModelSource(_fixture.DirectoryPath);
         var models = await source.ScanAsync();
 
         models.Should().ContainSingle();
@@ -55,11 +46,11 @@ public class DirectoryModelSourceTests : IDisposable
     [Fact]
     public async Task ScanAsync_RecursiveSubdirs()
     {
-        var subDir = Path.Combine(_tempDir, "subfolder");
+        var subDir = Path.Combine(_fixture.DirectoryPath, "subfolder");
         Directory.CreateDirectory(subDir);
         await File.WriteAllBytesAsync(Path.Combine(subDir, "nested.gguf"), new byte[64]);
 
-        var source = new DirectoryModelSource(_tempDir);
+        var source = new DirectoryModelSource(_fixture.DirectoryPath);
         var models = await source.ScanAsync();
 
         models.Should().ContainSingle();
@@ -68,7 +59,7 @@ public class DirectoryModelSourceTests : IDisposable
     [Fact]
     public async Task ScanAsync_NonexistentDir_ReturnsEmpty()
     {
-        var source = new DirectoryModelSource(Path.Combine(_tempDir, "nope"));
+        var source = new DirectoryModelSource(Path.Combine(_fixture.DirectoryPath, "nope"));
         var models = await source.ScanAsync();
         models.Should().BeEmpty();
     }

--- a/tests/JD.AI.Tests/LocalModels/FileModelSourceTests.cs
+++ b/tests/JD.AI.Tests/LocalModels/FileModelSourceTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.LocalModels.Sources;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.LocalModels;
 
 public class FileModelSourceTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public FileModelSourceTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-file-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task ScanAsync_ValidGguf_ReturnsSingleModel()
     {
-        var path = Path.Combine(_tempDir, "test-model-Q5_K_M.gguf");
+        var path = Path.Combine(_fixture.DirectoryPath, "test-model-Q5_K_M.gguf");
         await File.WriteAllBytesAsync(path, new byte[512]);
 
         var source = new FileModelSource(path);
@@ -45,7 +36,7 @@ public class FileModelSourceTests : IDisposable
     [Fact]
     public async Task ScanAsync_NonGgufFile_ReturnsEmpty()
     {
-        var path = Path.Combine(_tempDir, "readme.txt");
+        var path = Path.Combine(_fixture.DirectoryPath, "readme.txt");
         await File.WriteAllTextAsync(path, "hello");
 
         var source = new FileModelSource(path);

--- a/tests/JD.AI.Tests/LocalModels/LocalModelDetectorTests.cs
+++ b/tests/JD.AI.Tests/LocalModels/LocalModelDetectorTests.cs
@@ -1,29 +1,20 @@
 using FluentAssertions;
 using JD.AI.Core.LocalModels;
 using JD.AI.Core.Providers;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.LocalModels;
 
 public class LocalModelDetectorTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public LocalModelDetectorTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-detector-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task DetectAsync_NoModels_NotAvailable()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         var detector = new LocalModelDetector(registry);
 
         var info = await detector.DetectAsync();
@@ -38,10 +29,10 @@ public class LocalModelDetectorTests : IDisposable
     public async Task DetectAsync_WithModels_Available()
     {
         // Create a dummy GGUF file
-        var ggufPath = Path.Combine(_tempDir, "test-7b-Q4_K_M.gguf");
+        var ggufPath = Path.Combine(_fixture.DirectoryPath, "test-7b-Q4_K_M.gguf");
         await File.WriteAllBytesAsync(ggufPath, new byte[1024]);
 
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         var detector = new LocalModelDetector(registry);
 
         var info = await detector.DetectAsync();
@@ -62,10 +53,10 @@ public class LocalModelDetectorTests : IDisposable
     [Fact]
     public async Task DetectAsync_MultipleModels_ReturnsAll()
     {
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "model-a-Q4_K_M.gguf"), new byte[512]);
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "model-b-Q5_K_S.gguf"), new byte[768]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "model-a-Q4_K_M.gguf"), new byte[512]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "model-b-Q5_K_S.gguf"), new byte[768]);
 
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         var detector = new LocalModelDetector(registry);
 
         var info = await detector.DetectAsync();
@@ -77,13 +68,13 @@ public class LocalModelDetectorTests : IDisposable
     [Fact]
     public async Task DetectAsync_PersistsRegistry()
     {
-        await File.WriteAllBytesAsync(Path.Combine(_tempDir, "persist-test.gguf"), new byte[256]);
+        await File.WriteAllBytesAsync(Path.Combine(_fixture.DirectoryPath, "persist-test.gguf"), new byte[256]);
 
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         var detector = new LocalModelDetector(registry);
         await detector.DetectAsync();
 
         // Registry file should exist now
-        File.Exists(Path.Combine(_tempDir, "registry.json")).Should().BeTrue();
+        File.Exists(Path.Combine(_fixture.DirectoryPath, "registry.json")).Should().BeTrue();
     }
 }

--- a/tests/JD.AI.Tests/LocalModels/LocalModelRegistryTests.cs
+++ b/tests/JD.AI.Tests/LocalModels/LocalModelRegistryTests.cs
@@ -1,28 +1,19 @@
 using FluentAssertions;
 using JD.AI.Core.LocalModels;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.LocalModels;
 
 public class LocalModelRegistryTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public LocalModelRegistryTests()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, recursive: true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task LoadAsync_EmptyDir_CreatesEmptyRegistry()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         await registry.LoadAsync();
 
         registry.Models.Should().BeEmpty();
@@ -31,7 +22,7 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public async Task SaveAndLoad_RoundTrips()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
 
         var ggufPath = CreateDummyGguf("test-model.gguf");
 
@@ -46,7 +37,7 @@ public class LocalModelRegistryTests : IDisposable
         await registry.SaveAsync();
 
         // Load in a new instance
-        var registry2 = new LocalModelRegistry(_tempDir);
+        var registry2 = new LocalModelRegistry(_fixture.DirectoryPath);
         await registry2.LoadAsync();
 
         registry2.Models.Should().HaveCount(1);
@@ -61,8 +52,8 @@ public class LocalModelRegistryTests : IDisposable
         CreateDummyGguf("model-b.gguf");
         CreateDummyGguf("not-a-model.txt");
 
-        var registry = new LocalModelRegistry(_tempDir);
-        await registry.ScanDirectoryAsync(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
+        await registry.ScanDirectoryAsync(_fixture.DirectoryPath);
 
         registry.Models.Should().HaveCount(2);
     }
@@ -72,7 +63,7 @@ public class LocalModelRegistryTests : IDisposable
     {
         var path = CreateDummyGguf("single.gguf");
 
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         await registry.AddFileAsync(path);
 
         registry.Models.Should().HaveCount(1);
@@ -82,7 +73,7 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public void Find_ByExactId()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Add(new ModelMetadata
         {
             Id = "llama-7b-q4",
@@ -96,7 +87,7 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public void Find_BySubstring()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Add(new ModelMetadata
         {
             Id = "meta-llama-3-8b-instruct-q4_k_m",
@@ -110,14 +101,14 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public void Find_NoMatch_ReturnsNull()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Find("nonexistent").Should().BeNull();
     }
 
     [Fact]
     public void Remove_ById_Succeeds()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Add(new ModelMetadata
         {
             Id = "to-remove",
@@ -132,14 +123,14 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public void Remove_NotFound_ReturnsFalse()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Remove("nope").Should().BeFalse();
     }
 
     [Fact]
     public void Add_Deduplicates_BySamePath()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         var model = new ModelMetadata
         {
             Id = "model1",
@@ -157,17 +148,17 @@ public class LocalModelRegistryTests : IDisposable
     [Fact]
     public async Task Load_RemovesMissingFiles()
     {
-        var registry = new LocalModelRegistry(_tempDir);
+        var registry = new LocalModelRegistry(_fixture.DirectoryPath);
         registry.Add(new ModelMetadata
         {
             Id = "ghost",
             DisplayName = "Ghost Model",
-            FilePath = Path.Combine(_tempDir, "ghost.gguf"),
+            FilePath = Path.Combine(_fixture.DirectoryPath, "ghost.gguf"),
         });
         await registry.SaveAsync();
 
         // Reload — file doesn't exist, should be pruned
-        var registry2 = new LocalModelRegistry(_tempDir);
+        var registry2 = new LocalModelRegistry(_fixture.DirectoryPath);
         await registry2.LoadAsync();
 
         registry2.Models.Should().BeEmpty();
@@ -175,7 +166,7 @@ public class LocalModelRegistryTests : IDisposable
 
     private string CreateDummyGguf(string filename)
     {
-        var path = Path.Combine(_tempDir, filename);
+        var path = Path.Combine(_fixture.DirectoryPath, filename);
         File.WriteAllBytes(path, new byte[256]);
         return path;
     }

--- a/tests/JD.AI.Tests/MigrationToolsTests.cs
+++ b/tests/JD.AI.Tests/MigrationToolsTests.cs
@@ -1,25 +1,20 @@
 using JD.AI.Core.Tools;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests;
 
 public class MigrationToolsTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly string _claudeDir;
 
     public MigrationToolsTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-migration-test-{Guid.NewGuid():N}");
-        _claudeDir = Path.Combine(_tempDir, ".claude");
+        _claudeDir = Path.Combine(_fixture.DirectoryPath, ".claude");
         Directory.CreateDirectory(_claudeDir);
     }
 
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, true);
-        GC.SuppressFinalize(this);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     // ── migration_scan ───────────────────────────────────────
 
@@ -160,7 +155,7 @@ public class MigrationToolsTests : IDisposable
     [Fact]
     public void Convert_FromFile_WorksCorrectly()
     {
-        var filePath = Path.Combine(_tempDir, "CLAUDE.md");
+        var filePath = Path.Combine(_fixture.DirectoryPath, "CLAUDE.md");
         File.WriteAllText(filePath, "Use claude code tools.\nSee CLAUDE.md.");
 
         var result = MigrationTools.ConvertInstructions(filePath);

--- a/tests/JD.AI.Tests/Providers/ApiKeyDetectorTests.cs
+++ b/tests/JD.AI.Tests/Providers/ApiKeyDetectorTests.cs
@@ -1,28 +1,23 @@
 using FluentAssertions;
 using JD.AI.Core.Providers;
 using JD.AI.Core.Providers.Credentials;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Providers;
 
 public sealed class ApiKeyDetectorTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly EncryptedFileStore _store;
     private readonly ProviderConfigurationManager _config;
 
     public ApiKeyDetectorTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-det-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _store = new EncryptedFileStore(_tempDir);
+        _store = new EncryptedFileStore(_fixture.DirectoryPath);
         _config = new ProviderConfigurationManager(_store);
     }
 
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task OpenAIDetector_NoApiKey_ReturnsUnavailable()

--- a/tests/JD.AI.Tests/Providers/Credentials/EncryptedFileStoreTests.cs
+++ b/tests/JD.AI.Tests/Providers/Credentials/EncryptedFileStoreTests.cs
@@ -5,32 +5,21 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using JD.AI.Core.Providers.Credentials;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Providers.Credentials;
 
 public sealed class EncryptedFileStoreTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly EncryptedFileStore _store;
 
     public EncryptedFileStoreTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-efstore-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _store = new EncryptedFileStore(_tempDir);
+        _store = new EncryptedFileStore(_fixture.DirectoryPath);
     }
 
-    public void Dispose()
-    {
-        try
-        {
-            Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-            // Best-effort cleanup.
-        }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task GetAsync_NonExistentKey_ReturnsNull()
@@ -101,12 +90,12 @@ public sealed class EncryptedFileStoreTests : IDisposable
     [Fact]
     public async Task GetAsync_MountedSecretFallback_ReturnsValue()
     {
-        var mountDir = Path.Combine(_tempDir, "mounted");
+        var mountDir = Path.Combine(_fixture.DirectoryPath, "mounted");
         Directory.CreateDirectory(mountDir);
         await File.WriteAllTextAsync(Path.Combine(mountDir, "provider__token"), "mounted-token-value");
 
         var store = new EncryptedFileStore(
-            basePath: _tempDir,
+            basePath: _fixture.DirectoryPath,
             options: new EncryptedFileStoreOptions
             {
                 MountedSecretsPath = mountDir,
@@ -129,8 +118,8 @@ public sealed class EncryptedFileStoreTests : IDisposable
         const string Plaintext = "legacy-value";
 
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(Key)))[..16];
-        var mapPath = Path.Combine(_tempDir, "keymap.json");
-        var payloadPath = Path.Combine(_tempDir, $"{hash}.enc");
+        var mapPath = Path.Combine(_fixture.DirectoryPath, "keymap.json");
+        var payloadPath = Path.Combine(_fixture.DirectoryPath, $"{hash}.enc");
         await File.WriteAllTextAsync(mapPath, JsonSerializer.Serialize(new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [Key] = hash,
@@ -149,7 +138,7 @@ public sealed class EncryptedFileStoreTests : IDisposable
         var httpClient = new HttpClient(handler);
 
         var store = new EncryptedFileStore(
-            basePath: _tempDir,
+            basePath: _fixture.DirectoryPath,
             httpClient: httpClient,
             options: new EncryptedFileStoreOptions
             {

--- a/tests/JD.AI.Tests/Providers/Credentials/ProviderConfigurationManagerTests.cs
+++ b/tests/JD.AI.Tests/Providers/Credentials/ProviderConfigurationManagerTests.cs
@@ -1,27 +1,22 @@
 using FluentAssertions;
 using JD.AI.Core.Providers.Credentials;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Providers.Credentials;
 
 public sealed class ProviderConfigurationManagerTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly EncryptedFileStore _store;
     private readonly ProviderConfigurationManager _manager;
 
     public ProviderConfigurationManagerTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-pcm-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _store = new EncryptedFileStore(_tempDir);
+        _store = new EncryptedFileStore(_fixture.DirectoryPath);
         _manager = new ProviderConfigurationManager(_store);
     }
 
-    public void Dispose()
-    {
-        try { Directory.Delete(_tempDir, recursive: true); }
-        catch { /* best effort cleanup */ }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task GetCredentialAsync_FromStore_ReturnsStoreValue()

--- a/tests/JD.AI.Tests/Providers/OpenAICodexDetectorTests.cs
+++ b/tests/JD.AI.Tests/Providers/OpenAICodexDetectorTests.cs
@@ -1,32 +1,21 @@
 using FluentAssertions;
 using JD.AI.Core.Providers;
+using JD.AI.Tests.Fixtures;
 using JD.SemanticKernel.Connectors.OpenAICodex;
 
 namespace JD.AI.Tests.Providers;
 
 public sealed class OpenAICodexDetectorTests : IDisposable
 {
-    private readonly string _tempDir;
+    private readonly TempDirectoryFixture _fixture = new();
     private readonly string _cachePath;
 
     public OpenAICodexDetectorTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-codex-cache-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDir);
-        _cachePath = Path.Combine(_tempDir, "models_cache.json");
+        _cachePath = Path.Combine(_fixture.DirectoryPath, "models_cache.json");
     }
 
-    public void Dispose()
-    {
-        try
-        {
-            Directory.Delete(_tempDir, recursive: true);
-        }
-        catch
-        {
-            // Best-effort cleanup for temp directory.
-        }
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public void ReadModelsFromCache_FiltersAndSortsVisibleApiModels()
@@ -70,7 +59,7 @@ public sealed class OpenAICodexDetectorTests : IDisposable
     [Fact]
     public void ApplyCredentialOverridesFromAuthFile_UsesApiKeyWhenPresent()
     {
-        var authPath = Path.Combine(_tempDir, "auth.json");
+        var authPath = Path.Combine(_fixture.DirectoryPath, "auth.json");
         File.WriteAllText(authPath, """
                                     {
                                       "OPENAI_API_KEY": "sk-codex-from-file",
@@ -91,7 +80,7 @@ public sealed class OpenAICodexDetectorTests : IDisposable
     [Fact]
     public void ApplyCredentialOverridesFromAuthFile_UsesNestedIdTokenWhenApiKeyMissing()
     {
-        var authPath = Path.Combine(_tempDir, "auth.json");
+        var authPath = Path.Combine(_fixture.DirectoryPath, "auth.json");
         File.WriteAllText(authPath, """
                                     {
                                       "tokens": {
@@ -112,7 +101,7 @@ public sealed class OpenAICodexDetectorTests : IDisposable
     [Fact]
     public void ApplyCredentialOverridesFromAuthFile_IgnoresMalformedJson()
     {
-        var authPath = Path.Combine(_tempDir, "auth.json");
+        var authPath = Path.Combine(_fixture.DirectoryPath, "auth.json");
         File.WriteAllText(authPath, "{not-json");
 
         var options = new CodexSessionOptions { CredentialsPath = authPath };

--- a/tests/JD.AI.Tests/SessionExporterTests.cs
+++ b/tests/JD.AI.Tests/SessionExporterTests.cs
@@ -1,22 +1,13 @@
 using JD.AI.Core.Sessions;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests;
 
 public sealed class SessionExporterTests : IDisposable
 {
-    private readonly string _basePath;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public SessionExporterTests()
-    {
-        _basePath = Path.Combine(Path.GetTempPath(), $"jdai_export_test_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_basePath);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_basePath))
-            Directory.Delete(_basePath, recursive: true);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public async Task ExportAndImport_RoundTrips()
@@ -55,10 +46,10 @@ public sealed class SessionExporterTests : IDisposable
             TokensOut = 10,
         });
 
-        await SessionExporter.ExportAsync(session, _basePath);
+        await SessionExporter.ExportAsync(session, _fixture.DirectoryPath);
 
         // Verify file exists
-        var files = SessionExporter.ListExportedFiles("exphash1", _basePath).ToList();
+        var files = SessionExporter.ListExportedFiles("exphash1", _fixture.DirectoryPath).ToList();
         Assert.Single(files);
 
         // Import and verify
@@ -82,7 +73,7 @@ public sealed class SessionExporterTests : IDisposable
     [Fact]
     public void ListExportedFiles_EmptyDir_ReturnsEmpty()
     {
-        var files = SessionExporter.ListExportedFiles("nohash", _basePath);
+        var files = SessionExporter.ListExportedFiles("nohash", _fixture.DirectoryPath);
         Assert.Empty(files);
     }
 }

--- a/tests/JD.AI.Tests/Skills/SkillRuntimeConfigLoaderTests.cs
+++ b/tests/JD.AI.Tests/Skills/SkillRuntimeConfigLoaderTests.cs
@@ -1,22 +1,19 @@
 using JD.AI.Core.Skills;
+using JD.AI.Tests.Fixtures;
 
 namespace JD.AI.Tests.Skills;
 
 public sealed class SkillRuntimeConfigLoaderTests : IDisposable
 {
-    private readonly string _root;
+    private readonly TempDirectoryFixture _fixture = new();
 
-    public SkillRuntimeConfigLoaderTests()
-    {
-        _root = Path.Combine(Path.GetTempPath(), $"jdai-skill-config-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_root);
-    }
+    public void Dispose() => _fixture.Dispose();
 
     [Fact]
     public void Load_MergesUserAndWorkspaceWithWorkspaceOverride()
     {
-        var userPath = Path.Combine(_root, "user.json");
-        var workspacePath = Path.Combine(_root, "workspace.json");
+        var userPath = Path.Combine(_fixture.DirectoryPath, "user.json");
+        var workspacePath = Path.Combine(_fixture.DirectoryPath, "workspace.json");
 
         File.WriteAllText(userPath, """
             {
@@ -69,8 +66,8 @@ public sealed class SkillRuntimeConfigLoaderTests : IDisposable
     [Fact]
     public void Load_InvalidFilesFallsBackToDefaults()
     {
-        var userPath = Path.Combine(_root, "bad-user.json");
-        var workspacePath = Path.Combine(_root, "bad-workspace.json");
+        var userPath = Path.Combine(_fixture.DirectoryPath, "bad-user.json");
+        var workspacePath = Path.Combine(_fixture.DirectoryPath, "bad-workspace.json");
 
         File.WriteAllText(userPath, "{ this is invalid json }");
         File.WriteAllText(workspacePath, "[]");
@@ -84,20 +81,4 @@ public sealed class SkillRuntimeConfigLoaderTests : IDisposable
         Assert.Null(config.RootConfig);
     }
 
-    public void Dispose()
-    {
-        try
-        {
-            if (Directory.Exists(_root))
-                Directory.Delete(_root, recursive: true);
-        }
-        catch (IOException)
-        {
-            // Best effort temp cleanup.
-        }
-        catch (UnauthorizedAccessException)
-        {
-            // Best effort temp cleanup.
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Migrate 24 test files from duplicated IDisposable + temp directory boilerplate to the shared TempDirectoryFixture class.

## Changes
- Replace manual Path.Combine(Path.GetTempPath(), ...) + Directory.CreateDirectory constructor patterns with TempDirectoryFixture
- Replace _tempDir/_basePath/_root field references with _fixture.DirectoryPath
- Simplify Dispose() methods to delegate to _fixture.Dispose()
- Fix import ordering in 2 files

## Impact
- **24 files modified**
- **~170 net lines removed** (220 additions, 391 deletions)
- Zero test logic changes — only infrastructure boilerplate
- Build: 0 errors ✅
- Tests: all pass ✅

## Tier 1d of Comprehensive Code Cleanup Plan