### PR TITLE
chore(ci): fix formatting and naming drift breaking pr-checks

### DIFF
--- a/src/JD.AI.Core/Agents/AgentEnvironments.cs
+++ b/src/JD.AI.Core/Agents/AgentEnvironments.cs
@@ -6,15 +6,15 @@ namespace JD.AI.Core.Agents;
 /// </summary>
 public static class AgentEnvironments
 {
-    public const string Dev     = "dev";
+    public const string Dev = "dev";
     public const string Staging = "staging";
-    public const string Prod    = "prod";
+    public const string Prod = "prod";
 
     /// <summary>Ordered environments from lowest to highest.</summary>
     public static readonly IReadOnlyList<string> All = [Dev, Staging, Prod];
 
     /// <summary>Returns the next environment in the promotion chain, or null.</summary>
     public static string? NextAfter(string env) =>
-        env.Equals(Dev, StringComparison.OrdinalIgnoreCase)     ? Staging :
-        env.Equals(Staging, StringComparison.OrdinalIgnoreCase) ? Prod    : null;
+        env.Equals(Dev, StringComparison.OrdinalIgnoreCase) ? Staging :
+        env.Equals(Staging, StringComparison.OrdinalIgnoreCase) ? Prod : null;
 }

--- a/src/JD.AI.Core/Governance/PolicyEvaluator.cs
+++ b/src/JD.AI.Core/Governance/PolicyEvaluator.cs
@@ -198,12 +198,12 @@ public sealed class PolicyEvaluator : IPolicyEvaluator
 
         var merged = new RoleDefinition
         {
-            AllowTools = [..def.AllowTools],
-            DenyTools = [..def.DenyTools],
-            AllowProviders = [..def.AllowProviders],
-            DenyProviders = [..def.DenyProviders],
-            AllowModels = [..def.AllowModels],
-            DenyModels = [..def.DenyModels],
+            AllowTools = [.. def.AllowTools],
+            DenyTools = [.. def.DenyTools],
+            AllowProviders = [.. def.AllowProviders],
+            DenyProviders = [.. def.DenyProviders],
+            AllowModels = [.. def.AllowModels],
+            DenyModels = [.. def.DenyModels],
         };
 
         foreach (var parentName in def.Inherits)

--- a/src/JD.AI/Commands/AgentsCliHandler.cs
+++ b/src/JD.AI/Commands/AgentsCliHandler.cs
@@ -17,8 +17,8 @@ internal static class AgentsCliHandler
         {
             return sub switch
             {
-                "list"    => await ListAsync(registry, args[1..]).ConfigureAwait(false),
-                "tag"     => await TagAsync(registry, args[1..]).ConfigureAwait(false),
+                "list" => await ListAsync(registry, args[1..]).ConfigureAwait(false),
+                "tag" => await TagAsync(registry, args[1..]).ConfigureAwait(false),
                 "promote" => await PromoteAsync(registry, args[1..]).ConfigureAwait(false),
                 "remove" or "unregister"
                           => await RemoveAsync(registry, args[1..]).ConfigureAwait(false),
@@ -37,7 +37,7 @@ internal static class AgentsCliHandler
 
     private static async Task<int> ListAsync(FileAgentDefinitionRegistry registry, string[] args)
     {
-        var env   = GetFlag(args, "--env") ?? AgentEnvironments.Dev;
+        var env = GetFlag(args, "--env") ?? AgentEnvironments.Dev;
         var verbose = args.Contains("--verbose") || args.Contains("-v");
 
         var agentsRoot = Path.Combine(DataDirectories.Root, "agents");
@@ -114,10 +114,10 @@ internal static class AgentsCliHandler
             return 1;
         }
 
-        var name    = args[0];
+        var name = args[0];
         var version = args.Length > 1 && !args[1].StartsWith("--") ? args[1] : "latest";
-        var from    = GetFlag(args, "--from") ?? AgentEnvironments.Dev;
-        var to      = GetFlag(args, "--to");
+        var from = GetFlag(args, "--from") ?? AgentEnvironments.Dev;
+        var to = GetFlag(args, "--to");
 
         if (to is null)
         {
@@ -154,9 +154,9 @@ internal static class AgentsCliHandler
             return 1;
         }
 
-        var name    = args[0];
+        var name = args[0];
         var version = args[1];
-        var env     = GetFlag(args[2..], "--env") ?? AgentEnvironments.Dev;
+        var env = GetFlag(args[2..], "--env") ?? AgentEnvironments.Dev;
 
         await registry.UnregisterAsync(name, version, env).ConfigureAwait(false);
         Console.WriteLine($"✓ Removed '{name}@{version}' from '{env}'.");

--- a/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
@@ -96,7 +96,7 @@ public sealed class FileAgentDefinitionRegistryTests : IDisposable
         Assert.Equal(2, devList.Count);
 
         var stagingList = await _registry.ListAsync(AgentEnvironments.Staging);
-        Assert.Equal(1, stagingList.Count);
+        Assert.Single(stagingList);
     }
 
     [Fact]
@@ -229,9 +229,9 @@ public sealed class FileAgentDefinitionRegistryTests : IDisposable
 
     private static AgentDefinition MakeDef(string name, string version) => new()
     {
-        Name        = name,
-        Version     = version,
+        Name = name,
+        Version = version,
         Description = $"Test agent: {name}",
-        Model       = new AgentModelSpec { Provider = "ClaudeCode", Id = "claude-opus-4" },
+        Model = new AgentModelSpec { Provider = "ClaudeCode", Id = "claude-opus-4" },
     };
 }

--- a/tests/JD.AI.Tests/Tools/LoadoutYamlTests.cs
+++ b/tests/JD.AI.Tests/Tools/LoadoutYamlTests.cs
@@ -134,8 +134,8 @@ public sealed class LoadoutYamlTests : IDisposable
     [Fact]
     public void Deserialize_MinimalYaml_LoadsNameOnly()
     {
-        const string yaml = "name: minimal-yaml\n";
-        var result = ToolLoadoutYamlSerializer.Deserialize(yaml);
+        const string YamlText = "name: minimal-yaml\n";
+        var result = ToolLoadoutYamlSerializer.Deserialize(YamlText);
 
         Assert.Equal("minimal-yaml", result.Name);
         Assert.Null(result.ParentLoadoutName);
@@ -147,14 +147,14 @@ public sealed class LoadoutYamlTests : IDisposable
     [Fact]
     public void Deserialize_CategoryIsCaseInsensitive()
     {
-        const string yaml = """
+        const string YamlText = """
             name: case-test
             includeCategories:
               - git
               - SEARCH
             """;
 
-        var result = ToolLoadoutYamlSerializer.Deserialize(yaml);
+        var result = ToolLoadoutYamlSerializer.Deserialize(YamlText);
 
         Assert.Contains(ToolCategory.Git, result.IncludedCategories);
         Assert.Contains(ToolCategory.Search, result.IncludedCategories);
@@ -163,13 +163,13 @@ public sealed class LoadoutYamlTests : IDisposable
     [Fact]
     public void DeserializeFile_ReadsFromDisk()
     {
-        const string yaml = """
+        const string YamlText = """
             name: from-file
             includeCategories:
               - Filesystem
             """;
 
-        var path = WriteTempLoadout("test.loadout.yaml", yaml);
+        var path = WriteTempLoadout("test.loadout.yaml", YamlText);
         var result = ToolLoadoutYamlSerializer.DeserializeFile(path);
 
         Assert.Equal("from-file", result.Name);


### PR DESCRIPTION
Summary: apply whitespace and naming fixes so pr-checks dotnet-format gate passes again. Validation: dotnet format --verify-no-changes and CI-style build.