### PR TITLE
refactor: centralize gateway and daemon runtime constants

### DIFF
--- a/src/JD.AI.Core/Infrastructure/RuntimeConstants.cs
+++ b/src/JD.AI.Core/Infrastructure/RuntimeConstants.cs
@@ -1,0 +1,30 @@
+namespace JD.AI.Core.Infrastructure;
+
+/// <summary>
+/// Shared runtime defaults for gateway host/port/addressing and health endpoints.
+/// </summary>
+public static class GatewayRuntimeDefaults
+{
+    public const string DefaultHost = "localhost";
+    public const int DefaultPort = 15790;
+
+    public const string HealthPath = "/health";
+    public const string HealthReadyPath = "/health/ready";
+    public const string HealthLivePath = "/health/live";
+    public const string HealthStartupPath = "/health/startup";
+    public const string ReadyPath = "/ready";
+}
+
+/// <summary>
+/// Shared service and CLI identity constants for the JD.AI daemon.
+/// </summary>
+public static class DaemonServiceIdentity
+{
+    public const string ToolCommand = "jdai-daemon";
+    public const string WindowsServiceName = "JDAIDaemon";
+    public const string LinuxServiceName = ToolCommand;
+
+    public const string WindowsDisplayName = "JD.AI Gateway Daemon";
+    public const string WindowsDescription = "JD.AI AI Gateway - manages AI agents, channels, and routing.";
+    public const string HostedServiceDisplayName = "JD.AI Gateway";
+}

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -5,6 +5,7 @@ using JD.AI.Core.Channels;
 using JD.AI.Core.Commands;
 using JD.AI.Core.Config;
 using JD.AI.Core.Events;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.Memory;
 using JD.AI.Core.Plugins;
 using JD.AI.Core.Providers;
@@ -146,7 +147,7 @@ static void RunDaemon(string[] args)
     // Platform-specific service hosting
     builder.Services.AddWindowsService(options =>
     {
-        options.ServiceName = "JD.AI Gateway";
+        options.ServiceName = DaemonServiceIdentity.HostedServiceDisplayName;
     });
     builder.Services.AddSystemd();
 
@@ -380,9 +381,9 @@ static void RunDaemon(string[] args)
     app.MapOpenApi();
 
     // --- Health ---
-    app.MapHealthChecks("/health");
-    app.MapGet("/health/startup", () => Results.Ok(new { Status = "Started" }));
-    app.MapGet("/ready", () => Results.Ok(new { Status = "Ready" }));
+    app.MapHealthChecks(GatewayRuntimeDefaults.HealthPath);
+    app.MapGet(GatewayRuntimeDefaults.HealthStartupPath, () => Results.Ok(new { Status = "Started" }));
+    app.MapGet(GatewayRuntimeDefaults.ReadyPath, () => Results.Ok(new { Status = "Ready" }));
 
     // --- REST API endpoints ---
     app.MapSessionEndpoints();
@@ -443,7 +444,7 @@ static async Task RunUpdateCommandAsync(bool checkOnly)
 
     if (checkOnly)
     {
-        Console.WriteLine("Run 'jdai-daemon update' (without --check-only) to apply.");
+        Console.WriteLine($"Run '{DaemonServiceIdentity.ToolCommand} update' (without --check-only) to apply.");
         return;
     }
 

--- a/src/JD.AI.Daemon/Services/SystemdServiceManager.cs
+++ b/src/JD.AI.Daemon/Services/SystemdServiceManager.cs
@@ -10,7 +10,7 @@ namespace JD.AI.Daemon.Services;
 [SupportedOSPlatform("linux")]
 public sealed class SystemdServiceManager : IServiceManager
 {
-    private const string ServiceName = "jdai-daemon";
+    private const string ServiceName = DaemonServiceIdentity.LinuxServiceName;
     private const string UnitFileName = $"{ServiceName}.service";
     private const string UnitFilePath = $"/etc/systemd/system/{UnitFileName}";
 
@@ -18,7 +18,7 @@ public sealed class SystemdServiceManager : IServiceManager
     {
         var toolPath = GetToolPath();
         if (toolPath is null)
-            return new ServiceResult(false, "Cannot locate jdai-daemon. Is it installed via 'dotnet tool install -g JD.AI.Daemon'?");
+            return new ServiceResult(false, $"Cannot locate {DaemonServiceIdentity.ToolCommand}. Is it installed via 'dotnet tool install -g JD.AI.Daemon'?");
 
         var user = Environment.UserName;
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -26,7 +26,7 @@ public sealed class SystemdServiceManager : IServiceManager
 
         var unitContent = $"""
             [Unit]
-            Description=JD.AI Gateway Daemon
+            Description={DaemonServiceIdentity.WindowsDisplayName}
             Documentation=https://jerrettdavis.github.io/JD.AI/
             After=network-online.target
             Wants=network-online.target
@@ -59,14 +59,14 @@ public sealed class SystemdServiceManager : IServiceManager
         catch (UnauthorizedAccessException)
         {
             return new ServiceResult(false,
-                $"Permission denied writing {UnitFilePath}. Run with sudo:\n  sudo jdai-daemon install");
+                $"Permission denied writing {UnitFilePath}. Run with sudo:\n  sudo {DaemonServiceIdentity.ToolCommand} install");
         }
 
         await RunSystemctlAsync("daemon-reload", ct);
         await RunSystemctlAsync($"enable {ServiceName}", ct);
 
         return new ServiceResult(true,
-            $"Service '{ServiceName}' installed and enabled. Run 'jdai-daemon start' to begin.");
+            $"Service '{ServiceName}' installed and enabled. Run '{DaemonServiceIdentity.ToolCommand} start' to begin.");
     }
 
     public async Task<ServiceResult> UninstallAsync(CancellationToken ct = default)
@@ -85,7 +85,7 @@ public sealed class SystemdServiceManager : IServiceManager
         catch (UnauthorizedAccessException)
         {
             return new ServiceResult(false,
-                $"Permission denied deleting {UnitFilePath}. Run with sudo:\n  sudo jdai-daemon uninstall");
+                $"Permission denied deleting {UnitFilePath}. Run with sudo:\n  sudo {DaemonServiceIdentity.ToolCommand} uninstall");
         }
 
         await RunSystemctlAsync("daemon-reload", ct);
@@ -145,7 +145,7 @@ public sealed class SystemdServiceManager : IServiceManager
     private static string? GetToolPath()
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var toolPath = Path.Combine(home, ".dotnet", "tools", "jdai-daemon");
+        var toolPath = Path.Combine(home, ".dotnet", "tools", DaemonServiceIdentity.ToolCommand);
         return File.Exists(toolPath) ? toolPath : null;
     }
 

--- a/src/JD.AI.Daemon/Services/WindowsServiceManager.cs
+++ b/src/JD.AI.Daemon/Services/WindowsServiceManager.cs
@@ -9,10 +9,6 @@ namespace JD.AI.Daemon.Services;
 [SupportedOSPlatform("windows")]
 public sealed class WindowsServiceManager : IServiceManager
 {
-    private const string ServiceName = "JDAIDaemon";
-    private const string DisplayName = "JD.AI Gateway Daemon";
-    private const string Description = "JD.AI AI Gateway - manages AI agents, channels, and routing.";
-
     private const string OpenClawTaskName = "\\OpenClaw Gateway";
     private const string OpenClawWatchdogTaskName = "\\OpenClaw Gateway Watchdog";
     private const string OpenClawStateDirName = ".openclaw";
@@ -24,14 +20,14 @@ public sealed class WindowsServiceManager : IServiceManager
     {
         var toolPath = GetToolPath();
         if (toolPath is null)
-            return new ServiceResult(false, "Cannot locate jdai-daemon executable. Is it installed as a dotnet tool?");
+            return new ServiceResult(false, $"Cannot locate {DaemonServiceIdentity.ToolCommand} executable. Is it installed as a dotnet tool?");
 
         var serviceBinPath = BuildServiceBinPath(toolPath);
         var serviceExists = await ServiceExistsAsync(ct);
 
         var (exitCode, output) = serviceExists
-            ? await RunScAsync($"config {ServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DisplayName}\"", ct)
-            : await RunScAsync($"create {ServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DisplayName}\"", ct);
+            ? await RunScAsync($"config {DaemonServiceIdentity.WindowsServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DaemonServiceIdentity.WindowsDisplayName}\"", ct)
+            : await RunScAsync($"create {DaemonServiceIdentity.WindowsServiceName} binPath= {serviceBinPath} start= auto DisplayName= \"{DaemonServiceIdentity.WindowsDisplayName}\"", ct);
 
         if (exitCode != 0)
         {
@@ -40,8 +36,8 @@ public sealed class WindowsServiceManager : IServiceManager
         }
 
         // Best effort metadata configuration
-        await RunScAsync($"description {ServiceName} \"{Description}\"", ct);
-        await RunScAsync($"failure {ServiceName} reset=86400 actions=restart/5000/restart/10000/restart/30000", ct);
+        await RunScAsync($"description {DaemonServiceIdentity.WindowsServiceName} \"{DaemonServiceIdentity.WindowsDescription}\"", ct);
+        await RunScAsync($"failure {DaemonServiceIdentity.WindowsServiceName} reset=86400 actions=restart/5000/restart/10000/restart/30000", ct);
 
         var taskProvisioning = await EnsureOpenClawGatewayTasksAsync(ct);
         if (!taskProvisioning.Success)
@@ -49,7 +45,7 @@ public sealed class WindowsServiceManager : IServiceManager
 
         var action = serviceExists ? "updated" : "installed";
         return new ServiceResult(true,
-            $"Service '{ServiceName}' {action}. OpenClaw gateway tasks are configured. Run 'jdai-daemon start' to begin.");
+            $"Service '{DaemonServiceIdentity.WindowsServiceName}' {action}. OpenClaw gateway tasks are configured. Run '{DaemonServiceIdentity.ToolCommand} start' to begin.");
     }
 
     public async Task<ServiceResult> UninstallAsync(CancellationToken ct = default)
@@ -60,7 +56,7 @@ public sealed class WindowsServiceManager : IServiceManager
 
         if (status.State != ServiceState.NotInstalled)
         {
-            var (exitCode, output) = await RunScAsync($"delete {ServiceName}", ct);
+            var (exitCode, output) = await RunScAsync($"delete {DaemonServiceIdentity.WindowsServiceName}", ct);
             if (exitCode != 0)
                 return new ServiceResult(false, $"sc delete failed: {output}");
         }
@@ -69,28 +65,28 @@ public sealed class WindowsServiceManager : IServiceManager
         if (!cleanupResult.Success)
             return cleanupResult;
 
-        return new ServiceResult(true, $"Service '{ServiceName}' uninstalled and OpenClaw gateway tasks removed.");
+        return new ServiceResult(true, $"Service '{DaemonServiceIdentity.WindowsServiceName}' uninstalled and OpenClaw gateway tasks removed.");
     }
 
     public async Task<ServiceResult> StartAsync(CancellationToken ct = default)
     {
-        var (exitCode, output) = await RunScAsync($"start {ServiceName}", ct);
+        var (exitCode, output) = await RunScAsync($"start {DaemonServiceIdentity.WindowsServiceName}", ct);
         return exitCode == 0
-            ? new ServiceResult(true, $"Service '{ServiceName}' started.")
+            ? new ServiceResult(true, $"Service '{DaemonServiceIdentity.WindowsServiceName}' started.")
             : new ServiceResult(false, $"sc start failed: {output}");
     }
 
     public async Task<ServiceResult> StopAsync(CancellationToken ct = default)
     {
-        var (exitCode, output) = await RunScAsync($"stop {ServiceName}", ct);
+        var (exitCode, output) = await RunScAsync($"stop {DaemonServiceIdentity.WindowsServiceName}", ct);
         return exitCode == 0
-            ? new ServiceResult(true, $"Service '{ServiceName}' stopped.")
+            ? new ServiceResult(true, $"Service '{DaemonServiceIdentity.WindowsServiceName}' stopped.")
             : new ServiceResult(false, $"sc stop failed: {output}");
     }
 
     public async Task<ServiceStatus> GetStatusAsync(CancellationToken ct = default)
     {
-        var (exitCode, output) = await RunScAsync($"query {ServiceName}", ct);
+        var (exitCode, output) = await RunScAsync($"query {DaemonServiceIdentity.WindowsServiceName}", ct);
 
         if (exitCode != 0 || output.Contains("FAILED 1060", StringComparison.Ordinal))
             return new ServiceStatus(ServiceState.NotInstalled, null, null, "Service is not installed.");
@@ -113,7 +109,7 @@ public sealed class WindowsServiceManager : IServiceManager
         // Read from Windows Event Log
         var (exitCode, output) = await RunProcessAsync(
             "powershell",
-            $"-NoProfile -Command \"Get-EventLog -LogName Application -Source '{ServiceName}' -Newest {lines} | Format-Table -AutoSize\"",
+            $"-NoProfile -Command \"Get-EventLog -LogName Application -Source '{DaemonServiceIdentity.WindowsServiceName}' -Newest {lines} | Format-Table -AutoSize\"",
             ct);
 
         return exitCode == 0
@@ -168,7 +164,7 @@ public sealed class WindowsServiceManager : IServiceManager
     private static string? GetToolPath()
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var toolPath = Path.Combine(home, ".dotnet", "tools", "jdai-daemon.exe");
+        var toolPath = Path.Combine(home, ".dotnet", "tools", $"{DaemonServiceIdentity.ToolCommand}.exe");
         return File.Exists(toolPath) ? toolPath : null;
     }
 
@@ -177,7 +173,7 @@ public sealed class WindowsServiceManager : IServiceManager
 
     private static async Task<bool> ServiceExistsAsync(CancellationToken ct)
     {
-        var (exitCode, output) = await RunScAsync($"query {ServiceName}", ct);
+        var (exitCode, output) = await RunScAsync($"query {DaemonServiceIdentity.WindowsServiceName}", ct);
         return exitCode == 0 && !output.Contains("FAILED 1060", StringComparison.Ordinal);
     }
 

--- a/src/JD.AI.Gateway/Commands/DocsCommand.cs
+++ b/src/JD.AI.Gateway/Commands/DocsCommand.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using JD.AI.Core.Commands;
+using JD.AI.Core.Infrastructure;
 
 namespace JD.AI.Gateway.Commands;
 
@@ -16,7 +17,7 @@ public sealed class DocsCommand : IChannelCommand
     private static readonly (string Key, string Slug, string Title, string Summary)[] Topics =
     [
         ("observability", "observability",  "Observability",       "OpenTelemetry tracing, metrics, health checks, and /doctor"),
-        ("health",        "observability",  "Health Checks",       "Health endpoints (/health/ready, /health/live) and check configuration"),
+        ("health",        "observability",  "Health Checks",       $"Health endpoints ({GatewayRuntimeDefaults.HealthReadyPath}, {GatewayRuntimeDefaults.HealthLivePath}) and check configuration"),
         ("telemetry",     "observability",  "Telemetry",           "ActivitySource traces, metrics instruments, and OTel exporters"),
         ("gateway",       "gateway-api",    "Gateway API",         "REST endpoints, SignalR hubs, authentication, and rate limiting"),
         ("config",        "configuration",  "Configuration",       "appsettings.json, environment variables, and instruction files"),

--- a/src/JD.AI.Gateway/Config/GatewayConfig.cs
+++ b/src/JD.AI.Gateway/Config/GatewayConfig.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CA2227 // Collection properties should be read only — needed for IOptions binding
 
+using JD.AI.Core.Infrastructure;
+
 namespace JD.AI.Gateway.Config;
 
 public sealed class GatewayConfig
@@ -28,8 +30,8 @@ public sealed class EventBusConfig
 
 public sealed class ServerConfig
 {
-    public int Port { get; set; } = 18789;
-    public string Host { get; set; } = "localhost";
+    public int Port { get; set; } = GatewayRuntimeDefaults.DefaultPort;
+    public string Host { get; set; } = GatewayRuntimeDefaults.DefaultHost;
     public bool Verbose { get; set; }
 }
 

--- a/src/JD.AI.Gateway/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/JD.AI.Gateway/Middleware/ApiKeyAuthMiddleware.cs
@@ -1,3 +1,4 @@
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.Security;
 
 namespace JD.AI.Gateway.Middleware;
@@ -7,7 +8,12 @@ namespace JD.AI.Gateway.Middleware;
 /// </summary>
 public sealed class ApiKeyAuthMiddleware(RequestDelegate next, IAuthProvider authProvider)
 {
-    private static readonly string[] SkipPrefixes = ["/health", "/ready", "/hubs/"];
+    private static readonly string[] SkipPrefixes =
+    [
+        GatewayRuntimeDefaults.HealthPath,
+        GatewayRuntimeDefaults.ReadyPath,
+        "/hubs/",
+    ];
 
     public async Task InvokeAsync(HttpContext context)
     {

--- a/src/JD.AI.Gateway/Middleware/RateLimitMiddleware.cs
+++ b/src/JD.AI.Gateway/Middleware/RateLimitMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.Security;
 
 namespace JD.AI.Gateway.Middleware;
@@ -12,8 +13,8 @@ public sealed class RateLimitMiddleware(RequestDelegate next, IRateLimiter rateL
     {
         var path = context.Request.Path.Value ?? "";
 
-        if (path.StartsWith("/health", StringComparison.OrdinalIgnoreCase) ||
-            path.StartsWith("/ready", StringComparison.OrdinalIgnoreCase) ||
+        if (path.StartsWith(GatewayRuntimeDefaults.HealthPath, StringComparison.OrdinalIgnoreCase) ||
+            path.StartsWith(GatewayRuntimeDefaults.ReadyPath, StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) ||
             path.StartsWith("/css", StringComparison.OrdinalIgnoreCase) ||

--- a/src/JD.AI.Gateway/Program.cs
+++ b/src/JD.AI.Gateway/Program.cs
@@ -5,6 +5,7 @@ using JD.AI.Core.Commands;
 using JD.AI.Core.Config;
 using JD.AI.Core.Events;
 using JD.AI.Core.Governance.Audit;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.LocalModels;
 using JD.AI.Core.Memory;
 using JD.AI.Core.Plugins;
@@ -277,8 +278,8 @@ if (gatewayConfig.RateLimit.Enabled)
 app.MapOpenApi();
 
 // --- Health ---
-app.MapHealthChecks("/health");
-app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+app.MapHealthChecks(GatewayRuntimeDefaults.HealthPath);
+app.MapHealthChecks(GatewayRuntimeDefaults.HealthReadyPath, new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
 {
     Predicate = _ => true,
     ResultStatusCodes =
@@ -288,9 +289,9 @@ app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.Health
         [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable,
     },
 });
-app.MapGet("/health/live", () => Results.Ok(new { Status = "Live" }));
-app.MapGet("/health/startup", () => Results.Ok(new { Status = "Started" }));
-app.MapGet("/ready", () => Results.Ok(new { Status = "Ready" }));
+app.MapGet(GatewayRuntimeDefaults.HealthLivePath, () => Results.Ok(new { Status = "Live" }));
+app.MapGet(GatewayRuntimeDefaults.HealthStartupPath, () => Results.Ok(new { Status = "Started" }));
+app.MapGet(GatewayRuntimeDefaults.ReadyPath, () => Results.Ok(new { Status = "Ready" }));
 
 // --- REST API endpoints ---
 app.MapSessionEndpoints();

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -8,6 +8,7 @@ using JD.AI.Core.Channels;
 using JD.AI.Core.Config;
 using JD.AI.Core.Governance;
 using JD.AI.Core.Governance.Audit;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.Mcp;
 using JD.AI.Core.Plugins;
 using JD.AI.Core.Providers;
@@ -64,18 +65,19 @@ Microsoft.AspNetCore.Builder.WebApplication? gatewayHost = null;
 if (opts.GatewayMode)
 {
     var port = opts.GatewayPort ?? "5100";
-    var gwBuilder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder(["--urls", $"http://localhost:{port}"]);
+    var gwBuilder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder(
+        ["--urls", $"http://{GatewayRuntimeDefaults.DefaultHost}:{port}"]);
     gwBuilder.Logging.SetMinimumLevel(LogLevel.Warning);
 
     var gwApp = gwBuilder.Build();
-    gwApp.MapGet("/health", () => Results.Ok(new { Status = "Healthy" }));
-    gwApp.MapGet("/ready", () => Results.Ok(new { Status = "Ready" }));
+    gwApp.MapGet(GatewayRuntimeDefaults.HealthPath, () => Results.Ok(new { Status = "Healthy" }));
+    gwApp.MapGet(GatewayRuntimeDefaults.ReadyPath, () => Results.Ok(new { Status = "Ready" }));
 
     gatewayHost = gwApp;
     _ = gwApp.StartAsync();
     if (!opts.PrintMode)
     {
-        AnsiConsole.MarkupLine($"[dim]Gateway started on http://localhost:{port}[/]");
+        AnsiConsole.MarkupLine($"[dim]Gateway started on http://{GatewayRuntimeDefaults.DefaultHost}:{port}[/]");
     }
 }
 

--- a/tests/JD.AI.Gateway.Tests/GatewayConfigTests.cs
+++ b/tests/JD.AI.Gateway.Tests/GatewayConfigTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Gateway.Config;
 
 namespace JD.AI.Gateway.Tests;
@@ -10,8 +11,8 @@ public sealed class GatewayConfigTests
     {
         var config = new GatewayConfig();
 
-        config.Server.Port.Should().Be(18789);
-        config.Server.Host.Should().Be("localhost");
+        config.Server.Port.Should().Be(GatewayRuntimeDefaults.DefaultPort);
+        config.Server.Host.Should().Be(GatewayRuntimeDefaults.DefaultHost);
         config.Auth.Enabled.Should().BeFalse();
         config.RateLimit.Enabled.Should().BeTrue();
         config.RateLimit.MaxRequestsPerMinute.Should().Be(60);

--- a/tests/JD.AI.Gateway.Tests/HealthEndpointTests.cs
+++ b/tests/JD.AI.Gateway.Tests/HealthEndpointTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using JD.AI.Core.Infrastructure;
 
 namespace JD.AI.Gateway.Tests;
 
@@ -15,14 +16,14 @@ public sealed class HealthEndpointTests : IClassFixture<GatewayTestFactory>
     [Fact]
     public async Task Health_ReturnsHealthy()
     {
-        var response = await _client.GetAsync("/health");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.HealthPath);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task Ready_ReturnsOk()
     {
-        var response = await _client.GetAsync("/ready");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.ReadyPath);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var body = await response.Content.ReadFromJsonAsync<ReadyResponse>();
@@ -32,14 +33,14 @@ public sealed class HealthEndpointTests : IClassFixture<GatewayTestFactory>
     [Fact]
     public async Task HealthReady_ReturnsOk()
     {
-        var response = await _client.GetAsync("/health/ready");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.HealthReadyPath);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task HealthLive_ReturnsOk()
     {
-        var response = await _client.GetAsync("/health/live");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.HealthLivePath);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var body = await response.Content.ReadFromJsonAsync<LiveResponse>();

--- a/tests/JD.AI.Gateway.Tests/Middleware/ApiKeyAuthMiddlewareTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Middleware/ApiKeyAuthMiddlewareTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using JD.AI.Core.Infrastructure;
 using JD.AI.Core.Security;
 using JD.AI.Gateway.Config;
 using JD.AI.Gateway.Middleware;
@@ -77,8 +78,8 @@ public sealed class ApiKeyAuthMiddlewareUnitTests
     }
 
     [Theory]
-    [InlineData("/health")]
-    [InlineData("/ready")]
+    [InlineData(GatewayRuntimeDefaults.HealthPath)]
+    [InlineData(GatewayRuntimeDefaults.ReadyPath)]
     [InlineData("/hubs/agent")]
     [InlineData("/hubs/events")]
     public async Task SkipPaths_BypassAuth(string path)
@@ -163,14 +164,14 @@ public sealed class ApiKeyAuthMiddlewareIntegrationTests
     [Fact]
     public async Task HealthEndpoint_BypassesAuth()
     {
-        var response = await _client.GetAsync("/health");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.HealthPath);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]
     public async Task ReadyEndpoint_BypassesAuth()
     {
-        var response = await _client.GetAsync("/ready");
+        var response = await _client.GetAsync(GatewayRuntimeDefaults.ReadyPath);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 

--- a/tests/JD.AI.Tests/Infrastructure/RuntimeConstantsTests.cs
+++ b/tests/JD.AI.Tests/Infrastructure/RuntimeConstantsTests.cs
@@ -1,0 +1,26 @@
+using JD.AI.Core.Infrastructure;
+
+namespace JD.AI.Tests.Infrastructure;
+
+public sealed class RuntimeConstantsTests
+{
+    [Fact]
+    public void GatewayRuntimeDefaults_AreStable()
+    {
+        Assert.Equal("localhost", GatewayRuntimeDefaults.DefaultHost);
+        Assert.Equal(15790, GatewayRuntimeDefaults.DefaultPort);
+        Assert.Equal("/health", GatewayRuntimeDefaults.HealthPath);
+        Assert.Equal("/health/ready", GatewayRuntimeDefaults.HealthReadyPath);
+        Assert.Equal("/health/live", GatewayRuntimeDefaults.HealthLivePath);
+        Assert.Equal("/health/startup", GatewayRuntimeDefaults.HealthStartupPath);
+        Assert.Equal("/ready", GatewayRuntimeDefaults.ReadyPath);
+    }
+
+    [Fact]
+    public void DaemonServiceIdentity_UsesSingleToolCommandForLinux()
+    {
+        Assert.Equal("jdai-daemon", DaemonServiceIdentity.ToolCommand);
+        Assert.Equal(DaemonServiceIdentity.ToolCommand, DaemonServiceIdentity.LinuxServiceName);
+        Assert.Equal("JDAIDaemon", DaemonServiceIdentity.WindowsServiceName);
+    }
+}


### PR DESCRIPTION
## Summary
- add centralized runtime constants in `JD.AI.Core.Infrastructure` for:
  - gateway host/port defaults and health endpoint paths
  - daemon service/tool identity (Windows/Linux service names + tool command)
- refactor gateway, daemon, and TUI embedded gateway startup/middleware code to use shared constants
- refactor Windows/systemd service managers to use shared daemon identity constants
- update gateway docs/tests to consume shared health/default constants
- add runtime constants unit tests and parity assertions against `GatewayConfig` defaults

## Validation
- `dotnet test tests/JD.AI.Gateway.Tests/JD.AI.Gateway.Tests.csproj --filter "FullyQualifiedName~GatewayConfigTests|FullyQualifiedName~HealthEndpointTests|FullyQualifiedName~ApiKeyAuthMiddleware"`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --filter "FullyQualifiedName~RuntimeConstantsTests|FullyQualifiedName~DaemonServiceTests"`
- `dotnet build JD.AI.slnx -v minimal`
