### PR TITLE
Docs: clarify OpenClaw bridge hijack vs native channel switching

### DIFF
--- a/docs/developer-guide/channels.md
+++ b/docs/developer-guide/channels.md
@@ -60,6 +60,16 @@ public interface ICommandAwareChannel
 
 The gateway automatically registers commands with command-aware channels after connection. Discord and Slack support native slash commands; Signal uses prefix commands (`!jdai-help`).
 
+### Native commands vs OpenClaw bridge commands
+
+- Native adapters (Discord/Slack/Signal) register channel commands directly (for example, `/jdai-route` on Discord/Slack or `!jdai-route` on Signal).
+- OpenClaw does not register platform-native JD.AI commands. Instead, the OpenClaw routing service intercepts `/jdai-...` messages inside bridge sessions and executes them via the gateway command registry.
+
+Use this model when documenting runtime handoff:
+
+- **Native channels:** JD.AI is the primary command/runtime owner.
+- **OpenClaw bridge:** OpenClaw remains transport; JD.AI command execution is opt-in via `/jdai-*`.
+
 ## ChannelMessage
 
 All inbound messages are normalized to this record:

--- a/docs/developer-guide/openclaw-integration.md
+++ b/docs/developer-guide/openclaw-integration.md
@@ -63,6 +63,62 @@ Messages include origin metadata to prevent routing loops:
 }
 ```
 
+## Bridge hijack vs native channels
+
+JD.AI supports two distinct integration shapes:
+
+| Path | Transport owner | Who answers user messages | Best fit |
+|------|------------------|---------------------------|----------|
+| **Native channel adapters** (Discord/Signal/Slack/Telegram/Web) | JD.AI | JD.AI agent mapped to that channel | Primary JD.AI deployment |
+| **OpenClaw bridge + Passthrough** | OpenClaw | OpenClaw agent (JD.AI observes) | Keep OpenClaw as primary runtime |
+| **OpenClaw bridge + Intercept/Proxy** | OpenClaw transport, JD.AI execution | JD.AI (OpenClaw run is aborted or bypassed) | "Hijack" mode where JD.AI should answer |
+| **OpenClaw bridge + Sidecar** | Shared | OpenClaw by default, JD.AI on trigger | Mixed mode with selective JD.AI takeover |
+
+Operationally, "hijacking OpenClaw" means using **Intercept** or **Proxy** so JD.AI generates the assistant response while OpenClaw remains the session transport.
+
+## Fast switching and handoff commands
+
+You can switch routing/provider behavior at runtime without restarting either gateway.
+
+### Native channels (Discord/Slack/Signal)
+
+Use native channel commands:
+
+```text
+jdai-routes
+jdai-route
+jdai-route <agent-or-provider-or-model-fragment>
+jdai-provider
+jdai-provider <provider-name>
+jdai-providers
+```
+
+Examples:
+
+```text
+jdai-route ollama
+jdai-provider openai
+jdai-routes
+```
+
+### OpenClaw bridge sessions
+
+Inside an OpenClaw conversation, send `/jdai-...` commands. The bridge intercepts them, executes in JD.AI, and injects the result back into the session:
+
+```text
+/jdai-help
+/jdai-routes
+/jdai-route ollama
+/jdai-provider openai
+/jdai-status
+```
+
+### Practical switching behavior
+
+- In **Sidecar** mode, plain messages continue to OpenClaw; `/jdai-...` commands and configured triggers route to JD.AI.
+- In **Intercept/Proxy** mode, JD.AI is the active responder for routed messages.
+- In **Passthrough** mode, OpenClaw remains responder; use `/jdai-...` commands for targeted control operations.
+
 ## Setup
 
 ### Prerequisites

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -453,6 +453,7 @@ Gateway adapters expose command variants natively per platform:
 - Discord: slash commands (example: `/jdai-help`)
 - Slack: slash commands (example: `/jdai-help`)
 - Signal: command prefix form (example: `!jdai-help`)
+- OpenClaw bridge: message commands (example: `/jdai-help`)
 
 ### `jdai-help`
 
@@ -481,6 +482,44 @@ Clears one agent conversation or all if omitted.
 ### `jdai-agents`
 
 Lists active gateway agents and route mappings.
+
+### `jdai-route [agent]`
+
+Shows the current channel route or remaps the current channel to a matching agent/provider/model.
+
+```text
+jdai-route
+jdai-route ollama
+jdai-route gpt-5.3-codex
+```
+
+### `jdai-routes`
+
+Lists all channel-to-agent mappings.
+
+### `jdai-provider [name]`
+
+Shows current mapped agent provider or switches the mapped channel to a newly spawned agent on the selected provider.
+
+```text
+jdai-provider
+jdai-provider openai
+jdai-provider ollama
+```
+
+### `jdai-providers`
+
+Lists detected provider availability and models from the gateway runtime.
+
+### OpenClaw bridge invocation
+
+When issuing gateway commands from an OpenClaw conversation, always use `/jdai-` prefix messages:
+
+```text
+/jdai-routes
+/jdai-route ollama
+/jdai-provider openai
+```
 
 ## Quick reference
 

--- a/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
@@ -7,12 +7,14 @@ using JD.AI.Gateway.Commands;
 using JD.AI.Gateway.Config;
 using JD.AI.Gateway.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.SemanticKernel;
 using NSubstitute;
 
 namespace JD.AI.Gateway.Tests.Commands;
 
 public class GatewayCommandTests
 {
+    private readonly IProviderRegistry _providers;
     private readonly AgentPoolService _pool;
     private readonly ChannelRegistry _channels;
     private readonly AgentRouter _router;
@@ -20,9 +22,29 @@ public class GatewayCommandTests
 
     public GatewayCommandTests()
     {
-        var providers = Substitute.For<IProviderRegistry>();
+        _providers = Substitute.For<IProviderRegistry>();
+
+        var ollamaModel = new ProviderModelInfo("llama3.2:latest", "llama3.2:latest", "Ollama");
+        var openAiModel = new ProviderModelInfo("gpt-5.3-codex", "gpt-5.3-codex", "OpenAI");
+
+        var detectedProviders = new List<ProviderInfo>
+        {
+            new("Ollama", true, null, [ollamaModel]),
+            new("OpenAI", true, null, [openAiModel]),
+            new("Claude", false, "offline", [])
+        };
+
+        var detector = Substitute.For<IProviderDetector>();
+        detector.BuildKernel(Arg.Any<ProviderModelInfo>()).Returns(_ => Kernel.CreateBuilder().Build());
+
+        _providers.DetectProvidersAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<ProviderInfo>>(detectedProviders));
+        _providers.GetModelsAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<ProviderModelInfo>>([ollamaModel, openAiModel]));
+        _providers.GetDetector(Arg.Any<string>()).Returns(detector);
+
         var eventBus = Substitute.For<IEventBus>();
-        _pool = new AgentPoolService(providers, eventBus, NullLogger<AgentPoolService>.Instance);
+        _pool = new AgentPoolService(_providers, eventBus, NullLogger<AgentPoolService>.Instance);
         _channels = new ChannelRegistry();
         _router = new AgentRouter(_pool, _channels, eventBus, NullLogger<AgentRouter>.Instance);
         _config = new GatewayConfig
@@ -47,6 +69,63 @@ public class GatewayCommandTests
         ChannelType = "discord",
         Arguments = args ?? new Dictionary<string, string>(StringComparer.Ordinal)
     };
+
+    // --- Route commands ---
+
+    [Fact]
+    public async Task RouteCommand_RemapsCurrentChannel_WhenAgentMatchExists()
+    {
+        var agentId = await _pool.SpawnAgentAsync("Ollama", "llama3.2:latest", null, CancellationToken.None);
+        var cmd = new RouteCommand(_router, _pool);
+
+        var result = await cmd.ExecuteAsync(MakeContext("route", new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["agent"] = "ollama"
+        }));
+
+        result.Success.Should().BeTrue();
+        _router.GetAgentForChannel("discord").Should().Be(agentId);
+        result.Content.Should().Contain("now routes");
+    }
+
+    [Fact]
+    public async Task RoutesCommand_ListsMappedChannels()
+    {
+        var agentId = await _pool.SpawnAgentAsync("Ollama", "llama3.2:latest", null, CancellationToken.None);
+        _router.MapChannel("discord", agentId);
+        var cmd = new RoutesCommand(_router, _pool);
+
+        var result = await cmd.ExecuteAsync(MakeContext("routes"));
+
+        result.Success.Should().BeTrue();
+        result.Content.Should().Contain("discord");
+        result.Content.Should().Contain("Ollama/llama3.2:latest");
+    }
+
+    [Fact]
+    public async Task ProviderCommand_SwitchesProvider_ForMappedChannel()
+    {
+        var initialAgentId = await _pool.SpawnAgentAsync("Ollama", "llama3.2:latest", null, CancellationToken.None);
+        _router.MapChannel("discord", initialAgentId);
+        var cmd = new ProviderCommand(_router, _pool, _providers);
+
+        var result = await cmd.ExecuteAsync(MakeContext("provider", new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["name"] = "openai"
+        }));
+
+        result.Success.Should().BeTrue();
+        var mappedAgentId = _router.GetAgentForChannel("discord");
+        mappedAgentId.Should().NotBeNull();
+        mappedAgentId.Should().NotBe(initialAgentId);
+
+        var mappedAgent = _pool.ListAgents().Single(a =>
+            string.Equals(a.Id, mappedAgentId, StringComparison.Ordinal));
+        mappedAgent.Provider.Should().Be("OpenAI");
+        mappedAgent.Model.Should().Be("gpt-5.3-codex");
+
+        result.Content.Should().Contain("Switched to **OpenAI**");
+    }
 
     // --- StatusCommand ---
 
@@ -159,6 +238,10 @@ public class GatewayCommandTests
         registry.Register(helpCmd);
         registry.Register(new UsageCommand(_pool));
         registry.Register(new StatusCommand(_pool, _channels));
+        registry.Register(new RouteCommand(_router, _pool));
+        registry.Register(new RoutesCommand(_router, _pool));
+        registry.Register(new ProvidersCommand(_providers));
+        registry.Register(new ProviderCommand(_router, _pool, _providers));
 
         var result = await helpCmd.ExecuteAsync(MakeContext("help"));
 
@@ -166,5 +249,9 @@ public class GatewayCommandTests
         result.Content.Should().Contain("jdai-help");
         result.Content.Should().Contain("jdai-usage");
         result.Content.Should().Contain("jdai-status");
+        result.Content.Should().Contain("jdai-route");
+        result.Content.Should().Contain("jdai-routes");
+        result.Content.Should().Contain("jdai-provider");
+        result.Content.Should().Contain("jdai-providers");
     }
 }


### PR DESCRIPTION
## Summary\n- add explicit bridge-vs-native behavior matrix to OpenClaw integration docs\n- document runtime handoff/switch commands for native channels and OpenClaw bridge sessions\n- expand gateway command reference with jdai-route, jdai-routes, jdai-provider, and jdai-providers\n- add gateway command tests for route/provider switching and help coverage\n\n## Validation\n- dotnet test tests/JD.AI.Gateway.Tests/JD.AI.Gateway.Tests.csproj --filter GatewayCommandTests\n- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter ModeHandlerTests\n- docfx docs/docfx.json