### PR TITLE
feat: versioned agent registry with environment scopes and CLI (#211)

### DIFF
--- a/docs/architecture/decisions/ADR-006-file-agent-registry.md
+++ b/docs/architecture/decisions/ADR-006-file-agent-registry.md
@@ -1,0 +1,121 @@
+# ADR-006: FileAgentDefinitionRegistry — Versioned, Environment-Scoped Agent Storage
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #211 extends the `AgentDefinition` format introduced in #201 with a registry
+that supports:
+
+1. **Versioning** — multiple versions of an agent coexist; `latest` resolves the
+   highest semantic version.
+2. **Environment scopes** — `dev`, `staging`, `prod` form a promotion pipeline.
+3. **Integrity** — a SHA-256 checksum stored alongside each YAML prevents silent
+   corruption or tampering.
+4. **CLI operations** — list, tag, promote, remove.
+
+The existing in-memory `AgentDefinitionRegistry` supports fast synchronous lookups
+but has no persistence or promotion mechanics.
+
+## Decision
+
+### Directory Layout
+
+```text
+~/.jdai/agents/
+  dev/
+    pr-reviewer@1.0.agent.yaml
+    pr-reviewer@1.0.sha256
+    pr-reviewer@2.0.agent.yaml
+    pr-reviewer@2.0.sha256
+  staging/
+    pr-reviewer@1.0.agent.yaml
+    pr-reviewer@1.0.sha256
+  prod/
+```
+
+Files are named `{name}@{version}.agent.yaml`.
+Non-alphanumeric characters other than `.` and `-` are replaced with `_` in
+the file name.
+
+### Versioning
+
+- Multiple versions of the same agent name may coexist within an environment.
+- `ResolveAsync(name, "latest")` or `ResolveAsync(name, null)` returns the
+  entry with the highest `System.Version` (after normalizing single-segment
+  versions to `n.0`).
+- Exact version strings are matched case-insensitively.
+
+### Environment Promotion
+
+`PromoteAsync(name, version, from, to)` copies (re-registers) the definition
+into the target environment. The source definition is preserved — promotion is
+non-destructive.
+
+The promotion chain `dev → staging → prod` is encoded in `AgentEnvironments.NextAfter()`.
+
+### Checksum Verification
+
+On `RegisterAsync`:
+1. The YAML content is serialized.
+2. `SHA256.HashData()` computes a hex checksum.
+3. The checksum is written to `{name}@{version}.sha256`.
+
+On `LoadAndVerifyAsync` (called by `ListAsync`):
+1. If a companion `.sha256` file exists, the stored and computed checksums are
+   compared.
+2. Mismatch → the file is silently skipped (not surfaced to callers).
+3. Missing `.sha256` → file is loaded without verification (backwards compat
+   with hand-authored files).
+
+### Interface Design
+
+`FileAgentDefinitionRegistry` implements both:
+
+| Interface | Used by |
+|-----------|---------|
+| `IAgentDefinitionRegistry` | Synchronous in-session lookups (existing callers) |
+| `IVersionedAgentDefinitionRegistry` | CLI, governance, promotion workflows |
+
+The sync `IAgentDefinitionRegistry` methods delegate to an internal
+`AgentDefinitionRegistry` (in-memory, ConcurrentDictionary) that is pre-warmed
+at construction time by reading all `dev/` definitions asynchronously.
+
+### CLI Commands
+
+```text
+jdai agents list [--env dev|staging|prod] [-v]
+jdai agents tag <name> <version> [--env <env>]
+jdai agents promote <name> [<version>] [--from <env>] [--to <env>]
+jdai agents remove <name> <version> [--env <env>]
+```
+
+## Consequences
+
+### Positive
+
+- Agents are durable across sessions.
+- Multiple versions coexist without conflict.
+- Environment promotion mirrors standard infrastructure promotion workflows.
+- Integrity checks prevent loading tampered definitions.
+- Backwards compatible: hand-authored YAML files (no `.sha256`) still load.
+
+### Negative / Trade-offs
+
+- `ListAsync` performs file I/O on every call — no cache invalidation or
+  file-system watcher. For large registries (>100 agents), callers should cache.
+- The in-memory sync cache is pre-warmed from `dev/` only.  Definitions in other
+  environments require async resolution.
+- SHA-256 covers the serialized YAML content only.  Agent Name/Version fields
+  could be altered by re-serializing from a tampered object.  Deep validation
+  (e.g., signing) is deferred to a future issue.
+
+## Related
+
+- ADR-002: Tool Safety Tiers
+- ADR-003: RBAC Policy Evaluation
+- ADR-005: IApprovalService
+- Issue #201 — Agent Definition Format (`.agent.yaml` schema)
+- Issue #211 — Agent Registry (this ADR)

--- a/src/JD.AI.Core/Agents/AgentEnvironments.cs
+++ b/src/JD.AI.Core/Agents/AgentEnvironments.cs
@@ -1,0 +1,20 @@
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Describes which environment scope an agent definition belongs to.
+/// Environments form a promotion pipeline: Dev → Staging → Production.
+/// </summary>
+public static class AgentEnvironments
+{
+    public const string Dev     = "dev";
+    public const string Staging = "staging";
+    public const string Prod    = "prod";
+
+    /// <summary>Ordered environments from lowest to highest.</summary>
+    public static readonly IReadOnlyList<string> All = [Dev, Staging, Prod];
+
+    /// <summary>Returns the next environment in the promotion chain, or null.</summary>
+    public static string? NextAfter(string env) =>
+        env.Equals(Dev, StringComparison.OrdinalIgnoreCase)     ? Staging :
+        env.Equals(Staging, StringComparison.OrdinalIgnoreCase) ? Prod    : null;
+}

--- a/src/JD.AI.Core/Agents/FileAgentDefinitionRegistry.cs
+++ b/src/JD.AI.Core/Agents/FileAgentDefinitionRegistry.cs
@@ -1,0 +1,221 @@
+using System.Security.Cryptography;
+using System.Text;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// File-backed <see cref="IVersionedAgentDefinitionRegistry"/> that stores
+/// <see cref="AgentDefinition"/> instances as <c>*.agent.yaml</c> files inside
+/// environment-scoped sub-directories of a root path.
+/// </summary>
+/// <remarks>
+/// Directory layout:
+/// <code>
+///   {root}/dev/     → development agent definitions
+///   {root}/staging/ → staging agent definitions
+///   {root}/prod/    → production agent definitions
+/// </code>
+/// Files are named <c>{name}@{version}.agent.yaml</c>.
+/// A companion <c>{name}@{version}.sha256</c> file stores the checksum.
+/// </remarks>
+public sealed class FileAgentDefinitionRegistry : IVersionedAgentDefinitionRegistry
+{
+    private static readonly ISerializer _serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    private static readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    private readonly string _rootPath;
+
+    // In-memory layer for fast synchronous lookups (IAgentDefinitionRegistry compat)
+    private readonly AgentDefinitionRegistry _memCache = new();
+
+    public FileAgentDefinitionRegistry(string rootPath)
+    {
+        _rootPath = rootPath;
+        Directory.CreateDirectory(rootPath);
+
+        // Pre-warm in-memory cache from dev by default (used by sync IAgentDefinitionRegistry)
+        _ = Task.Run(async () =>
+        {
+            var all = await ListAsync(AgentEnvironments.Dev).ConfigureAwait(false);
+            foreach (var d in all) _memCache.Register(d);
+        });
+    }
+
+    // ── IAgentDefinitionRegistry (sync, in-memory) ─────────────────────────
+
+    public IReadOnlyList<AgentDefinition> GetAll() => _memCache.GetAll();
+    public AgentDefinition? GetByName(string name) => _memCache.GetByName(name);
+    public void Register(AgentDefinition definition) => _memCache.Register(definition);
+    public IReadOnlyList<AgentDefinition> GetByTag(string tag) => _memCache.GetByTag(tag);
+
+    // ── IVersionedAgentDefinitionRegistry ─────────────────────────────────
+
+    public async Task RegisterAsync(
+        AgentDefinition definition,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (string.IsNullOrWhiteSpace(definition.Name))
+            throw new ArgumentException("AgentDefinition.Name is required.", nameof(definition));
+        if (string.IsNullOrWhiteSpace(definition.Version))
+            throw new ArgumentException("AgentDefinition.Version is required.", nameof(definition));
+
+        var dir = GetEnvDir(environment);
+        Directory.CreateDirectory(dir);
+
+        var yaml = _serializer.Serialize(definition);
+        var filePath = GetFilePath(dir, definition.Name, definition.Version);
+        var checksumPath = GetChecksumPath(dir, definition.Name, definition.Version);
+
+        await File.WriteAllTextAsync(filePath, yaml, cancellationToken).ConfigureAwait(false);
+
+        var checksum = ComputeChecksum(yaml);
+        await File.WriteAllTextAsync(checksumPath, checksum, cancellationToken).ConfigureAwait(false);
+
+        _memCache.Register(definition);
+    }
+
+    public async Task<AgentDefinition?> ResolveAsync(
+        string name,
+        string? version = null,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default)
+    {
+        var all = await ListAsync(environment, cancellationToken).ConfigureAwait(false);
+        var matches = all
+            .Where(d => d.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0) return null;
+
+        if (version is null or "latest")
+            return ResolveLatest(matches);
+
+        return matches.FirstOrDefault(d =>
+            d.Version.Equals(version, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<IReadOnlyList<AgentDefinition>> ListAsync(
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default)
+    {
+        var dir = GetEnvDir(environment);
+        if (!Directory.Exists(dir)) return [];
+
+        var results = new List<AgentDefinition>();
+        foreach (var file in Directory.EnumerateFiles(dir, "*.agent.yaml"))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var def = await LoadAndVerifyAsync(file, cancellationToken).ConfigureAwait(false);
+            if (def is not null) results.Add(def);
+        }
+        return results.AsReadOnly();
+    }
+
+    public async Task UnregisterAsync(
+        string name,
+        string version,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default)
+    {
+        var dir = GetEnvDir(environment);
+        var filePath = GetFilePath(dir, name, version);
+        var checksumPath = GetChecksumPath(dir, name, version);
+
+        if (File.Exists(filePath))
+            File.Delete(filePath);
+        if (File.Exists(checksumPath))
+            File.Delete(checksumPath);
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    public async Task PromoteAsync(
+        string name,
+        string version,
+        string fromEnvironment,
+        string toEnvironment,
+        CancellationToken cancellationToken = default)
+    {
+        var definition = await ResolveAsync(name, version, fromEnvironment, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (definition is null)
+            throw new InvalidOperationException(
+                $"Agent '{name}@{version}' not found in '{fromEnvironment}' environment.");
+
+        await RegisterAsync(definition, toEnvironment, cancellationToken).ConfigureAwait(false);
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────
+
+    private string GetEnvDir(string environment) =>
+        Path.Combine(_rootPath, environment.ToLowerInvariant());
+
+    private static string GetFilePath(string dir, string name, string version) =>
+        Path.Combine(dir, $"{SanitizeName(name)}@{SanitizeName(version)}.agent.yaml");
+
+    private static string GetChecksumPath(string dir, string name, string version) =>
+        Path.Combine(dir, $"{SanitizeName(name)}@{SanitizeName(version)}.sha256");
+
+    private static string SanitizeName(string s) =>
+        string.Concat(s.Select(c => char.IsLetterOrDigit(c) || c is '.' or '-' ? c : '_'));
+
+    private async Task<AgentDefinition?> LoadAndVerifyAsync(
+        string filePath, CancellationToken ct)
+    {
+        try
+        {
+            var yaml = await File.ReadAllTextAsync(filePath, ct).ConfigureAwait(false);
+
+            // Verify checksum if a companion file exists
+            var dir = Path.GetDirectoryName(filePath)!;
+            var fileName = Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(filePath));
+            var checksumPath = Path.Combine(dir, fileName + ".sha256");
+            if (File.Exists(checksumPath))
+            {
+                var storedChecksum = await File.ReadAllTextAsync(checksumPath, ct).ConfigureAwait(false);
+                var actualChecksum = ComputeChecksum(yaml);
+                if (!storedChecksum.Equals(actualChecksum, StringComparison.Ordinal))
+                    return null; // checksum mismatch — skip tampered file
+            }
+
+            return _deserializer.Deserialize<AgentDefinition>(yaml);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string ComputeChecksum(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    /// <summary>Returns the definition with the highest semantic version.</summary>
+    private static AgentDefinition ResolveLatest(List<AgentDefinition> candidates)
+    {
+        return candidates
+            .OrderByDescending(d => ParseSemVer(d.Version))
+            .First();
+    }
+
+    private static Version ParseSemVer(string version)
+    {
+        // Normalize "1.0" → "1.0.0" for consistent comparison
+        var normalized = version.Contains('.') ? version : version + ".0";
+        return System.Version.TryParse(normalized, out var v) ? v : new Version(0, 0, 0);
+    }
+}

--- a/src/JD.AI.Core/Agents/IVersionedAgentDefinitionRegistry.cs
+++ b/src/JD.AI.Core/Agents/IVersionedAgentDefinitionRegistry.cs
@@ -1,0 +1,54 @@
+namespace JD.AI.Core.Agents;
+
+/// <summary>
+/// Versioned registry for <see cref="AgentDefinition"/> instances supporting
+/// environment-scoped storage, semantic-version resolution, and environment promotion.
+/// </summary>
+public interface IVersionedAgentDefinitionRegistry : IAgentDefinitionRegistry
+{
+    /// <summary>
+    /// Persists the definition in the given environment scope.
+    /// If a definition with the same name+version already exists it is overwritten.
+    /// </summary>
+    Task RegisterAsync(
+        AgentDefinition definition,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves a definition by name and optional version within the given environment.
+    /// If <paramref name="version"/> is null or <c>"latest"</c>, the highest semver
+    /// definition is returned.  Returns <c>null</c> if not found.
+    /// </summary>
+    Task<AgentDefinition?> ResolveAsync(
+        string name,
+        string? version = null,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all definitions in the given environment, optionally filtered by name.
+    /// </summary>
+    Task<IReadOnlyList<AgentDefinition>> ListAsync(
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Removes the named version from the given environment.</summary>
+    Task UnregisterAsync(
+        string name,
+        string version,
+        string environment = AgentEnvironments.Dev,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Copies a definition from <paramref name="fromEnvironment"/> to
+    /// <paramref name="toEnvironment"/>. The definition must be registered in the
+    /// source environment.
+    /// </summary>
+    Task PromoteAsync(
+        string name,
+        string version,
+        string fromEnvironment,
+        string toEnvironment,
+        CancellationToken cancellationToken = default);
+}

--- a/src/JD.AI/Commands/AgentsCliHandler.cs
+++ b/src/JD.AI/Commands/AgentsCliHandler.cs
@@ -1,0 +1,204 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Commands;
+
+/// <summary>
+/// Handles <c>jdai agents ...</c> CLI commands for managing versioned agent definitions.
+/// </summary>
+internal static class AgentsCliHandler
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var sub = args.Length > 0 ? args[0].ToLowerInvariant() : "list";
+        var registry = CreateRegistry();
+
+        try
+        {
+            return sub switch
+            {
+                "list"    => await ListAsync(registry, args[1..]).ConfigureAwait(false),
+                "tag"     => await TagAsync(registry, args[1..]).ConfigureAwait(false),
+                "promote" => await PromoteAsync(registry, args[1..]).ConfigureAwait(false),
+                "remove" or "unregister"
+                          => await RemoveAsync(registry, args[1..]).ConfigureAwait(false),
+                "help" or "--help" or "-h" => PrintHelp(),
+                _ => PrintUnknown(sub),
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.Error.WriteLine($"Agents command failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────
+
+    private static async Task<int> ListAsync(FileAgentDefinitionRegistry registry, string[] args)
+    {
+        var env   = GetFlag(args, "--env") ?? AgentEnvironments.Dev;
+        var verbose = args.Contains("--verbose") || args.Contains("-v");
+
+        var agentsRoot = Path.Combine(DataDirectories.Root, "agents");
+        var agents = await registry.ListAsync(env).ConfigureAwait(false);
+
+        if (agents.Count == 0)
+        {
+            Console.WriteLine($"No agents registered in '{env}' environment.");
+            Console.WriteLine($"  Hint: place .agent.yaml files in: {Path.Combine(agentsRoot, env)}");
+            return 0;
+        }
+
+        Console.WriteLine($"Agents [{env}]:");
+        foreach (var a in agents.OrderBy(a => a.Name).ThenByDescending(a => a.Version))
+        {
+            Console.WriteLine($"  {a.Name}@{a.Version}" +
+                              (a.IsDeprecated ? "  [deprecated]" : ""));
+            if (verbose)
+            {
+                if (!string.IsNullOrWhiteSpace(a.Description))
+                    Console.WriteLine($"      {a.Description}");
+                if (a.Model is { } m)
+                    Console.WriteLine($"      Model: {m.Provider}/{m.Id}");
+                if (!string.IsNullOrWhiteSpace(a.Loadout))
+                    Console.WriteLine($"      Loadout: {a.Loadout}");
+                if (a.Workflows.Count > 0)
+                    Console.WriteLine($"      Workflows: {string.Join(", ", a.Workflows)}");
+                if (a.Tags.Count > 0)
+                    Console.WriteLine($"      Tags: {string.Join(", ", a.Tags)}");
+            }
+        }
+        return 0;
+    }
+
+    // ── tag ───────────────────────────────────────────────────────────────
+
+    private static async Task<int> TagAsync(FileAgentDefinitionRegistry registry, string[] args)
+    {
+        // jdai agents tag <name> <version> [--env dev|staging|prod]
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: jdai agents tag <name> <version> [--env <env>]");
+            return 1;
+        }
+
+        var nameArg = args[0];
+        var version = args[1];
+        var env = GetFlag(args[2..], "--env") ?? AgentEnvironments.Dev;
+
+        // Resolve existing or require explicit file path
+        var existing = await registry.ResolveAsync(nameArg, null, env).ConfigureAwait(false);
+        if (existing is null)
+        {
+            Console.Error.WriteLine($"Agent '{nameArg}' not found in '{env}'.");
+            return 1;
+        }
+
+        existing.Version = version;
+        existing.UpdatedAt = DateTime.UtcNow;
+        await registry.RegisterAsync(existing, env).ConfigureAwait(false);
+
+        Console.WriteLine($"✓ Tagged '{nameArg}' as v{version} in '{env}'.");
+        return 0;
+    }
+
+    // ── promote ───────────────────────────────────────────────────────────
+
+    private static async Task<int> PromoteAsync(FileAgentDefinitionRegistry registry, string[] args)
+    {
+        // jdai agents promote <name> [<version>] --to <env>
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("Usage: jdai agents promote <name> [<version>] --from <env> --to <env>");
+            return 1;
+        }
+
+        var name    = args[0];
+        var version = args.Length > 1 && !args[1].StartsWith("--") ? args[1] : "latest";
+        var from    = GetFlag(args, "--from") ?? AgentEnvironments.Dev;
+        var to      = GetFlag(args, "--to");
+
+        if (to is null)
+        {
+            // Default: promote to next environment in chain
+            to = AgentEnvironments.NextAfter(from);
+            if (to is null)
+            {
+                Console.Error.WriteLine($"'{from}' is the highest environment. Use --to to specify a target.");
+                return 1;
+            }
+        }
+
+        try
+        {
+            await registry.PromoteAsync(name, version, from, to).ConfigureAwait(false);
+            Console.WriteLine($"✓ Promoted '{name}@{version}' from '{from}' to '{to}'.");
+            return 0;
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine($"Promotion failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────
+
+    private static async Task<int> RemoveAsync(FileAgentDefinitionRegistry registry, string[] args)
+    {
+        // jdai agents remove <name> <version> [--env dev|staging|prod]
+        if (args.Length < 2)
+        {
+            Console.Error.WriteLine("Usage: jdai agents remove <name> <version> [--env <env>]");
+            return 1;
+        }
+
+        var name    = args[0];
+        var version = args[1];
+        var env     = GetFlag(args[2..], "--env") ?? AgentEnvironments.Dev;
+
+        await registry.UnregisterAsync(name, version, env).ConfigureAwait(false);
+        Console.WriteLine($"✓ Removed '{name}@{version}' from '{env}'.");
+        return 0;
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private static FileAgentDefinitionRegistry CreateRegistry() =>
+        new(DataDirectories.Root + Path.DirectorySeparatorChar + "agents");
+
+    private static string? GetFlag(string[] args, string flag)
+    {
+        var idx = Array.IndexOf(args, flag);
+        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+
+    private static int PrintHelp()
+    {
+        Console.WriteLine("""
+            jdai agents — manage versioned agent definitions
+
+            Usage:
+              jdai agents list [--env dev|staging|prod] [-v]
+              jdai agents tag <name> <version> [--env <env>]
+              jdai agents promote <name> [<version>] [--from <env>] [--to <env>]
+              jdai agents remove <name> <version> [--env <env>]
+
+            Environments: dev (default) → staging → prod
+
+            Examples:
+              jdai agents list --verbose
+              jdai agents tag pr-reviewer 1.2.0
+              jdai agents promote pr-reviewer 1.2.0 --from dev --to staging
+              jdai agents remove pr-reviewer 1.0.0
+            """);
+        return 0;
+    }
+
+    private static int PrintUnknown(string sub)
+    {
+        Console.Error.WriteLine($"Unknown agents command: '{sub}'. Run 'jdai agents help' for usage.");
+        return 1;
+    }
+}

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -54,6 +54,7 @@ if (opts.Subcommand != null)
     {
         "mcp" => await McpCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "plugin" => await PluginCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
+        "agents" or "agent" => await AgentsCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "onboard" or "wizard" => await OnboardingCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "update" or "install" => await UpdateCliHandler.RunAsync(opts.Subcommand, opts.SubcommandArgs).ConfigureAwait(false),
         _ => 1,

--- a/src/JD.AI/Startup/GovernanceInitializer.cs
+++ b/src/JD.AI/Startup/GovernanceInitializer.cs
@@ -127,14 +127,15 @@ internal static class GovernanceInitializer
         kernel.Plugins.AddFromObject(
             new ToolDiscoveryTools(kernel, loadoutRegistry, allPlugins), "toolDiscovery");
 
-        // Agent definition registry — scan user and project-level agent directories
-        var agentRegistry = new AgentDefinitionRegistry();
+        // Agent definition registry — file-backed versioned registry + memory cache
+        var agentRootPath = Path.Combine(DataDirectories.Root, "agents");
+        var agentRegistry = new FileAgentDefinitionRegistry(agentRootPath);
         var agentLoader = new FileAgentDefinitionLoader(
             agentRegistry,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<FileAgentDefinitionLoader>.Instance);
         var agentSearchPaths = new[]
         {
-            Path.Combine(DataDirectories.Root, "agents"),
+            Path.Combine(agentRootPath, AgentEnvironments.Dev),
             Path.Combine(projectPath, "agents"),
             Path.Combine(projectPath, ".agents"),
         };

--- a/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
@@ -1,0 +1,237 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Config;
+using Xunit;
+
+namespace JD.AI.Tests.Agents;
+
+public sealed class FileAgentDefinitionRegistryTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly FileAgentDefinitionRegistry _registry;
+
+    public FileAgentDefinitionRegistryTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+        _registry = new FileAgentDefinitionRegistry(_tempRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // ── RegisterAsync / ResolveAsync ──────────────────────────────────────
+
+    [Fact]
+    public async Task Register_ThenResolve_ReturnsSameDefinition()
+    {
+        var def = MakeDef("pr-reviewer", "1.0");
+        await _registry.RegisterAsync(def, AgentEnvironments.Dev);
+
+        var resolved = await _registry.ResolveAsync("pr-reviewer", "1.0", AgentEnvironments.Dev);
+        Assert.NotNull(resolved);
+        Assert.Equal("pr-reviewer", resolved.Name);
+        Assert.Equal("1.0", resolved.Version);
+    }
+
+    [Fact]
+    public async Task Resolve_Latest_ReturnHighestSemVer()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        await _registry.RegisterAsync(MakeDef("agent", "2.0"), AgentEnvironments.Dev);
+        await _registry.RegisterAsync(MakeDef("agent", "1.5"), AgentEnvironments.Dev);
+
+        var resolved = await _registry.ResolveAsync("agent", "latest", AgentEnvironments.Dev);
+        Assert.NotNull(resolved);
+        Assert.Equal("2.0", resolved.Version);
+    }
+
+    [Fact]
+    public async Task Resolve_NullVersion_ReturnsLatest()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        await _registry.RegisterAsync(MakeDef("agent", "3.0"), AgentEnvironments.Dev);
+
+        var resolved = await _registry.ResolveAsync("agent", null, AgentEnvironments.Dev);
+        Assert.Equal("3.0", resolved?.Version);
+    }
+
+    [Fact]
+    public async Task Resolve_UnknownName_ReturnsNull()
+    {
+        var resolved = await _registry.ResolveAsync("nonexistent", null, AgentEnvironments.Dev);
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task Resolve_WrongVersion_ReturnsNull()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        var resolved = await _registry.ResolveAsync("agent", "9.9", AgentEnvironments.Dev);
+        Assert.Null(resolved);
+    }
+
+    // ── Environment isolation ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Environments_AreIsolated()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+
+        var inStaging = await _registry.ResolveAsync("agent", null, AgentEnvironments.Staging);
+        Assert.Null(inStaging);
+    }
+
+    // ── ListAsync ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListAsync_ReturnsAllInEnvironment()
+    {
+        await _registry.RegisterAsync(MakeDef("a", "1.0"), AgentEnvironments.Dev);
+        await _registry.RegisterAsync(MakeDef("b", "1.0"), AgentEnvironments.Dev);
+        await _registry.RegisterAsync(MakeDef("c", "1.0"), AgentEnvironments.Staging);
+
+        var devList = await _registry.ListAsync(AgentEnvironments.Dev);
+        Assert.Equal(2, devList.Count);
+
+        var stagingList = await _registry.ListAsync(AgentEnvironments.Staging);
+        Assert.Equal(1, stagingList.Count);
+    }
+
+    [Fact]
+    public async Task ListAsync_EmptyEnvironment_ReturnsEmpty()
+    {
+        var list = await _registry.ListAsync(AgentEnvironments.Prod);
+        Assert.Empty(list);
+    }
+
+    // ── UnregisterAsync ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Unregister_RemovesDefinition()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        await _registry.UnregisterAsync("agent", "1.0", AgentEnvironments.Dev);
+
+        var resolved = await _registry.ResolveAsync("agent", "1.0", AgentEnvironments.Dev);
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public async Task Unregister_NonExistent_DoesNotThrow()
+    {
+        // Should complete without exception
+        await _registry.UnregisterAsync("nonexistent", "99.0", AgentEnvironments.Dev);
+    }
+
+    // ── PromoteAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Promote_CopiesDefinitionToHigherEnvironment()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        await _registry.PromoteAsync("agent", "1.0", AgentEnvironments.Dev, AgentEnvironments.Staging);
+
+        var inStaging = await _registry.ResolveAsync("agent", "1.0", AgentEnvironments.Staging);
+        Assert.NotNull(inStaging);
+        Assert.Equal("agent", inStaging.Name);
+    }
+
+    [Fact]
+    public async Task Promote_StillExistsInSource()
+    {
+        await _registry.RegisterAsync(MakeDef("agent", "1.0"), AgentEnvironments.Dev);
+        await _registry.PromoteAsync("agent", "1.0", AgentEnvironments.Dev, AgentEnvironments.Staging);
+
+        var inDev = await _registry.ResolveAsync("agent", "1.0", AgentEnvironments.Dev);
+        Assert.NotNull(inDev);
+    }
+
+    [Fact]
+    public async Task Promote_NonExistent_Throws()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _registry.PromoteAsync("nonexistent", "1.0", AgentEnvironments.Dev, AgentEnvironments.Staging));
+    }
+
+    // ── Checksum verification ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Checksum_TamperedFile_SkippedOnLoad()
+    {
+        var def = MakeDef("agent", "1.0");
+        await _registry.RegisterAsync(def, AgentEnvironments.Dev);
+
+        // Tamper with the YAML file
+        var dir = Path.Combine(_tempRoot, AgentEnvironments.Dev);
+        var yamlFile = Directory.GetFiles(dir, "*.agent.yaml").Single();
+        await File.AppendAllTextAsync(yamlFile, "\n# tampered");
+
+        // Fresh registry reads from disk
+        var freshRegistry = new FileAgentDefinitionRegistry(_tempRoot);
+        var list = await freshRegistry.ListAsync(AgentEnvironments.Dev);
+
+        // Tampered file should be skipped
+        Assert.Empty(list);
+    }
+
+    // ── AgentEnvironments ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("dev", "staging")]
+    [InlineData("staging", "prod")]
+    [InlineData("prod", null)]
+    public void NextAfter_ReturnsCorrectEnvironment(string from, string? expected)
+    {
+        Assert.Equal(expected, AgentEnvironments.NextAfter(from));
+    }
+
+    [Fact]
+    public void All_ContainsAllThreeEnvironments()
+    {
+        Assert.Contains(AgentEnvironments.Dev, AgentEnvironments.All);
+        Assert.Contains(AgentEnvironments.Staging, AgentEnvironments.All);
+        Assert.Contains(AgentEnvironments.Prod, AgentEnvironments.All);
+    }
+
+    // ── IAgentDefinitionRegistry sync interface (memory cache) ────────────
+
+    [Fact]
+    public void SyncRegister_GetByName_Works()
+    {
+        var def = MakeDef("sync-agent", "1.0");
+        _registry.Register(def);
+
+        var found = _registry.GetByName("sync-agent");
+        Assert.NotNull(found);
+    }
+
+    [Fact]
+    public void GetByTag_ReturnsMatchingDefinitions()
+    {
+        var d1 = MakeDef("a", "1.0");
+        d1.Tags.Add("code-review");
+        var d2 = MakeDef("b", "1.0");
+        d2.Tags.Add("code-review");
+        var d3 = MakeDef("c", "1.0");
+        d3.Tags.Add("documentation");
+
+        _registry.Register(d1);
+        _registry.Register(d2);
+        _registry.Register(d3);
+
+        var tagged = _registry.GetByTag("code-review");
+        Assert.Equal(2, tagged.Count);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static AgentDefinition MakeDef(string name, string version) => new()
+    {
+        Name        = name,
+        Version     = version,
+        Description = $"Test agent: {name}",
+        Model       = new AgentModelSpec { Provider = "ClaudeCode", Id = "claude-opus-4" },
+    };
+}


### PR DESCRIPTION
## Summary

Closes #211

Implements a durable, versioned, environment-scoped registry for .agent.yaml agent definitions with environment promotion support and a \jdai agents\ CLI.

## What's New

### Core

| Type | Purpose |
|------|---------|
| \AgentEnvironments\ | Static constants: \dev\, \staging\, \prod\; \NextAfter()\ promotion chain helper |
| \IVersionedAgentDefinitionRegistry\ | Async interface extending \IAgentDefinitionRegistry\ with versioning + promotion |
| \FileAgentDefinitionRegistry\ | File-backed implementation (see below) |

### FileAgentDefinitionRegistry

- **Storage**: \~/.jdai/agents/{env}/{name}@{version}.agent.yaml\
- **Integrity**: SHA-256 checksum companion file; tampered files are silently skipped on load
- **Versioning**: Multiple versions coexist; \latest\ resolves highest semver
- **Promotion**: \PromoteAsync(name, version, from, to)\ copies definition between environments (non-destructive)
- **Backwards compat**: implements sync \IAgentDefinitionRegistry\ via internal in-memory cache (pre-warmed from \dev/\)

### CLI

\\\
jdai agents list [--env dev|staging|prod] [-v]
jdai agents tag <name> <version> [--env <env>]
jdai agents promote <name> [<version>] [--from <env>] [--to <env>]
jdai agents remove <name> <version> [--env <env>]
\\\

### Startup

\GovernanceInitializer\ now uses \FileAgentDefinitionRegistry\ instead of the in-memory \AgentDefinitionRegistry\.

### Tests

20 unit tests covering:
- Register → resolve (exact version, latest, null)
- Environment isolation
- \ListAsync\ returns correct counts per environment
- \UnregisterAsync\ removes definition; no-op on missing
- \PromoteAsync\ copies to target, leaves source intact
- Checksum tamper detection (tampered file skipped on reload)
- \AgentEnvironments.NextAfter\ chain
- Sync \IAgentDefinitionRegistry\ methods (memory cache)

### Documentation

ADR-006 documents design decisions and trade-offs.