### PR TITLE
Fix version-bump workflow NBGV format usage

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           BUMP="${{ steps.semver.outputs.bump }}"
-          CURRENT=$(nbgv get-version -f "{MajorMinorVersion}")
+          CURRENT=$(nbgv get-version -v MajorMinorVersion)
           MAJOR=$(echo "$CURRENT" | cut -d. -f1)
           MINOR=$(echo "$CURRENT" | cut -d. -f2)
 
@@ -91,10 +91,15 @@ jobs:
         shell: bash
         run: |
           BUMP="${{ steps.semver.outputs.bump }}"
-          NEW_VERSION=$(nbgv get-version -f "{MajorMinorVersion}")
+          NEW_VERSION=$(nbgv get-version -v MajorMinorVersion)
 
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- version.json; then
+            echo "No version.json changes detected; skipping commit."
+            exit 0
+          fi
 
           git add version.json
           git commit -m "chore(version): bump to ${NEW_VERSION} [${BUMP}]


### PR DESCRIPTION
## Problem
The version bump workflow failed in run 22745925940 job 65969606337 because it invoked an unsupported NBGV format argument.

## Fix
- use 
bgv get-version -v MajorMinorVersion instead of the unsupported format invocation
- add a no-op guard to skip commit when ersion.json has no changes

## Expected result
The Apply version bump step should no longer fail with "Unsupported format: {MajorMinorVersion}" and the workflow will safely skip commit when no bump is needed.
