### PR TITLE
refactor: migrate remaining ProcessStartInfo to ProcessExecutor + add Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
           name: coverage-report
           path: coverage-report
 
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-report/Cobertura.xml
+          fail_ci_if_error: false
+
       - name: Add coverage summary to PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JD.AI
 
 [![CI](https://github.com/JerrettDavis/JD.AI/actions/workflows/ci.yml/badge.svg)](https://github.com/JerrettDavis/JD.AI/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/JerrettDavis/JD.AI/graph/badge.svg)](https://codecov.io/gh/JerrettDavis/JD.AI)
 [![NuGet](https://img.shields.io/nuget/v/JD.AI.svg)](https://www.nuget.org/packages/JD.AI)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)

--- a/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
+++ b/src/JD.AI.Core/Providers/ClaudeCodeDetector.cs
@@ -1,5 +1,5 @@
-using System.Diagnostics;
 using Anthropic.SDK;
+using JD.AI.Core.Infrastructure;
 using JD.SemanticKernel.Connectors.ClaudeCode;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -164,32 +164,12 @@ public sealed class ClaudeCodeDetector : IProviderDetector
 
             Console.WriteLine("  ↻ Attempting Claude session refresh...");
 
-            var psi = new ProcessStartInfo
-            {
-                FileName = claudePath,
-                Arguments = "--version",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
+            var result = await ProcessExecutor.RunAsync(
+                claudePath, "--version",
+                timeout: TimeSpan.FromSeconds(15),
+                cancellationToken: ct).ConfigureAwait(false);
 
-            using var proc = Process.Start(psi);
-            if (proc is null) return false;
-
-            // Drain stdout/stderr to prevent pipe buffer deadlocks, then
-            // wait for exit with a timeout so detection never hangs.
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(TimeSpan.FromSeconds(15));
-            var token = cts.Token;
-
-            var stdoutTask = proc.StandardOutput.ReadToEndAsync(token);
-            var stderrTask = proc.StandardError.ReadToEndAsync(token);
-
-            await proc.WaitForExitAsync(token).ConfigureAwait(false);
-            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
-
-            return proc.ExitCode == 0;
+            return result.Success;
         }
 #pragma warning disable CA1031 // best-effort refresh
         catch

--- a/src/JD.AI.Core/Providers/CopilotDetector.cs
+++ b/src/JD.AI.Core/Providers/CopilotDetector.cs
@@ -1,3 +1,4 @@
+using JD.AI.Core.Infrastructure;
 using JD.SemanticKernel.Connectors.GitHubCopilot;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -149,32 +150,12 @@ public sealed class CopilotDetector : IProviderDetector
 
             Console.WriteLine("  ↻ Attempting GitHub Copilot auth refresh...");
 
-            var psi = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = ghPath,
-                Arguments = "auth status",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
+            var result = await ProcessExecutor.RunAsync(
+                ghPath, "auth status",
+                timeout: TimeSpan.FromSeconds(15),
+                cancellationToken: ct).ConfigureAwait(false);
 
-            using var proc = System.Diagnostics.Process.Start(psi);
-            if (proc is null) return false;
-
-            // Drain stdout/stderr to prevent pipe buffer deadlocks, then
-            // wait for exit with a timeout so detection never hangs.
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(TimeSpan.FromSeconds(15));
-            var token = cts.Token;
-
-            var stdoutTask = proc.StandardOutput.ReadToEndAsync(token);
-            var stderrTask = proc.StandardError.ReadToEndAsync(token);
-
-            await proc.WaitForExitAsync(token).ConfigureAwait(false);
-            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
-
-            return proc.ExitCode == 0;
+            return result.Success;
         }
 #pragma warning disable CA1031 // best-effort refresh
         catch { return false; }

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -448,22 +448,14 @@ static async Task RunUpdateCommandAsync(bool checkOnly)
     }
 
     Console.WriteLine("Applying update via 'dotnet tool update'...");
-    var process = new System.Diagnostics.Process
-    {
-        StartInfo = new System.Diagnostics.ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = $"tool update -g {host.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<UpdateConfig>>().Value.PackageId}",
-            UseShellExecute = false,
-        },
-    };
+    var packageId = host.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<UpdateConfig>>().Value.PackageId;
+    var updateResult = await JD.AI.Core.Infrastructure.ProcessExecutor.RunAsync(
+        "dotnet", $"tool update -g {packageId}",
+        timeout: TimeSpan.FromSeconds(120)).ConfigureAwait(false);
 
-    process.Start();
-    await process.WaitForExitAsync();
-
-    if (process.ExitCode != 0)
+    if (!updateResult.Success)
     {
-        Console.WriteLine("✗ Update failed. Check the output above.");
+        Console.WriteLine($"✗ Update failed: {updateResult.StandardError}");
         return;
     }
 

--- a/src/JD.AI/UpdateChecker.cs
+++ b/src/JD.AI/UpdateChecker.cs
@@ -87,25 +87,15 @@ public static class UpdateChecker
     /// </summary>
     public static async Task<(bool Success, string Output)> ApplyUpdateAsync(CancellationToken ct = default)
     {
-        var psi = new System.Diagnostics.ProcessStartInfo
-        {
-            FileName = "dotnet",
-            Arguments = $"tool update -g {PackageId}",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
+        var result = await ProcessExecutor.RunAsync(
+            "dotnet", $"tool update -g {PackageId}",
+            timeout: TimeSpan.FromSeconds(120),
+            cancellationToken: ct).ConfigureAwait(false);
 
-        using var proc = System.Diagnostics.Process.Start(psi);
-        if (proc is null) return (false, "Failed to start dotnet process.");
-
-        var stdout = await proc.StandardOutput.ReadToEndAsync(ct).ConfigureAwait(false);
-        var stderr = await proc.StandardError.ReadToEndAsync(ct).ConfigureAwait(false);
-        await proc.WaitForExitAsync(ct).ConfigureAwait(false);
-
-        var output = string.IsNullOrWhiteSpace(stderr) ? stdout : $"{stdout}\n{stderr}";
-        return (proc.ExitCode == 0, output.Trim());
+        var output = string.IsNullOrWhiteSpace(result.StandardError)
+            ? result.StandardOutput
+            : $"{result.StandardOutput}\n{result.StandardError}";
+        return (result.Success, output.Trim());
     }
 
     /// <summary>Compares two semver-ish version strings. Returns true if latest > current.</summary>


### PR DESCRIPTION
## Summary

Completes **Tier 1a** of the cleanup plan by migrating the last 4 files with raw `ProcessStartInfo` patterns to the shared `ProcessExecutor` utility.

### ProcessExecutor migrations (4 files, -50 lines)
- **ClaudeCodeDetector.cs** — `--version` check for auth refresh
- **CopilotDetector.cs** — `gh auth status` check for auth refresh
- **UpdateChecker.cs** — `dotnet tool update -g` invocation
- **Daemon/Program.cs** — `dotnet tool update -g` invocation

### Codecov integration
- Added `codecov/codecov-action@v5` step to CI workflow (uploads combined Cobertura report)
- Added Codecov badge to README.md

### What's left using raw ProcessStartInfo (intentionally)
- **ProcessSessionManager.cs** — Interactive PTY sessions (requires stdin/stdout streaming)
- **SignalChannel.cs** — Long-lived JSON-RPC daemon (bidirectional IPC)
- **OllamaModelSearch.cs / FoundryLocalModelSearch.cs** — Streaming progress callbacks during model pulls