### PR TITLE
test: fix analyzer violations in approval-related tests

### DIFF
--- a/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
@@ -58,8 +58,8 @@ public sealed class AgentDefinitionRegistryTests : IDisposable
 
         var results = registry.GetByTag("code-review");
         Assert.Equal(2, results.Count);
-        Assert.Contains(results, d => d.Name == "a");
-        Assert.Contains(results, d => d.Name == "c");
+        Assert.Contains(results, d => string.Equals(d.Name, "a", StringComparison.Ordinal));
+        Assert.Contains(results, d => string.Equals(d.Name, "c", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/PolicyRbacTests.cs
+++ b/tests/JD.AI.Tests/PolicyRbacTests.cs
@@ -26,7 +26,7 @@ public sealed class PolicyRbacTests
     [Fact]
     public void EvaluateTool_RoleDenyWins_EvenIfBaseAllows()
     {
-        var spec = WithRoles(new Dictionary<string, RoleDefinition>
+        var spec = WithRoles(new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
         {
             ["guest"] = new() { DenyTools = ["ReadFile"] }
         });
@@ -46,7 +46,7 @@ public sealed class PolicyRbacTests
             Tools = new ToolPolicy { Denied = ["ReadFile"] },
             Roles = new RolePolicy
             {
-                Definitions = new Dictionary<string, RoleDefinition>
+                Definitions = new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
                 {
                     ["superuser"] = new() { AllowTools = ["ReadFile"] }
                 }
@@ -68,7 +68,7 @@ public sealed class PolicyRbacTests
             Tools = new ToolPolicy { Allowed = ["ListFiles"] },
             Roles = new RolePolicy
             {
-                Definitions = new Dictionary<string, RoleDefinition>
+                Definitions = new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
                 {
                     ["developer"] = new() { AllowTools = ["ReadFile", "WriteFile"] }
                 }
@@ -93,7 +93,7 @@ public sealed class PolicyRbacTests
     [Fact]
     public void EvaluateTool_InheritedRoleDenyApplied()
     {
-        var spec = WithRoles(new Dictionary<string, RoleDefinition>
+        var spec = WithRoles(new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
         {
             ["base"] = new() { DenyTools = ["DangerousTool"] },
             ["derived"] = new() { Inherits = ["base"] }
@@ -109,7 +109,7 @@ public sealed class PolicyRbacTests
     [Fact]
     public void EvaluateTool_CircularInheritanceDoesNotInfiniteLoop()
     {
-        var spec = WithRoles(new Dictionary<string, RoleDefinition>
+        var spec = WithRoles(new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
         {
             ["a"] = new() { Inherits = ["b"] },
             ["b"] = new() { Inherits = ["a"], DenyTools = ["BannedTool"] }
@@ -129,7 +129,7 @@ public sealed class PolicyRbacTests
     [Fact]
     public void EvaluateProvider_RoleDenyWins()
     {
-        var spec = WithRoles(new Dictionary<string, RoleDefinition>
+        var spec = WithRoles(new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
         {
             ["restricted"] = new() { DenyProviders = ["OpenAI"] }
         });
@@ -149,7 +149,7 @@ public sealed class PolicyRbacTests
             Providers = new ProviderPolicy { Denied = ["OpenAI"] },
             Roles = new RolePolicy
             {
-                Definitions = new Dictionary<string, RoleDefinition>
+                Definitions = new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
                 {
                     ["admin"] = new() { AllowProviders = ["OpenAI"] }
                 }
@@ -168,7 +168,7 @@ public sealed class PolicyRbacTests
     [Fact]
     public void EvaluateModel_RoleDenyModelPattern()
     {
-        var spec = WithRoles(new Dictionary<string, RoleDefinition>
+        var spec = WithRoles(new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
         {
             ["limited"] = new() { DenyModels = ["gpt-4*"] }
         });
@@ -207,7 +207,7 @@ public sealed class PolicyRbacTests
             {
                 Roles = new RolePolicy
                 {
-                    Definitions = new Dictionary<string, RoleDefinition>
+                    Definitions = new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
                     {
                         ["developer"] = new() { AllowTools = ["ReadFile"] }
                     }
@@ -222,7 +222,7 @@ public sealed class PolicyRbacTests
             {
                 Roles = new RolePolicy
                 {
-                    Definitions = new Dictionary<string, RoleDefinition>
+                    Definitions = new Dictionary<string, RoleDefinition>(StringComparer.Ordinal)
                     {
                         ["developer"] = new() { AllowTools = ["WriteFile"] }
                     }

--- a/tests/JD.AI.Tests/Telemetry/AgentLoopTracingTests.cs
+++ b/tests/JD.AI.Tests/Telemetry/AgentLoopTracingTests.cs
@@ -156,10 +156,9 @@ public sealed class AgentLoopTracingTests
     {
         // When no listener is registered for the source, StartActivity returns null.
         // AgentLoop uses null-conditional ?. so this must not throw.
-        Activity? activity = null;
-        var nullableActivity = activity;
-        nullableActivity?.SetStatus(ActivityStatusCode.Ok);
-        nullableActivity?.SetGenAiRequestAttributes("sys", "model");
+        using var activity = ActivitySources.Agent.StartActivity("agent.turn", ActivityKind.Internal);
+        activity?.SetStatus(ActivityStatusCode.Ok);
+        activity?.SetGenAiRequestAttributes("sys", "model");
         // No exception means the null-conditional guards are correct.
     }
 }


### PR DESCRIPTION
Summary: fix MA0006, MA0002, and CA1508 analyzer errors in test files introduced in recent merges. Validation: dotnet build tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release /p:ContinuousIntegrationBuild=true