### PR TITLE
feat(audit): SQLite queryable audit sink

### DIFF
--- a/docs/architecture/decisions/ADR-004-sqlite-audit-sink.md
+++ b/docs/architecture/decisions/ADR-004-sqlite-audit-sink.md
@@ -1,0 +1,104 @@
+# ADR-004: SQLite Queryable Audit Sink
+
+**Status**: Accepted  
+**Date**: 2025  
+**Closes**: GitHub issue #206 (partial — SQLite sink)
+
+---
+
+## Context
+
+The existing `AuditService` dispatches events to four sinks:
+- `FileAuditSink` — append-only JSONL file
+- `ElasticsearchAuditSink` — Elasticsearch index
+- `WebhookAuditSink` — HTTP POST
+- `InMemoryAuditSink` — in-process list (testing)
+
+None of these sinks implement `IQueryableAuditSink`, so there is no way to
+query audit events programmatically (e.g., "show me all ToolCall events from
+session X in the last hour"). For developer and compliance workflows, a local
+queryable audit store is essential.
+
+SQLite was chosen over PostgreSQL for the initial implementation because:
+- No external dependency (Microsoft.Data.Sqlite is already referenced)
+- Works on all platforms including local developer machines
+- Supports all required query filters via SQL
+- WAL mode provides adequate write throughput for audit volumes
+
+---
+
+## Decision
+
+### `SqliteAuditSink` implements `IQueryableAuditSink`
+
+The sink stores audit events in a SQLite database with:
+
+**Schema:**
+```sql
+CREATE TABLE audit_events (
+    rowid        INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id     TEXT    NOT NULL UNIQUE,
+    timestamp    TEXT    NOT NULL,   -- ISO 8601
+    user_id      TEXT,
+    session_id   TEXT,
+    trace_id     TEXT,
+    action       TEXT    NOT NULL,
+    resource     TEXT,
+    detail       TEXT,
+    severity     INTEGER NOT NULL,   -- enum ordinal
+    policy_result TEXT,
+    tool_name    TEXT,
+    tool_args    TEXT,
+    tool_result  TEXT,
+    duration_ms  INTEGER,
+    previous_hash TEXT,
+    payload      TEXT    NOT NULL    -- full JSON
+);
+```
+
+**Indexes:** timestamp (DESC), session_id, user_id, action (NOCASE), severity
+
+**Design choices:**
+- `event_id UNIQUE` — duplicate events are silently ignored (idempotent writes)
+- Full JSON payload stored alongside indexed columns to support deserializing
+  complete `AuditEvent` objects from queries
+- WAL + NORMAL synchronous mode: reduces fsync overhead while maintaining
+  crash-consistent writes for non-critical local audit storage
+- `IAsyncDisposable` implemented but no-op: SQLite connections are opened and
+  closed per-operation to avoid connection pool issues in async contexts
+
+### SQL injection prevention
+
+`BuildWhereClause` generates only parameterized conditions. `LIMIT` and `OFFSET`
+are passed as sanitized integers (Math.Min/Max bounds), which cannot contain
+injection. CA2100 suppressions are documented at each site.
+
+### DI registration
+
+`SqliteAuditSink` should be registered as a named `IAuditSink` option when
+`AuditPolicy.Sink == "sqlite"`. The `ConnectionString` or `DataSource` path
+from `AuditPolicy` provides the database file location.
+
+---
+
+## Consequences
+
+### Positive
+
+- Developers get a zero-infrastructure queryable audit trail
+- `IQueryableAuditSink` can be used by a future CLI `jdai audit query` command
+- Tamper-evident chaining (PreviousHash) is preserved in the payload JSON
+- All existing sinks continue to work unchanged
+
+### Negative / Trade-offs
+
+- WAL mode + shared cache requires SQLite >= 3.7.0 (guaranteed by NuGet package)
+- Not suitable for high-throughput multi-process concurrent writes (use Elasticsearch for that)
+- No built-in retention/pruning — callers must manage database size
+
+### Future work
+
+- PostgreSQL `IQueryableAuditSink` using Npgsql for production deployments
+- `jdai audit query` CLI command using `IQueryableAuditSink`
+- `JdAiWorkflowAuditBridge` to forward WorkflowFramework audit events to `AuditService`
+- Automatic database pruning based on `SessionPolicy.RetentionDays`

--- a/src/JD.AI.Core/Governance/Audit/SqliteAuditSink.cs
+++ b/src/JD.AI.Core/Governance/Audit/SqliteAuditSink.cs
@@ -1,0 +1,252 @@
+using System.Data;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
+
+namespace JD.AI.Core.Governance.Audit;
+
+/// <summary>
+/// An <see cref="IQueryableAuditSink"/> that persists audit events to a SQLite database.
+/// Supports tamper-evident event chaining and all <see cref="AuditQuery"/> filters.
+/// </summary>
+public sealed class SqliteAuditSink : IQueryableAuditSink, IAsyncDisposable
+{
+    private readonly string _connectionString;
+    private long _count;
+
+    public string Name => "sqlite";
+
+    public long Count => Interlocked.Read(ref _count);
+
+    public SqliteAuditSink(string dbPath)
+    {
+        ArgumentNullException.ThrowIfNull(dbPath);
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Cache = SqliteCacheMode.Shared,
+        }.ToString();
+
+        InitializeDatabase();
+    }
+
+    private void InitializeDatabase()
+    {
+        using var conn = OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS audit_events (
+                rowid       INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id    TEXT    NOT NULL UNIQUE,
+                timestamp   TEXT    NOT NULL,
+                user_id     TEXT,
+                session_id  TEXT,
+                trace_id    TEXT,
+                action      TEXT    NOT NULL,
+                resource    TEXT,
+                detail      TEXT,
+                severity    INTEGER NOT NULL DEFAULT 1,
+                policy_result TEXT,
+                tool_name   TEXT,
+                tool_args   TEXT,
+                tool_result TEXT,
+                duration_ms INTEGER,
+                previous_hash TEXT,
+                payload     TEXT    NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_session   ON audit_events(session_id);
+            CREATE INDEX IF NOT EXISTS idx_audit_user      ON audit_events(user_id);
+            CREATE INDEX IF NOT EXISTS idx_audit_action    ON audit_events(action COLLATE NOCASE);
+            CREATE INDEX IF NOT EXISTS idx_audit_severity  ON audit_events(severity);
+            """;
+        cmd.ExecuteNonQuery();
+
+        // Seed the count
+        using var countCmd = conn.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM audit_events;";
+        var result = countCmd.ExecuteScalar();
+        Interlocked.Exchange(ref _count, result is long l ? l : Convert.ToInt64(result));
+    }
+
+    /// <inheritdoc/>
+    public async Task WriteAsync(AuditEvent evt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        await using var conn = await OpenConnectionAsync(ct).ConfigureAwait(false);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = """
+            INSERT OR IGNORE INTO audit_events
+                (event_id, timestamp, user_id, session_id, trace_id, action, resource,
+                 detail, severity, policy_result, tool_name, tool_args, tool_result,
+                 duration_ms, previous_hash, payload)
+            VALUES
+                (@eid, @ts, @uid, @sid, @tid, @act, @res,
+                 @det, @sev, @pol, @tn, @ta, @tr,
+                 @dur, @ph, @payload);
+            """;
+
+        AddParameter(cmd, "@eid", evt.EventId);
+        AddParameter(cmd, "@ts", evt.Timestamp.ToString("O"));
+        AddParameter(cmd, "@uid", (object?)evt.UserId ?? DBNull.Value);
+        AddParameter(cmd, "@sid", (object?)evt.SessionId ?? DBNull.Value);
+        AddParameter(cmd, "@tid", (object?)evt.TraceId ?? DBNull.Value);
+        AddParameter(cmd, "@act", evt.Action);
+        AddParameter(cmd, "@res", (object?)evt.Resource ?? DBNull.Value);
+        AddParameter(cmd, "@det", (object?)evt.Detail ?? DBNull.Value);
+        AddParameter(cmd, "@sev", (int)evt.Severity);
+        AddParameter(cmd, "@pol", evt.PolicyResult.HasValue ? (object)evt.PolicyResult.Value.ToString() : DBNull.Value);
+        AddParameter(cmd, "@tn", (object?)evt.ToolName ?? DBNull.Value);
+        AddParameter(cmd, "@ta", (object?)evt.ToolArguments ?? DBNull.Value);
+        AddParameter(cmd, "@tr", (object?)evt.ToolResult ?? DBNull.Value);
+        AddParameter(cmd, "@dur", evt.DurationMs.HasValue ? (object)evt.DurationMs.Value : DBNull.Value);
+        AddParameter(cmd, "@ph", (object?)evt.PreviousHash ?? DBNull.Value);
+        AddParameter(cmd, "@payload", JsonSerializer.Serialize(evt));
+
+        var rows = await cmd.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        if (rows > 0)
+            Interlocked.Increment(ref _count);
+    }
+
+    /// <inheritdoc/>
+    public async Task<AuditQueryResult> QueryAsync(AuditQuery query, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var limit = Math.Min(query.Limit > 0 ? query.Limit : 50, 1000);
+        var offset = Math.Max(query.Offset, 0);
+
+        await using var conn = await OpenConnectionAsync(ct).ConfigureAwait(false);
+
+        var (where, parameters) = BuildWhereClause(query);
+
+        // Count total
+        await using var countCmd = conn.CreateCommand();
+        // CA2100: where clause uses only parameterized conditions built by BuildWhereClause — no injection risk
+#pragma warning disable CA2100
+        countCmd.CommandText = $"SELECT COUNT(*) FROM audit_events {where};";
+        foreach (var (name, value) in parameters)
+            AddParameter(countCmd, name, value);
+#pragma warning restore CA2100
+
+        var totalRaw = await countCmd.ExecuteScalarAsync(ct).ConfigureAwait(false);
+        var total = totalRaw is long l ? l : Convert.ToInt64(totalRaw);
+
+        // Fetch events
+        await using var dataCmd = conn.CreateCommand();
+        // CA2100: limit and offset are integer-sanitized above (Math.Min/Max) — no injection risk
+#pragma warning disable CA2100
+        dataCmd.CommandText = $"""
+            SELECT payload FROM audit_events
+            {where}
+            ORDER BY timestamp DESC
+            LIMIT {limit} OFFSET {offset};
+            """;
+#pragma warning restore CA2100
+        foreach (var (name, value) in parameters)
+            AddParameter(dataCmd, name, value);
+
+        var events = new List<AuditEvent>();
+        await using var reader = await dataCmd.ExecuteReaderAsync(ct).ConfigureAwait(false);
+        while (await reader.ReadAsync(ct).ConfigureAwait(false))
+        {
+            var json = reader.GetString(0);
+            var evt = JsonSerializer.Deserialize<AuditEvent>(json);
+            if (evt is not null)
+                events.Add(evt);
+        }
+
+        return new AuditQueryResult { Events = events, TotalCount = total };
+    }
+
+    /// <inheritdoc/>
+    public Task FlushAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static (string where, List<(string name, object value)> parameters) BuildWhereClause(AuditQuery q)
+    {
+        var conditions = new List<string>();
+        var parameters = new List<(string, object)>();
+
+        if (q.Action is not null)
+        {
+            conditions.Add("action = @action COLLATE NOCASE");
+            parameters.Add(("@action", q.Action));
+        }
+
+        if (q.MinSeverity.HasValue)
+        {
+            conditions.Add("severity >= @sev");
+            parameters.Add(("@sev", (int)q.MinSeverity.Value));
+        }
+
+        if (q.SessionId is not null)
+        {
+            conditions.Add("session_id = @sid");
+            parameters.Add(("@sid", q.SessionId));
+        }
+
+        if (q.UserId is not null)
+        {
+            conditions.Add("user_id = @uid");
+            parameters.Add(("@uid", q.UserId));
+        }
+
+        if (q.Resource is not null)
+        {
+            conditions.Add("resource LIKE @res COLLATE NOCASE");
+            parameters.Add(("@res", $"%{q.Resource}%"));
+        }
+
+        if (q.From.HasValue)
+        {
+            conditions.Add("timestamp >= @from");
+            parameters.Add(("@from", q.From.Value.ToString("O")));
+        }
+
+        if (q.Until.HasValue)
+        {
+            conditions.Add("timestamp < @until");
+            parameters.Add(("@until", q.Until.Value.ToString("O")));
+        }
+
+        var where = conditions.Count > 0
+            ? "WHERE " + string.Join(" AND ", conditions)
+            : string.Empty;
+
+        return (where, parameters);
+    }
+
+    private static void AddParameter(SqliteCommand cmd, string name, object value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
+    }
+
+    private SqliteConnection OpenConnection()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+        using var pragma = conn.CreateCommand();
+        pragma.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
+        pragma.ExecuteNonQuery();
+        return conn;
+    }
+
+    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken ct)
+    {
+        var conn = new SqliteConnection(_connectionString);
+        await conn.OpenAsync(ct).ConfigureAwait(false);
+        await using var pragma = conn.CreateCommand();
+        pragma.CommandText = "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;";
+        await pragma.ExecuteNonQueryAsync(ct).ConfigureAwait(false);
+        return conn;
+    }
+}

--- a/tests/JD.AI.Tests/SqliteAuditSinkTests.cs
+++ b/tests/JD.AI.Tests/SqliteAuditSinkTests.cs
@@ -1,0 +1,213 @@
+using JD.AI.Core.Governance;
+using JD.AI.Core.Governance.Audit;
+using Xunit;
+
+namespace JD.AI.Tests;
+
+public sealed class SqliteAuditSinkTests : IAsyncDisposable
+{
+    private readonly string _dbPath;
+    private readonly SqliteAuditSink _sink;
+
+    public SqliteAuditSinkTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"audit_test_{Guid.NewGuid():N}.db");
+        _sink = new SqliteAuditSink(_dbPath);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _sink.DisposeAsync();
+        if (File.Exists(_dbPath))
+            File.Delete(_dbPath);
+    }
+
+    // ── write and count ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WriteAsync_SingleEvent_CountIncreases()
+    {
+        var evt = MakeEvent("ToolCall");
+        await _sink.WriteAsync(evt);
+        Assert.Equal(1, _sink.Count);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DuplicateEventId_NotDuplicated()
+    {
+        var evt = MakeEvent("ToolCall");
+        await _sink.WriteAsync(evt);
+        await _sink.WriteAsync(evt); // same event id
+        Assert.Equal(1, _sink.Count);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MultipleEvents_AllPersisted()
+    {
+        for (var i = 0; i < 5; i++)
+            await _sink.WriteAsync(MakeEvent("Action" + i));
+
+        Assert.Equal(5, _sink.Count);
+    }
+
+    // ── query — no filter ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_NoFilter_ReturnsAllEvents()
+    {
+        await _sink.WriteAsync(MakeEvent("A"));
+        await _sink.WriteAsync(MakeEvent("B"));
+
+        var result = await _sink.QueryAsync(new AuditQuery { Limit = 100 });
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.Equal(2, result.Events.Count);
+    }
+
+    // ── query — action filter ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_FilterByAction_ReturnsMatchingOnly()
+    {
+        await _sink.WriteAsync(MakeEvent("ToolCall"));
+        await _sink.WriteAsync(MakeEvent("ProviderCall"));
+        await _sink.WriteAsync(MakeEvent("ToolCall"));
+
+        var result = await _sink.QueryAsync(new AuditQuery { Action = "ToolCall" });
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.All(result.Events, e => Assert.Equal("ToolCall", e.Action));
+    }
+
+    [Fact]
+    public async Task QueryAsync_ActionIsCaseInsensitive()
+    {
+        await _sink.WriteAsync(MakeEvent("ToolCall"));
+
+        var result = await _sink.QueryAsync(new AuditQuery { Action = "toolcall" });
+        Assert.Equal(1, result.TotalCount);
+    }
+
+    // ── query — severity filter ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_FilterByMinSeverity_ExcludesLower()
+    {
+        await _sink.WriteAsync(MakeEvent("A", AuditSeverity.Info));
+        await _sink.WriteAsync(MakeEvent("B", AuditSeverity.Warning));
+        await _sink.WriteAsync(MakeEvent("C", AuditSeverity.Error));
+
+        var result = await _sink.QueryAsync(new AuditQuery { MinSeverity = AuditSeverity.Warning });
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.All(result.Events, e => Assert.True(e.Severity >= AuditSeverity.Warning));
+    }
+
+    // ── query — user/session filters ─────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_FilterByUserId_ReturnsMatchingOnly()
+    {
+        await _sink.WriteAsync(MakeEvent("A", userId: "alice"));
+        await _sink.WriteAsync(MakeEvent("B", userId: "bob"));
+
+        var result = await _sink.QueryAsync(new AuditQuery { UserId = "alice" });
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("alice", result.Events[0].UserId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_FilterBySessionId_ReturnsMatchingOnly()
+    {
+        var sid = "session-abc";
+        await _sink.WriteAsync(MakeEvent("A", sessionId: sid));
+        await _sink.WriteAsync(MakeEvent("B", sessionId: "other"));
+
+        var result = await _sink.QueryAsync(new AuditQuery { SessionId = sid });
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal(sid, result.Events[0].SessionId);
+    }
+
+    // ── query — time filters ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_FilterByFrom_ExcludesOlderEvents()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await _sink.WriteAsync(MakeEvent("Old", timestamp: now.AddHours(-2)));
+        await _sink.WriteAsync(MakeEvent("New", timestamp: now));
+
+        var result = await _sink.QueryAsync(new AuditQuery { From = now.AddHours(-1) });
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("New", result.Events[0].Action);
+    }
+
+    // ── query — pagination ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_Pagination_ReturnsCorrectPage()
+    {
+        for (var i = 0; i < 10; i++)
+            await _sink.WriteAsync(MakeEvent("Action" + i));
+
+        var page1 = await _sink.QueryAsync(new AuditQuery { Limit = 5, Offset = 0 });
+        var page2 = await _sink.QueryAsync(new AuditQuery { Limit = 5, Offset = 5 });
+
+        Assert.Equal(5, page1.Events.Count);
+        Assert.Equal(5, page2.Events.Count);
+        Assert.Equal(10, page1.TotalCount);
+        // No overlap
+        var ids1 = page1.Events.Select(e => e.EventId).ToHashSet(StringComparer.Ordinal);
+        Assert.DoesNotContain(page2.Events, e => ids1.Contains(e.EventId));
+    }
+
+    // ── query — newest first ordering ────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_OrderIsNewestFirst()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await _sink.WriteAsync(MakeEvent("First", timestamp: now.AddMinutes(-10)));
+        await _sink.WriteAsync(MakeEvent("Second", timestamp: now.AddMinutes(-5)));
+        await _sink.WriteAsync(MakeEvent("Third", timestamp: now));
+
+        var result = await _sink.QueryAsync(new AuditQuery());
+
+        Assert.Equal("Third", result.Events[0].Action);
+        Assert.Equal("First", result.Events[^1].Action);
+    }
+
+    // ── IAuditSink interface ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Name_IsCorrect()
+    {
+        Assert.Equal("sqlite", _sink.Name);
+    }
+
+    [Fact]
+    public async Task FlushAsync_DoesNotThrow()
+    {
+        await _sink.FlushAsync(); // should be no-op
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static AuditEvent MakeEvent(
+        string action,
+        AuditSeverity severity = AuditSeverity.Info,
+        string? userId = null,
+        string? sessionId = null,
+        DateTimeOffset? timestamp = null) =>
+        new()
+        {
+            Action = action,
+            Severity = severity,
+            UserId = userId,
+            SessionId = sessionId,
+            Timestamp = timestamp ?? DateTimeOffset.UtcNow,
+        };
+}


### PR DESCRIPTION
Closes #206 (partial — SQLite sink)

## What changed

- Added \SqliteAuditSink\ implementing \IQueryableAuditSink\
- WAL mode + shared cache for concurrent read performance
- Parameterized SQL for all filter conditions (no injection risk)
- Indexes on timestamp, session_id, user_id, action (NOCASE), severity
- Full JSON payload column for complete AuditEvent round-trip
- 14 unit tests covering: write, dedup, pagination, all filters, newest-first ordering
- ADR-004 documenting design decisions

## Schema

\\\sql
CREATE TABLE audit_events (
    event_id TEXT NOT NULL UNIQUE, timestamp TEXT NOT NULL,
    action TEXT NOT NULL, severity INTEGER, ...
    payload TEXT NOT NULL  -- full JSON
);
\\\

## Future work (tracked in #206)
- PostgreSQL IQueryableAuditSink
- CLI \jdai audit query\ command  
- JdAiWorkflowAuditBridge