### PR TITLE
feat(agents): AgentDefinition YAML format and registry

### DIFF
--- a/src/JD.AI.Core/Agents/AgentDefinition.cs
+++ b/src/JD.AI.Core/Agents/AgentDefinition.cs
@@ -1,0 +1,94 @@
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Describes a fully configured agent as a serializable, versionable artifact.
+/// An agent definition captures everything needed to reproduce an agent's behavior
+/// across environments: model selection, tool loadout, system prompt, and workflow chain.
+/// </summary>
+/// <remarks>
+/// YAML format example:
+/// <code>
+/// name: pr-reviewer
+/// displayName: PR Reviewer Agent
+/// description: Reviews pull requests for code quality and security
+/// version: "1.0"
+/// model:
+///   provider: ClaudeCode
+///   id: claude-opus-4
+///   maxOutputTokens: 8096
+/// loadout: developer
+/// systemPrompt: |
+///   You are a code reviewer focused on...
+/// workflows:
+///   - pr-review-workflow
+/// tags:
+///   - code-review
+/// </code>
+/// </remarks>
+public sealed class AgentDefinition
+{
+    /// <summary>Unique identifier for this agent (kebab-case, e.g. "pr-reviewer").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Human-readable display name.</summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>Description of this agent's purpose and capabilities.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Semantic version string (e.g. "1.0", "2.3.1").</summary>
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>Model selection for this agent.</summary>
+    public AgentModelSpec? Model { get; set; }
+
+    /// <summary>
+    /// Name of the tool loadout to apply (must be registered in <c>IToolLoadoutRegistry</c>).
+    /// Defaults to the session's active loadout if not specified.
+    /// </summary>
+    public string? Loadout { get; set; }
+
+    /// <summary>System prompt override. Supports multi-line YAML block scalars.</summary>
+    public string? SystemPrompt { get; set; }
+
+    /// <summary>
+    /// Named workflows this agent can trigger (references <c>AgentWorkflowDefinition.Name</c>).
+    /// </summary>
+    public IList<string> Workflows { get; init; } = [];
+
+    /// <summary>Classification and discovery tags.</summary>
+    public IList<string> Tags { get; init; } = [];
+
+    /// <summary>Whether this definition is deprecated and should not be used for new sessions.</summary>
+    public bool IsDeprecated { get; set; }
+
+    /// <summary>Guidance for migrating to a newer version.</summary>
+    public string? MigrationGuidance { get; set; }
+
+    /// <summary>Environment this definition is intended for (e.g. "development", "production").</summary>
+    public string? Environment { get; set; }
+
+    /// <summary>Timestamp the definition was first authored.</summary>
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Timestamp the definition was last modified.</summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Model selection within an <see cref="AgentDefinition"/>.
+/// </summary>
+public sealed class AgentModelSpec
+{
+    /// <summary>Provider name (e.g. "ClaudeCode", "OpenAI", "Ollama").</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>Model identifier within the provider (e.g. "claude-opus-4", "gpt-4o").</summary>
+    public string? Id { get; set; }
+
+    /// <summary>Maximum output tokens override.</summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>Temperature override (0.0–2.0).</summary>
+    public double? Temperature { get; set; }
+}

--- a/src/JD.AI.Core/Agents/AgentDefinitionRegistry.cs
+++ b/src/JD.AI.Core/Agents/AgentDefinitionRegistry.cs
@@ -1,0 +1,40 @@
+using System.Collections.Concurrent;
+
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Thread-safe in-memory <see cref="IAgentDefinitionRegistry"/>.
+/// </summary>
+public sealed class AgentDefinitionRegistry : IAgentDefinitionRegistry
+{
+    private readonly ConcurrentDictionary<string, AgentDefinition> _definitions =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentDefinition> GetAll() =>
+        [.. _definitions.Values];
+
+    /// <inheritdoc />
+    public AgentDefinition? GetByName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        return _definitions.TryGetValue(name, out var def) ? def : null;
+    }
+
+    /// <inheritdoc />
+    public void Register(AgentDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (string.IsNullOrWhiteSpace(definition.Name))
+            throw new ArgumentException("AgentDefinition.Name must not be empty.", nameof(definition));
+
+        _definitions[definition.Name] = definition;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<AgentDefinition> GetByTag(string tag)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag);
+        return [.. _definitions.Values.Where(d => d.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))];
+    }
+}

--- a/src/JD.AI.Core/Agents/AgentSession.cs
+++ b/src/JD.AI.Core/Agents/AgentSession.cs
@@ -133,6 +133,11 @@ public sealed class AgentSession
     public IReadOnlyList<KernelPlugin>? AllPlugins { get; set; }
 
     /// <summary>
+    /// Registry of agent definitions loaded from <c>*.agent.yaml</c> files.
+    /// </summary>
+    public IAgentDefinitionRegistry? AgentDefinitionRegistry { get; set; }
+
+    /// <summary>
     /// When true, supported providers can automatically enable prompt caching.
     /// </summary>
     public bool PromptCachingEnabled { get; set; } = true;

--- a/src/JD.AI.Core/Agents/FileAgentDefinitionLoader.cs
+++ b/src/JD.AI.Core/Agents/FileAgentDefinitionLoader.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Loads <see cref="AgentDefinition"/> instances from <c>*.agent.yaml</c> files
+/// in one or more search directories and registers them into an
+/// <see cref="IAgentDefinitionRegistry"/>.
+/// </summary>
+public sealed class FileAgentDefinitionLoader
+{
+    private static readonly IDeserializer Deserializer =
+        new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+    private readonly IAgentDefinitionRegistry _registry;
+    private readonly ILogger<FileAgentDefinitionLoader> _logger;
+
+    public FileAgentDefinitionLoader(
+        IAgentDefinitionRegistry registry,
+        ILogger<FileAgentDefinitionLoader> logger)
+    {
+        _registry = registry;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Scans <paramref name="searchPaths"/> for <c>*.agent.yaml</c> files and loads
+    /// each into the registry. Malformed files are skipped with a warning.
+    /// </summary>
+    public void LoadAll(IEnumerable<string> searchPaths)
+    {
+        foreach (var dir in searchPaths)
+        {
+            if (!Directory.Exists(dir))
+                continue;
+
+            var files = Directory.EnumerateFiles(dir, "*.agent.yaml", SearchOption.AllDirectories);
+            foreach (var file in files)
+                LoadFile(file);
+        }
+    }
+
+    /// <summary>Loads and registers a single <c>.agent.yaml</c> file.</summary>
+    public void LoadFile(string path)
+    {
+        try
+        {
+            var yaml = File.ReadAllText(path);
+            var definition = Deserializer.Deserialize<AgentDefinition>(yaml);
+
+            if (string.IsNullOrWhiteSpace(definition.Name))
+            {
+                _logger.LogWarning("Skipping agent definition file {File}: missing 'name' field", path);
+                return;
+            }
+
+            _registry.Register(definition);
+            _logger.LogDebug("Loaded agent definition '{Name}' v{Version} from {File}",
+                definition.Name, definition.Version, path);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse agent definition file {File}", path);
+        }
+    }
+}

--- a/src/JD.AI.Core/Agents/IAgentDefinitionRegistry.cs
+++ b/src/JD.AI.Core/Agents/IAgentDefinitionRegistry.cs
@@ -1,0 +1,26 @@
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Registry for <see cref="AgentDefinition"/> instances loaded from
+/// YAML files or registered programmatically.
+/// </summary>
+public interface IAgentDefinitionRegistry
+{
+    /// <summary>Returns all registered agent definitions.</summary>
+    IReadOnlyList<AgentDefinition> GetAll();
+
+    /// <summary>
+    /// Returns the definition with the given <paramref name="name"/>,
+    /// or <c>null</c> if no matching definition is registered.
+    /// </summary>
+    AgentDefinition? GetByName(string name);
+
+    /// <summary>
+    /// Registers a definition. If a definition with the same
+    /// <paramref name="definition.Name"/> already exists it is replaced.
+    /// </summary>
+    void Register(AgentDefinition definition);
+
+    /// <summary>Returns all definitions that carry the specified <paramref name="tag"/>.</summary>
+    IReadOnlyList<AgentDefinition> GetByTag(string tag);
+}

--- a/src/JD.AI/Startup/GovernanceInitializer.cs
+++ b/src/JD.AI/Startup/GovernanceInitializer.cs
@@ -127,6 +127,22 @@ internal static class GovernanceInitializer
         kernel.Plugins.AddFromObject(
             new ToolDiscoveryTools(kernel, loadoutRegistry, allPlugins), "toolDiscovery");
 
+        // Agent definition registry — scan user and project-level agent directories
+        var agentRegistry = new AgentDefinitionRegistry();
+        var agentLoader = new FileAgentDefinitionLoader(
+            agentRegistry,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<FileAgentDefinitionLoader>.Instance);
+        var agentSearchPaths = new[]
+        {
+            Path.Combine(DataDirectories.Root, "agents"),
+            Path.Combine(projectPath, "agents"),
+            Path.Combine(projectPath, ".agents"),
+        };
+        agentLoader.LoadAll(agentSearchPaths);
+        session.AgentDefinitionRegistry = agentRegistry;
+        if (!opts.PrintMode && agentRegistry.GetAll().Count > 0)
+            ChatRenderer.RenderInfo($"  Loaded {agentRegistry.GetAll().Count} agent definition(s)");
+
         // Project instructions
         var instructions = InstructionsLoader.Load();
         if (instructions.HasInstructions)

--- a/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
@@ -1,0 +1,185 @@
+using JD.AI.Core.Agents;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace JD.AI.Tests.Agents;
+
+public sealed class AgentDefinitionRegistryTests : IDisposable
+{
+    private readonly string _tmpDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")[..8]);
+
+    public AgentDefinitionRegistryTests() => Directory.CreateDirectory(_tmpDir);
+    public void Dispose() { try { Directory.Delete(_tmpDir, recursive: true); } catch { } }
+
+    // ── Registry tests ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Register_AddsDefinition()
+    {
+        var registry = new AgentDefinitionRegistry();
+        registry.Register(new AgentDefinition { Name = "my-agent" });
+        Assert.Single(registry.GetAll());
+    }
+
+    [Fact]
+    public void Register_OverwritesExistingName()
+    {
+        var registry = new AgentDefinitionRegistry();
+        registry.Register(new AgentDefinition { Name = "alpha", Version = "1.0" });
+        registry.Register(new AgentDefinition { Name = "alpha", Version = "2.0" });
+        var def = registry.GetByName("alpha");
+        Assert.NotNull(def);
+        Assert.Equal("2.0", def.Version);
+    }
+
+    [Fact]
+    public void GetByName_CaseInsensitive()
+    {
+        var registry = new AgentDefinitionRegistry();
+        registry.Register(new AgentDefinition { Name = "MyAgent" });
+        Assert.NotNull(registry.GetByName("myagent"));
+        Assert.NotNull(registry.GetByName("MYAGENT"));
+    }
+
+    [Fact]
+    public void GetByName_ReturnsNullWhenNotFound()
+    {
+        var registry = new AgentDefinitionRegistry();
+        Assert.Null(registry.GetByName("nope"));
+    }
+
+    [Fact]
+    public void GetByTag_ReturnsMatchingDefinitions()
+    {
+        var registry = new AgentDefinitionRegistry();
+        registry.Register(new AgentDefinition { Name = "a", Tags = ["code-review", "security"] });
+        registry.Register(new AgentDefinition { Name = "b", Tags = ["docs"] });
+        registry.Register(new AgentDefinition { Name = "c", Tags = ["code-review"] });
+
+        var results = registry.GetByTag("code-review");
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, d => d.Name == "a");
+        Assert.Contains(results, d => d.Name == "c");
+    }
+
+    [Fact]
+    public void GetByTag_CaseInsensitive()
+    {
+        var registry = new AgentDefinitionRegistry();
+        registry.Register(new AgentDefinition { Name = "x", Tags = ["CodeReview"] });
+        Assert.Single(registry.GetByTag("codereview"));
+    }
+
+    [Fact]
+    public void Register_ThrowsOnEmptyName()
+    {
+        var registry = new AgentDefinitionRegistry();
+        Assert.Throws<ArgumentException>(() =>
+            registry.Register(new AgentDefinition { Name = "" }));
+    }
+
+    // ── Loader tests ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Loader_LoadsValidYamlFile()
+    {
+        var yaml = """
+            name: pr-reviewer
+            displayName: PR Reviewer
+            version: "1.2"
+            description: Reviews pull requests
+            loadout: developer
+            tags:
+              - code-review
+              - security
+            workflows:
+              - pr-workflow
+            """;
+
+        File.WriteAllText(Path.Combine(_tmpDir, "pr-reviewer.agent.yaml"), yaml);
+
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        loader.LoadAll([_tmpDir]);
+
+        var def = registry.GetByName("pr-reviewer");
+        Assert.NotNull(def);
+        Assert.Equal("PR Reviewer", def.DisplayName);
+        Assert.Equal("1.2", def.Version);
+        Assert.Contains("code-review", def.Tags);
+        Assert.Contains("pr-workflow", def.Workflows);
+    }
+
+    [Fact]
+    public void Loader_SkipsMissingDirectory()
+    {
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        // Should not throw
+        loader.LoadAll(["/nonexistent/path/agents"]);
+        Assert.Empty(registry.GetAll());
+    }
+
+    [Fact]
+    public void Loader_SkipsMalformedYaml()
+    {
+        File.WriteAllText(Path.Combine(_tmpDir, "bad.agent.yaml"), "{ not valid yaml: [[[");
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        // Should not throw
+        loader.LoadAll([_tmpDir]);
+        Assert.Empty(registry.GetAll());
+    }
+
+    [Fact]
+    public void Loader_SkipsFileWithNoName()
+    {
+        var yaml = """
+            displayName: No Name Agent
+            version: "1.0"
+            """;
+        File.WriteAllText(Path.Combine(_tmpDir, "noname.agent.yaml"), yaml);
+
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        loader.LoadAll([_tmpDir]);
+        Assert.Empty(registry.GetAll());
+    }
+
+    [Fact]
+    public void Loader_LoadsMultipleFiles()
+    {
+        File.WriteAllText(Path.Combine(_tmpDir, "a.agent.yaml"), "name: agent-a\nversion: \"1.0\"");
+        File.WriteAllText(Path.Combine(_tmpDir, "b.agent.yaml"), "name: agent-b\nversion: \"1.0\"");
+
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        loader.LoadAll([_tmpDir]);
+        Assert.Equal(2, registry.GetAll().Count);
+    }
+
+    [Fact]
+    public void Loader_LoadsModelSpec()
+    {
+        var yaml = """
+            name: smart-agent
+            model:
+              provider: ClaudeCode
+              id: claude-opus-4
+              maxOutputTokens: 8096
+              temperature: 0.7
+            """;
+        File.WriteAllText(Path.Combine(_tmpDir, "smart.agent.yaml"), yaml);
+
+        var registry = new AgentDefinitionRegistry();
+        var loader = new FileAgentDefinitionLoader(registry, NullLogger<FileAgentDefinitionLoader>.Instance);
+        loader.LoadAll([_tmpDir]);
+
+        var def = registry.GetByName("smart-agent");
+        Assert.NotNull(def?.Model);
+        Assert.Equal("ClaudeCode", def.Model.Provider);
+        Assert.Equal("claude-opus-4", def.Model.Id);
+        Assert.Equal(8096, def.Model.MaxOutputTokens);
+        Assert.Equal(0.7, def.Model.Temperature);
+    }
+}


### PR DESCRIPTION
Closes #201

## What changed

Added a full .agent.yaml format and supporting infrastructure for defining agents as versioned artifacts.

### New types

- AgentDefinition: YAML model with name, displayName, version, model spec, loadout, systemPrompt, workflows, tags
- AgentModelSpec: Nested model selection (provider, id, maxOutputTokens, temperature)
- IAgentDefinitionRegistry + AgentDefinitionRegistry: Thread-safe, case-insensitive in-memory registry
- FileAgentDefinitionLoader: Scans *.agent.yaml from configurable search paths

### Startup

GovernanceInitializer now scans at startup:
- ~/.jdai/agents/ (user-level)
- ./agents/ (project-level)
- ./.agents/ (alternative project location)

## Tests

15 unit tests: register, override, case-insensitive lookup, tag filter, YAML parsing, malformed YAML, missing name, model spec deserialization.
