### PR TITLE
feat(multi-tenancy): tenant credential isolation, audit namespacing, and quota extensions (#215)

### DIFF
--- a/src/JD.AI.Core/Governance/Audit/AuditEvent.cs
+++ b/src/JD.AI.Core/Governance/Audit/AuditEvent.cs
@@ -27,6 +27,9 @@ public sealed class AuditEvent
 
     /// <summary>Hash of the previous audit event for tamper-evident chaining. Null for the first event.</summary>
     public string? PreviousHash { get; init; }
+
+    /// <summary>Tenant identifier when running in a multi-tenant deployment.</summary>
+    public string? TenantId { get; init; }
 }
 
 public enum AuditSeverity { Debug, Info, Warning, Error, Critical }

--- a/src/JD.AI.Core/Governance/Audit/AuditService.cs
+++ b/src/JD.AI.Core/Governance/Audit/AuditService.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using JD.AI.Core.MultiTenancy;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -14,13 +15,15 @@ public sealed class AuditService
     private readonly IReadOnlyList<IAuditSink> _sinks;
     private readonly ILogger<AuditService> _logger;
     private readonly Channel<DeadLetterEntry> _deadLetterQueue;
+    private readonly TenantContext? _tenantContext;
     private long _deadLetterCount;
 
-    public AuditService(IEnumerable<IAuditSink> sinks, ILogger<AuditService>? logger = null)
+    public AuditService(IEnumerable<IAuditSink> sinks, ILogger<AuditService>? logger = null, TenantContext? tenantContext = null)
     {
         ArgumentNullException.ThrowIfNull(sinks);
         _sinks = [.. sinks];
         _logger = logger ?? NullLogger<AuditService>.Instance;
+        _tenantContext = tenantContext;
         _deadLetterQueue = Channel.CreateBounded<DeadLetterEntry>(
             new BoundedChannelOptions(1000)
             {
@@ -40,6 +43,30 @@ public sealed class AuditService
     public async Task EmitAsync(AuditEvent evt, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(evt);
+
+        // Stamp TenantId from current scope if not already set
+        if (_tenantContext?.IsResolved == true && evt.TenantId is null)
+        {
+            evt = new AuditEvent
+            {
+                EventId = evt.EventId,
+                Timestamp = evt.Timestamp,
+                UserId = evt.UserId,
+                SessionId = evt.SessionId,
+                TraceId = evt.TraceId,
+                Action = evt.Action,
+                Resource = evt.Resource,
+                Detail = evt.Detail,
+                Severity = evt.Severity,
+                PolicyResult = evt.PolicyResult,
+                ToolName = evt.ToolName,
+                ToolArguments = evt.ToolArguments,
+                ToolResult = evt.ToolResult,
+                DurationMs = evt.DurationMs,
+                PreviousHash = evt.PreviousHash,
+                TenantId = _tenantContext.TenantId,
+            };
+        }
 
         foreach (var sink in _sinks)
         {

--- a/src/JD.AI.Core/Governance/Audit/IQueryableAuditSink.cs
+++ b/src/JD.AI.Core/Governance/Audit/IQueryableAuditSink.cs
@@ -44,6 +44,9 @@ public sealed class AuditQuery
 
     /// <summary>Number of events to skip for pagination.</summary>
     public int Offset { get; init; }
+
+    /// <summary>Filter by tenant ID. When set, only events from this tenant are returned.</summary>
+    public string? TenantId { get; init; }
 }
 
 /// <summary>Result of an audit event query.</summary>

--- a/src/JD.AI.Core/Governance/Audit/InMemoryAuditSink.cs
+++ b/src/JD.AI.Core/Governance/Audit/InMemoryAuditSink.cs
@@ -90,6 +90,9 @@ public sealed class InMemoryAuditSink : IQueryableAuditSink
         if (query.Until is { } until)
             filtered = filtered.Where(e => e.Timestamp < until);
 
+        if (query.TenantId is not null)
+            filtered = filtered.Where(e => string.Equals(e.TenantId, query.TenantId, StringComparison.OrdinalIgnoreCase));
+
         var matchedList = filtered.ToList();
         var totalCount = matchedList.Count;
 

--- a/src/JD.AI.Core/MultiTenancy/TenantQuota.cs
+++ b/src/JD.AI.Core/MultiTenancy/TenantQuota.cs
@@ -19,7 +19,7 @@ public sealed class TenantQuota
     /// <summary>
     /// Checks if the tenant has exceeded their request quota.
     /// </summary>
-    public bool IsOverQuota(string tenantId)
+    public bool IsOverRequestQuota(string tenantId)
     {
         if (!_usage.TryGetValue(tenantId, out var usage))
             return false;
@@ -28,6 +28,28 @@ public sealed class TenantQuota
 
         return _config.MaxRequestsPerWindow > 0
                && usage.RequestCount >= _config.MaxRequestsPerWindow;
+    }
+
+    /// <summary>
+    /// Checks if the tenant has exceeded their daily token budget.
+    /// </summary>
+    public bool IsOverTokenQuota(string tenantId)
+    {
+        if (_config.MaxTokensPerDay <= 0) return false;
+        if (!_usage.TryGetValue(tenantId, out var usage)) return false;
+
+        return usage.DailyTokens >= _config.MaxTokensPerDay;
+    }
+
+    /// <summary>
+    /// Checks if the tenant has exceeded their concurrent session limit.
+    /// </summary>
+    public bool IsOverSessionQuota(string tenantId)
+    {
+        if (_config.MaxConcurrentSessions <= 0) return false;
+        if (!_usage.TryGetValue(tenantId, out var usage)) return false;
+
+        return usage.ConcurrentSessions >= _config.MaxConcurrentSessions;
     }
 
     /// <summary>
@@ -40,18 +62,55 @@ public sealed class TenantQuota
     }
 
     /// <summary>
+    /// Records token consumption for the given tenant.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="tokens">Number of tokens consumed.</param>
+    public void RecordTokens(string tenantId, long tokens)
+    {
+        if (tokens <= 0) return;
+        var usage = _usage.GetOrAdd(tenantId, _ => new TenantUsage());
+        usage.AddTokens(tokens);
+    }
+
+    /// <summary>
+    /// Increments the concurrent session count for the given tenant.
+    /// Call <see cref="ReleaseSession"/> when the session ends.
+    /// </summary>
+    public void AcquireSession(string tenantId)
+    {
+        var usage = _usage.GetOrAdd(tenantId, _ => new TenantUsage());
+        usage.IncrementSessions();
+    }
+
+    /// <summary>
+    /// Decrements the concurrent session count for the given tenant.
+    /// </summary>
+    public void ReleaseSession(string tenantId)
+    {
+        if (_usage.TryGetValue(tenantId, out var usage))
+        {
+            usage.DecrementSessions();
+        }
+    }
+
+    /// <summary>
     /// Gets current usage stats for a tenant.
     /// </summary>
     public TenantUsageStats GetUsage(string tenantId)
     {
         if (!_usage.TryGetValue(tenantId, out var usage))
-            return new TenantUsageStats(0, _config.MaxRequestsPerWindow, _config.WindowDuration);
+            return new TenantUsageStats(0, _config.MaxRequestsPerWindow, _config.WindowDuration, 0, _config.MaxTokensPerDay, 0, _config.MaxConcurrentSessions);
 
         usage.PruneExpired(_config.WindowDuration);
         return new TenantUsageStats(
             usage.RequestCount,
             _config.MaxRequestsPerWindow,
-            _config.WindowDuration);
+            _config.WindowDuration,
+            usage.DailyTokens,
+            _config.MaxTokensPerDay,
+            usage.ConcurrentSessions,
+            _config.MaxConcurrentSessions);
     }
 }
 
@@ -63,24 +122,56 @@ public sealed class TenantQuotaConfig
 
     /// <summary>Rolling window duration for quota tracking.</summary>
     public TimeSpan WindowDuration { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>Maximum tokens consumed per day. 0 = unlimited.</summary>
+    public long MaxTokensPerDay { get; init; }
+
+    /// <summary>Maximum concurrent agent sessions per tenant. 0 = unlimited.</summary>
+    public int MaxConcurrentSessions { get; init; }
+
+    /// <summary>Action taken when any quota threshold is exceeded.</summary>
+    public QuotaExceededAction OnQuotaExceeded { get; init; } = QuotaExceededAction.Reject;
+}
+
+/// <summary>Action taken when a tenant exceeds a quota.</summary>
+public enum QuotaExceededAction
+{
+    /// <summary>Reject the request with an error.</summary>
+    Reject,
+
+    /// <summary>Queue the request until quota resets.</summary>
+    Queue,
+
+    /// <summary>Allow the request but degrade to a smaller/cheaper model.</summary>
+    Degrade,
 }
 
 /// <summary>Current usage stats for a tenant.</summary>
 public sealed record TenantUsageStats(
     int CurrentRequests,
     int MaxRequests,
-    TimeSpan WindowDuration);
+    TimeSpan WindowDuration,
+    long CurrentTokensToday,
+    long MaxTokensPerDay,
+    int CurrentSessions,
+    int MaxConcurrentSessions);
 
 /// <summary>Thread-safe per-tenant usage tracker.</summary>
 internal sealed class TenantUsage
 {
     private readonly Lock _lock = new();
     private readonly List<DateTimeOffset> _timestamps = [];
+    private long _dailyTokens;
+    private int _concurrentSessions;
 
     public int RequestCount
     {
         get { lock (_lock) return _timestamps.Count; }
     }
+
+    public long DailyTokens => Interlocked.Read(ref _dailyTokens);
+
+    public int ConcurrentSessions => Volatile.Read(ref _concurrentSessions);
 
     public void AddRequest()
     {
@@ -88,6 +179,16 @@ internal sealed class TenantUsage
         {
             _timestamps.Add(DateTimeOffset.UtcNow);
         }
+    }
+
+    public void AddTokens(long tokens) => Interlocked.Add(ref _dailyTokens, tokens);
+
+    public void IncrementSessions() => Interlocked.Increment(ref _concurrentSessions);
+
+    public void DecrementSessions()
+    {
+        var current = Volatile.Read(ref _concurrentSessions);
+        if (current > 0) Interlocked.Decrement(ref _concurrentSessions);
     }
 
     public void PruneExpired(TimeSpan window)

--- a/src/JD.AI.Core/Providers/Credentials/TenantScopedCredentialStore.cs
+++ b/src/JD.AI.Core/Providers/Credentials/TenantScopedCredentialStore.cs
@@ -1,0 +1,79 @@
+using JD.AI.Core.MultiTenancy;
+
+namespace JD.AI.Core.Providers.Credentials;
+
+/// <summary>
+/// Wraps an underlying <see cref="ICredentialStore"/> and enforces tenant-namespace isolation.
+/// All credential keys are automatically prefixed with the current tenant ID so that
+/// credentials belonging to different tenants cannot be accessed across tenant boundaries.
+/// </summary>
+/// <remarks>
+/// This store should be registered as a scoped service so that it inherits the current
+/// <see cref="TenantContext"/> from the DI scope.
+/// </remarks>
+public sealed class TenantScopedCredentialStore : ICredentialStore
+{
+    private readonly ICredentialStore _inner;
+    private readonly TenantContext _tenantContext;
+
+    /// <summary>
+    /// Initializes a new <see cref="TenantScopedCredentialStore"/>.
+    /// </summary>
+    /// <param name="inner">The backing credential store (e.g. EncryptedFileStore, Azure KV).</param>
+    /// <param name="tenantContext">The current tenant scope.</param>
+    public TenantScopedCredentialStore(ICredentialStore inner, TenantContext tenantContext)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _tenantContext = tenantContext ?? throw new ArgumentNullException(nameof(tenantContext));
+    }
+
+    /// <inheritdoc/>
+    public bool IsAvailable => _inner.IsAvailable;
+
+    /// <inheritdoc/>
+    public string StoreName => $"{_inner.StoreName} (tenant-scoped)";
+
+    /// <inheritdoc/>
+    public Task<string?> GetAsync(string key, CancellationToken ct = default) =>
+        _inner.GetAsync(BuildKey(key), ct);
+
+    /// <inheritdoc/>
+    public Task SetAsync(string key, string value, CancellationToken ct = default) =>
+        _inner.SetAsync(BuildKey(key), value, ct);
+
+    /// <inheritdoc/>
+    public Task RemoveAsync(string key, CancellationToken ct = default) =>
+        _inner.RemoveAsync(BuildKey(key), ct);
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> ListKeysAsync(string prefix, CancellationToken ct = default)
+    {
+        var tenantPrefix = BuildKey(prefix ?? string.Empty);
+        var innerKeys = await _inner.ListKeysAsync(tenantPrefix, ct).ConfigureAwait(false);
+
+        // Strip the tenant prefix from returned keys so callers see unnamespaced keys
+        var tenantPart = GetTenantPrefix();
+        return innerKeys
+            .Where(k => k.StartsWith(tenantPart, StringComparison.OrdinalIgnoreCase))
+            .Select(k => k[tenantPart.Length..])
+            .ToList();
+    }
+
+    private string BuildKey(string key)
+    {
+        EnsureTenantResolved();
+        return $"{GetTenantPrefix()}{key}";
+    }
+
+    private string GetTenantPrefix() => $"tenants/{_tenantContext.TenantId}/";
+
+    private void EnsureTenantResolved()
+    {
+        if (!_tenantContext.IsResolved)
+        {
+            throw new InvalidOperationException(
+                "TenantScopedCredentialStore requires an active tenant context. " +
+                "Ensure a tenant has been resolved before accessing credentials.");
+        }
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/TenantAuditTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantAuditTests.cs
@@ -1,0 +1,63 @@
+using JD.AI.Core.Governance.Audit;
+using JD.AI.Core.MultiTenancy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class TenantAuditTests
+{
+    [Fact]
+    public async Task EmitAsync_StampsTenantId_FromContext()
+    {
+        var sink = new InMemoryAuditSink();
+        var ctx = new TenantContext { TenantId = "team-alpha" };
+        var svc = new AuditService([sink], NullLogger<AuditService>.Instance, ctx);
+
+        await svc.EmitAsync(new AuditEvent { Action = "login" });
+
+        var result = await sink.QueryAsync(new AuditQuery());
+        Assert.Single(result.Events);
+        Assert.Equal("team-alpha", result.Events[0].TenantId);
+    }
+
+    [Fact]
+    public async Task EmitAsync_DoesNotOverrideExistingTenantId()
+    {
+        var sink = new InMemoryAuditSink();
+        var ctx = new TenantContext { TenantId = "ctx-tenant" };
+        var svc = new AuditService([sink], NullLogger<AuditService>.Instance, ctx);
+        var evt = new AuditEvent { Action = "test", TenantId = "explicit-tenant" };
+
+        await svc.EmitAsync(evt);
+
+        var result = await sink.QueryAsync(new AuditQuery());
+        Assert.Equal("explicit-tenant", result.Events[0].TenantId);
+    }
+
+    [Fact]
+    public async Task QueryAsync_FiltersByTenantId()
+    {
+        var sink = new InMemoryAuditSink();
+        await sink.WriteAsync(new AuditEvent { Action = "a", TenantId = "alpha" });
+        await sink.WriteAsync(new AuditEvent { Action = "b", TenantId = "beta" });
+        await sink.WriteAsync(new AuditEvent { Action = "c", TenantId = "alpha" });
+
+        var result = await sink.QueryAsync(new AuditQuery { TenantId = "alpha" });
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.All(result.Events, e => Assert.Equal("alpha", e.TenantId));
+    }
+
+    [Fact]
+    public async Task QueryAsync_TenantFilter_ExcludesCrossTenantData()
+    {
+        var sink = new InMemoryAuditSink();
+        await sink.WriteAsync(new AuditEvent { Action = "secret", TenantId = "acme" });
+        await sink.WriteAsync(new AuditEvent { Action = "public", TenantId = "other" });
+
+        var result = await sink.QueryAsync(new AuditQuery { TenantId = "acme" });
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("secret", result.Events[0].Action);
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/TenantQuotaExtendedTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantQuotaExtendedTests.cs
@@ -1,0 +1,78 @@
+using JD.AI.Core.MultiTenancy;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class TenantQuotaExtendedTests
+{
+    [Fact]
+    public void IsOverTokenQuota_ReturnsFalse_WhenUnlimited()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxTokensPerDay = 0 });
+        quota.RecordTokens("t1", 999_999);
+        Assert.False(quota.IsOverTokenQuota("t1"));
+    }
+
+    [Fact]
+    public void IsOverTokenQuota_ReturnsTrue_WhenExceeded()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxTokensPerDay = 1000 });
+        quota.RecordTokens("t1", 1001);
+        Assert.True(quota.IsOverTokenQuota("t1"));
+    }
+
+    [Fact]
+    public void IsOverSessionQuota_ReturnsFalse_WhenUnderLimit()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxConcurrentSessions = 5 });
+        quota.AcquireSession("t1");
+        quota.AcquireSession("t1");
+        Assert.False(quota.IsOverSessionQuota("t1"));
+    }
+
+    [Fact]
+    public void IsOverSessionQuota_ReturnsTrue_WhenAtLimit()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxConcurrentSessions = 2 });
+        quota.AcquireSession("t1");
+        quota.AcquireSession("t1");
+        Assert.True(quota.IsOverSessionQuota("t1"));
+    }
+
+    [Fact]
+    public void ReleaseSession_DecrementsCount()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig { MaxConcurrentSessions = 2 });
+        quota.AcquireSession("t1");
+        quota.AcquireSession("t1");
+        quota.ReleaseSession("t1");
+
+        // Now at 1 of 2 — should not be over quota
+        Assert.False(quota.IsOverSessionQuota("t1"));
+    }
+
+    [Fact]
+    public void GetUsage_ReturnsAllStats()
+    {
+        var quota = new TenantQuota(new TenantQuotaConfig
+        {
+            MaxTokensPerDay = 10_000,
+            MaxConcurrentSessions = 5,
+        });
+        quota.RecordTokens("t1", 3_000);
+        quota.AcquireSession("t1");
+
+        var stats = quota.GetUsage("t1");
+
+        Assert.Equal(3_000, stats.CurrentTokensToday);
+        Assert.Equal(10_000, stats.MaxTokensPerDay);
+        Assert.Equal(1, stats.CurrentSessions);
+        Assert.Equal(5, stats.MaxConcurrentSessions);
+    }
+
+    [Fact]
+    public void QuotaExceededAction_DefaultIsReject()
+    {
+        var config = new TenantQuotaConfig();
+        Assert.Equal(QuotaExceededAction.Reject, config.OnQuotaExceeded);
+    }
+}

--- a/tests/JD.AI.Tests/MultiTenancy/TenantQuotaTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantQuotaTests.cs
@@ -6,48 +6,48 @@ namespace JD.AI.Tests.MultiTenancy;
 public sealed class TenantQuotaTests
 {
     [Fact]
-    public void IsOverQuota_NoRequests_ReturnsFalse()
+    public void IsOverRequestQuota_NoRequests_ReturnsFalse()
     {
         var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 10 });
 
-        quota.IsOverQuota("tenant-a").Should().BeFalse();
+        quota.IsOverRequestQuota("tenant-a").Should().BeFalse();
     }
 
     [Fact]
-    public void IsOverQuota_UnderLimit_ReturnsFalse()
+    public void IsOverRequestQuota_UnderLimit_ReturnsFalse()
     {
         var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 5 });
 
         for (var i = 0; i < 3; i++)
             quota.RecordRequest("tenant-a");
 
-        quota.IsOverQuota("tenant-a").Should().BeFalse();
+        quota.IsOverRequestQuota("tenant-a").Should().BeFalse();
     }
 
     [Fact]
-    public void IsOverQuota_AtLimit_ReturnsTrue()
+    public void IsOverRequestQuota_AtLimit_ReturnsTrue()
     {
         var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 3 });
 
         for (var i = 0; i < 3; i++)
             quota.RecordRequest("tenant-a");
 
-        quota.IsOverQuota("tenant-a").Should().BeTrue();
+        quota.IsOverRequestQuota("tenant-a").Should().BeTrue();
     }
 
     [Fact]
-    public void IsOverQuota_Unlimited_NeverTrue()
+    public void IsOverRequestQuota_Unlimited_NeverTrue()
     {
         var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 0 });
 
         for (var i = 0; i < 100; i++)
             quota.RecordRequest("tenant-a");
 
-        quota.IsOverQuota("tenant-a").Should().BeFalse();
+        quota.IsOverRequestQuota("tenant-a").Should().BeFalse();
     }
 
     [Fact]
-    public void IsOverQuota_IsolatedPerTenant()
+    public void IsOverRequestQuota_IsolatedPerTenant()
     {
         var quota = new TenantQuota(new TenantQuotaConfig { MaxRequestsPerWindow = 2 });
 
@@ -55,8 +55,8 @@ public sealed class TenantQuotaTests
         quota.RecordRequest("tenant-a");
         quota.RecordRequest("tenant-b");
 
-        quota.IsOverQuota("tenant-a").Should().BeTrue();
-        quota.IsOverQuota("tenant-b").Should().BeFalse();
+        quota.IsOverRequestQuota("tenant-a").Should().BeTrue();
+        quota.IsOverRequestQuota("tenant-b").Should().BeFalse();
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/MultiTenancy/TenantScopedCredentialStoreTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantScopedCredentialStoreTests.cs
@@ -1,0 +1,79 @@
+using JD.AI.Core.MultiTenancy;
+using JD.AI.Core.Providers.Credentials;
+using NSubstitute;
+
+namespace JD.AI.Tests.MultiTenancy;
+
+public sealed class TenantScopedCredentialStoreTests
+{
+    private readonly ICredentialStore _inner = Substitute.For<ICredentialStore>();
+
+    [Fact]
+    public async Task GetAsync_PrefixesTenantId()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-a" };
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+
+        await sut.GetAsync("mykey");
+
+        await _inner.Received(1).GetAsync("tenants/tenant-a/mykey", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetAsync_PrefixesTenantId()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-b" };
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+
+        await sut.SetAsync("api-key", "value");
+
+        await _inner.Received(1).SetAsync("tenants/tenant-b/api-key", "value", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveAsync_PrefixesTenantId()
+    {
+        var ctx = new TenantContext { TenantId = "tenant-c" };
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+
+        await sut.RemoveAsync("key");
+
+        await _inner.Received(1).RemoveAsync("tenants/tenant-c/key", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListKeysAsync_StripsPrefix()
+    {
+        var ctx = new TenantContext { TenantId = "acme" };
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+        _inner.ListKeysAsync("tenants/acme/", Arg.Any<CancellationToken>())
+              .Returns([
+                  "tenants/acme/openai-key",
+                  "tenants/acme/github-token",
+              ]);
+
+        var keys = await sut.ListKeysAsync(string.Empty);
+
+        Assert.Equal(2, keys.Count);
+        Assert.Contains("openai-key", keys);
+        Assert.Contains("github-token", keys);
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsWhenTenantNotResolved()
+    {
+        var ctx = new TenantContext(); // TenantId = null
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.GetAsync("key"));
+    }
+
+    [Fact]
+    public void StoreName_IncludesTenantScopedSuffix()
+    {
+        _inner.StoreName.Returns("EncryptedFileStore");
+        var ctx = new TenantContext { TenantId = "org" };
+        var sut = new TenantScopedCredentialStore(_inner, ctx);
+        Assert.Contains("tenant-scoped", sut.StoreName);
+    }
+}


### PR DESCRIPTION
Implements #215.

**TenantScopedCredentialStore** — wraps any ICredentialStore and enforces tenant-namespaced key isolation. Keys stored as tenants/{tenantId}/{key}. Throws if no tenant is resolved.

**Tenant-aware audit** — AuditEvent and AuditQuery gain TenantId. AuditService auto-stamps it from TenantContext. InMemoryAuditSink.QueryAsync enforces tenant boundary filtering.

**Extended TenantQuotaConfig** — adds MaxTokensPerDay, MaxConcurrentSessions, and OnQuotaExceeded (Reject/Queue/Degrade). New TenantQuota methods: RecordTokens, AcquireSession, ReleaseSession, IsOverTokenQuota, IsOverSessionQuota.

38 multi-tenancy tests, all passing.