### PR TITLE
Docs: expand screenshot coverage across README and guides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,7 @@
 - [ ] All new and existing tests pass (`dotnet test`)
 - [ ] The solution builds with zero warnings (`dotnet build`)
 - [ ] I have updated the documentation if needed
+- [ ] For docs/README changes, I added or refreshed screenshots/GIFs where they improve clarity
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,16 @@ The project has **772+ tests** across **3 test projects** (`JD.AI.Tests`, `JD.AI
 - Add XML doc comments for public APIs
 - Keep test coverage high
 
+## Documentation & Screenshots
+
+Docs and README content should be visual and task-oriented. When you add or update user-facing docs:
+
+- Include screenshots or GIFs for key workflows (TUI, daemon/service flows, dashboard pages, channel routing).
+- Prefer real captures generated via:
+  - `npm --prefix docs/scripts run screenshots` (Playwright static screenshots)
+  - `./docs/tapes/generate.sh` (VHS recordings and frame captures)
+- Use concise alt text that explains what the reader should notice in the image.
+
 ## Code Quality Requirements
 
 All pull requests must pass the following analyzer checks (CI enforced):

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 AI-powered terminal assistant and multi-channel platform built on [Semantic Kernel](https://github.com/microsoft/semantic-kernel). 14 AI providers, 17 tool categories, 33+ slash commands, MCP server integration, workflow engine, subagent orchestration, team strategies, and six channel adapters — across 18 projects with 772+ tests.
 
+![JD.AI terminal startup](docs/images/demo-startup.png)
+![JD.AI dashboard overview](docs/images/dashboard/dashboard-overview.png)
+
 ## Architecture
 
 ```

--- a/docs/developer-guide/channels.md
+++ b/docs/developer-guide/channels.md
@@ -7,6 +7,8 @@ description: "IChannel interface, message types, writing a custom channel adapte
 
 Channel adapters connect the JD.AI Gateway to external messaging platforms. Each adapter implements the `IChannel` interface and translates platform-specific messaging into a unified `ChannelMessage` format.
 
+![Channel connectivity dashboard view](../images/dashboard/dashboard-channels.png)
+
 JD.AI ships with six adapters:
 
 | Channel | Package | Transport |

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -7,6 +7,8 @@ description: "Technical architecture of JD.AI — project structure, layering, S
 
 JD.AI is an AI-powered terminal assistant built on [Microsoft Semantic Kernel](https://learn.microsoft.com/semantic-kernel/). This guide explains the internal architecture for developers who want to understand, extend, or contribute to JD.AI.
 
+![Gateway dashboard architecture surface](../images/dashboard/dashboard-overview.png)
+
 ## Project structure
 
 The solution is organized into **18 projects** across four layers:

--- a/docs/developer-guide/openclaw-integration.md
+++ b/docs/developer-guide/openclaw-integration.md
@@ -7,6 +7,8 @@ description: "Bridge JD.AI and OpenClaw gateways for cross-platform multi-AI orc
 
 OpenClaw is an open-source multi-AI gateway that orchestrates conversations across different AI providers and messaging platforms. The JD.AI ↔ OpenClaw integration connects the two gateways via the `OpenClawBridgeChannel`, enabling agents on either platform to communicate, share context, and route messages across boundaries.
 
+![OpenClaw routing visibility in the JD.AI dashboard](../images/dashboard/dashboard-routing.png)
+
 ## Why integrate with OpenClaw
 
 | Scenario | Without integration | With integration |

--- a/docs/developer-guide/orchestration.md
+++ b/docs/developer-guide/orchestration.md
@@ -7,6 +7,8 @@ description: "IOrchestrationStrategy interface, implementing custom strategies, 
 
 Team orchestration coordinates multiple [subagents](subagents.md) working together on complex tasks. This guide covers the internals for developers who want to understand, customize, or extend the orchestration system.
 
+![Team orchestration progress panel](../images/demo-orchestration.png)
+
 ## IOrchestrationStrategy interface
 
 All strategies implement this interface from `src/JD.AI.Core/Agents/Orchestration/`:

--- a/docs/operations/dashboard.md
+++ b/docs/operations/dashboard.md
@@ -7,6 +7,8 @@ description: "Manage the JD.AI Gateway through the Blazor WebAssembly dashboard 
 
 The JD.AI Admin Dashboard is a Blazor WebAssembly application that provides a real-time management interface for the JD.AI Gateway. It connects to the Gateway via REST API and SignalR for live updates.
 
+![Dashboard overview page](../images/dashboard/dashboard-overview.png)
+
 ## Getting Started
 
 1. Start the Gateway:
@@ -46,6 +48,8 @@ Connection status is shown in the top-right corner with a green "LIVE" indicator
 
 The Agents page lists all currently running agent instances with full lifecycle controls.
 
+![Agents management page](../images/dashboard/dashboard-agents.png)
+
 | Column | Description |
 |--------|-------------|
 | ID | Unique agent instance identifier |
@@ -79,6 +83,8 @@ From the Agents page, monitor each agent's:
 
 The Channels page shows all configured communication channels and their connection status.
 
+![Channel status and connectivity controls](../images/dashboard/dashboard-channels.png)
+
 Each channel card displays:
 
 - Channel name and type (web, discord, signal, slack, telegram)
@@ -92,6 +98,8 @@ The **Sync OpenClaw** button synchronizes channel configuration with the OpenCla
 
 The Chat page provides a built-in web interface for communicating with agents:
 
+![Web chat with streaming responses](../images/dashboard/dashboard-chat.png)
+
 - **Agent selector** — choose which agent to chat with from the dropdown
 - **Streaming responses** — tokens stream in real-time via SignalR
 - **Message history** — full conversation displayed with user/assistant bubbles
@@ -103,6 +111,8 @@ Messages are sent to the Gateway's `AgentHub` and streamed back as chunked respo
 ## Configuration UI
 
 The Settings page provides a WYSIWYG editor for all Gateway configuration. Changes are applied in real-time and persisted to the configuration file.
+
+![Settings editor](../images/dashboard/dashboard-settings.png)
 
 > [!TIP]
 > Changes made through the Settings UI are validated before applying. Invalid values are rejected with a descriptive error message.
@@ -147,6 +157,8 @@ Each channel configuration includes:
 
 The Providers page shows all configured AI providers, their connection status, and available models. Each provider card shows:
 
+![Provider catalog and status page](../images/dashboard/dashboard-providers.png)
+
 - Provider name and status (Online / Offline)
 - Number of available models
 - Model catalog with ID and display name
@@ -156,6 +168,8 @@ Supported providers include Claude Code, GitHub Copilot, OpenAI Codex, Ollama, l
 ## Routing Configuration
 
 The Routing tab in Settings defines how messages are routed to agents:
+
+![Routing configuration page](../images/dashboard/dashboard-routing.png)
 
 - **Default agent** — which agent handles messages when no specific route matches
 - **Channel-to-agent mappings** — assign specific agents to specific channels

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -7,6 +7,8 @@ description: "Install and run JD.AI Gateway as a Windows Service, systemd unit, 
 
 JD.AI Gateway can run as a native system service on both Windows and Linux, or as a Docker container, providing always-on AI assistant capabilities with automatic updates and health monitoring.
 
+![Daemon and CLI service workflow](../images/demo-cli.png)
+
 ## Prerequisites
 
 - .NET 10.0 SDK or Runtime

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -7,6 +7,8 @@ description: "Guide to deploying, monitoring, securing, and governing JD.AI in p
 
 This section covers deploying, monitoring, securing, and governing JD.AI in production environments. Whether you are running a single-instance developer setup or a multi-team enterprise deployment, these guides provide the operational knowledge you need.
 
+![Operations dashboard overview](../images/dashboard/dashboard-overview.png)
+
 ## What's covered
 
 ### [Service Deployment](deployment.md)

--- a/docs/scripts/package.json
+++ b/docs/scripts/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "screenshots": "node generate-screenshots.mjs",
+    "og": "node generate-og-image.mjs",
+    "media": "npm run screenshots && npm run og"
   },
   "keywords": [],
   "author": "",

--- a/docs/tapes/README.md
+++ b/docs/tapes/README.md
@@ -2,6 +2,11 @@
 
 These `.tape` files generate terminal screenshots and GIFs for JD.AI documentation using [Charmbracelet VHS](https://github.com/charmbracelet/vhs).
 
+JD.AI docs use two media pipelines:
+
+- **VHS** for realistic terminal recordings and frame captures (`docs/tapes/*.tape`)
+- **Playwright** for styled static screenshots and social assets (`docs/scripts/*.mjs`)
+
 ## Prerequisites
 
 Install VHS and its dependencies:
@@ -31,6 +36,19 @@ Or run individual tapes:
 
 ```bash
 vhs docs/tapes/demo-startup.tape
+```
+
+Generate Playwright-based docs images:
+
+```bash
+npm --prefix docs/scripts install
+npm --prefix docs/scripts run screenshots
+```
+
+Generate Open Graph image:
+
+```bash
+npm --prefix docs/scripts run og
 ```
 
 ## Output

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -7,6 +7,8 @@ description: Slash commands grouped by task — getting help, model management, 
 
 Slash commands are typed at the `>` prompt prefixed with `/`. Type `/help` to see all available commands. This page groups commands by task with brief descriptions and examples. For full details on every parameter, see the [Commands Reference](../reference/commands.md).
 
+![Slash command help output in JD.AI](../images/demo-commands-help.png)
+
 ## Getting help
 
 | Command | Description |

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -7,6 +7,8 @@ description: Introduction to the JD.AI user guide — an AI-powered terminal ass
 
 JD.AI is an AI-powered terminal assistant that brings intelligent code understanding, generation, and project management directly to your command line. Built on [Microsoft Semantic Kernel](https://learn.microsoft.com/semantic-kernel/), it connects to 14 AI providers — from cloud APIs to fully offline local models — and ships with a rich set of built-in developer tools.
 
+![JD.AI startup flow in the terminal](../images/demo-startup.png)
+
 This guide covers everything you need to use JD.AI day-to-day.
 
 ## What you'll find here

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -7,6 +7,8 @@ description: Install JD.AI, configure prerequisites, and run it for the first ti
 
 Get JD.AI up and running on your machine. This page covers prerequisites, installation methods, first run, and basic CLI options. For provider-specific setup, see [Provider Setup](provider-setup.md).
 
+![JD.AI CLI help output](../images/demo-cli.png)
+
 ## Prerequisites
 
 - [.NET 10.0 SDK](https://dotnet.microsoft.com/download) or later

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -6,6 +6,8 @@ description: "Interactive mode guide for JD.AI: prompt behavior, keyboard shortc
 
 JD.AI interactive mode is the default `jdai` terminal experience: live prompt editing, slash commands, tool use, streaming responses, and session persistence.
 
+![Interactive chat response with streamed output](../images/demo-chat.png)
+
 ## Start interactive mode
 
 ```bash

--- a/docs/user-guide/local-models.md
+++ b/docs/user-guide/local-models.md
@@ -7,6 +7,8 @@ description: Run GGUF language models offline with LLamaSharp — fully private 
 
 JD.AI can run GGUF language models directly in-process via [LLamaSharp](https://github.com/SciSharp/LLamaSharp), a C# binding for [llama.cpp](https://github.com/ggerganov/llama.cpp). This enables fully standalone operation — no Ollama, no cloud API keys, no internet connection.
 
+![Provider list showing local model availability](../images/demo-providers.png)
+
 ## Quick start
 
 1. Download a GGUF model (example: TinyLlama for testing):

--- a/docs/user-guide/provider-setup.md
+++ b/docs/user-guide/provider-setup.md
@@ -7,6 +7,8 @@ description: Configure any of JD.AI's 14 supported AI providers — cloud APIs, 
 
 JD.AI supports 14 AI providers. This guide walks through setting up each one — from quick environment variable configuration to the interactive `/provider add` wizard.
 
+![Provider detection and availability view](../images/demo-providers.png)
+
 ## Provider overview
 
 JD.AI detects providers automatically on startup. Providers fall into three authentication categories:

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -7,6 +7,8 @@ description: Get productive with JD.AI in under five minutes — from launching 
 
 Get productive with JD.AI in under five minutes. This guide walks through a typical workflow — from launching the assistant to committing changes — so you can see how every major feature fits together.
 
+![Quickstart terminal workflow](../images/demo-chat.png)
+
 ## Before you begin
 
 Make sure you have:

--- a/docs/user-guide/sessions.md
+++ b/docs/user-guide/sessions.md
@@ -7,6 +7,8 @@ description: Save, resume, and export JD.AI conversations — session persistenc
 
 JD.AI automatically saves conversation history to a local SQLite database so you can resume where you left off. Sessions capture turns, token usage, tool calls, and files touched — giving you a complete record of each interaction.
 
+![Session listing and resume workflow](../images/demo-sessions.png)
+
 ## How it works
 
 - Sessions are stored in SQLite at `~/.jdai/sessions.db`

--- a/docs/user-guide/tools.md
+++ b/docs/user-guide/tools.md
@@ -7,6 +7,8 @@ description: Overview of JD.AI's 19 built-in tool categories — what each does,
 
 JD.AI provides 19 categories of built-in tools that the AI agent invokes automatically during conversations. You don't call tools directly — describe what you want in natural language and JD.AI selects the right tool. Each tool call is confirmed before execution unless you've enabled auto-run.
 
+![Tool execution example in the terminal](../images/demo-tools.png)
+
 For full parameter documentation, see the [Tools Reference](../reference/tools.md).
 
 ## Tool categories at a glance


### PR DESCRIPTION
## Summary\n- add screenshots to key README, user-guide, developer-guide, and operations docs pages\n- add dashboard page screenshots throughout the admin dashboard operations guide\n- document media generation paths (VHS + Playwright) in docs tape workflow\n- add docs/scripts npm commands for screenshot and OG generation\n- add contributor and PR-template guidance to include screenshots for docs changes\n\n## Validation\n- docfx docs/docfx.json\n  - succeeds with existing unrelated warnings (invalid cref + pre-existing invalid file links)\n