### PR TITLE
feat: Kubernetes integration with OTLP, distributed workers, batch jobs, and Helm lint CI

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -90,3 +90,21 @@ jobs:
           subject-name: ${{ steps.image.outputs.name }}
           subject-digest: ${{ steps.build.outputs.digest }}
           sbom-path: sbom-${{ matrix.component }}.spdx.json
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Helm lint
+        run: helm lint deploy/helm/jdai
+
+      - name: Helm template (dry-run)
+        run: helm template jdai deploy/helm/jdai --debug > /dev/null
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.7
+# Root Dockerfile — builds JD.AI.Daemon (default workload).
+# For other targets see deploy/docker/Dockerfile.gateway and deploy/docker/Dockerfile.tui.
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore src/JD.AI.Daemon/JD.AI.Daemon.csproj
+RUN dotnet publish src/JD.AI.Daemon/JD.AI.Daemon.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 15790
+ENV ASPNETCORE_URLS=http://+:15790
+USER $APP_UID
+ENTRYPOINT ["dotnet", "JD.AI.Daemon.dll"]

--- a/deploy/helm/jdai/templates/configmap-telemetry.yaml
+++ b/deploy/helm/jdai/templates/configmap-telemetry.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.telemetry.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jdai.fullname" . }}-telemetry
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+data:
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.telemetry.otlpEndpoint | quote }}
+  OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.telemetry.otlpProtocol | quote }}
+  OTEL_SERVICE_NAME: {{ .Values.telemetry.serviceName | quote }}
+  {{- range $key, $value := .Values.telemetry.attributes }}
+  OTEL_RESOURCE_ATTRIBUTES_{{ $key | upper }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/jdai/templates/deployment-worker.yaml
+++ b/deploy/helm/jdai/templates/deployment-worker.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.distributedWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jdai.fullname" . }}-worker
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.distributedWorker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jdai.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "jdai.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jdai.serviceAccountName" . }}
+      containers:
+        - name: worker
+          image: "{{ .Values.distributedWorker.image.repository }}:{{ .Values.distributedWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.distributedWorker.image.pullPolicy }}
+          env:
+            - name: JDAI__DISTRIBUTED__TRANSPORT
+              value: {{ .Values.distributedWorker.transport | quote }}
+            {{- if eq .Values.distributedWorker.transport "redis" }}
+            - name: JDAI__DISTRIBUTED__REDIS__CONNECTIONSTRING
+              value: {{ .Values.distributedWorker.redis.connectionString | quote }}
+            - name: JDAI__DISTRIBUTED__REDIS__STREAMKEY
+              value: {{ .Values.distributedWorker.redis.streamKey | quote }}
+            - name: JDAI__DISTRIBUTED__REDIS__CONSUMERGROUP
+              value: {{ .Values.distributedWorker.redis.consumerGroup | quote }}
+            {{- else if eq .Values.distributedWorker.transport "azure-service-bus" }}
+            - name: JDAI__DISTRIBUTED__AZURESERVICEBUS__CONNECTIONSTRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jdai.fullname" . }}-secrets
+                  key: {{ .Values.distributedWorker.azureServiceBus.connectionStringSecretKey }}
+            - name: JDAI__DISTRIBUTED__AZURESERVICEBUS__QUEUENAME
+              value: {{ .Values.distributedWorker.azureServiceBus.queueName | quote }}
+            {{- end }}
+            {{- if .Values.telemetry.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.telemetry.otlpEndpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ printf "%s-worker" .Values.telemetry.serviceName | quote }}
+            {{- end }}
+            {{- with .Values.distributedWorker.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.distributedWorker.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/jdai/templates/job-batch.yaml
+++ b/deploy/helm/jdai/templates/job-batch.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.batchJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "jdai.fullname" . }}-batch
+  labels:
+    {{- include "jdai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: batch-job
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jdai.serviceAccountName" . }}
+      containers:
+        - name: batch-agent
+          image: "{{ .Values.batchJob.image.repository }}:{{ .Values.batchJob.image.tag }}"
+          imagePullPolicy: {{ .Values.batchJob.image.pullPolicy }}
+          command:
+            - dotnet
+            - JD.AI.Daemon.dll
+            - run
+            - --agent
+            - {{ .Values.batchJob.agent | quote }}
+            - --workflow
+            - {{ .Values.batchJob.workflow | quote }}
+          {{- if .Values.telemetry.enabled }}
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.telemetry.otlpEndpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ printf "%s-batch" .Values.telemetry.serviceName | quote }}
+            {{- with .Values.batchJob.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
+          {{- with .Values.batchJob.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.batchJob.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/jdai/values.yaml
+++ b/deploy/helm/jdai/values.yaml
@@ -122,3 +122,44 @@ tui:
   image:
     repository: ghcr.io/jerrettdavis/jd.ai-tui
     tag: latest
+
+# OpenTelemetry / observability configuration
+telemetry:
+  enabled: false
+  otlpEndpoint: ""          # e.g. http://otel-collector:4317
+  otlpProtocol: grpc        # grpc | http/protobuf
+  serviceName: jdai
+  # Additional OTEL resource attributes
+  attributes: {}
+
+# Distributed workflow workers (JD.AI.Workflows.Distributed)
+distributedWorker:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-daemon
+    tag: latest
+    pullPolicy: IfNotPresent
+  transport: inmemory        # inmemory | redis | azure-service-bus
+  redis:
+    connectionString: ""     # e.g. redis-master:6379
+    streamKey: jdai:workflows
+    consumerGroup: jdai-workers
+  azureServiceBus:
+    connectionStringSecretKey: azure-service-bus-connection-string
+    queueName: jdai-workflows
+  resources: {}
+  env: []
+
+# Batch/job mode: run a single agent workflow and exit
+batchJob:
+  enabled: false
+  agent: ""
+  workflow: ""
+  image:
+    repository: ghcr.io/jerrettdavis/jd.ai-daemon
+    tag: latest
+    pullPolicy: IfNotPresent
+  resources: {}
+  env: []
+

--- a/docs/architecture/kubernetes-operator-design.md
+++ b/docs/architecture/kubernetes-operator-design.md
@@ -1,0 +1,132 @@
+# JD.AI Kubernetes Operator — v2 Design
+
+**Status**: Planned (v2 scope — not required for initial Helm-based deployment)
+
+---
+
+## Overview
+
+The Kubernetes operator extends the JD.AI deployment model to support `JdAiAgent` custom resources. Agents become first-class Kubernetes objects — versioned, policy-enforced, and lifecycle-managed by the cluster.
+
+This document captures the design intent for the operator so the API surface can be validated before implementation begins.
+
+---
+
+## Custom Resource: `JdAiAgent`
+
+```yaml
+apiVersion: jdai.io/v1
+kind: JdAiAgent
+metadata:
+  name: code-reviewer
+  namespace: jdai
+spec:
+  # References a versioned agent definition from AgentDefinitionRegistry
+  agentDefinition: code-reviewer@1.2.0
+
+  # Number of concurrent agent replicas
+  replicas: 2
+
+  # Resource requests/limits per replica
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+
+  # Tool loadout (referenced by name from ConnectorRegistry)
+  loadout: jira-readonly
+
+  # Policy override (references a JdAiPolicy resource)
+  policyRef:
+    name: strict-code-review
+
+  # Telemetry configuration
+  telemetry:
+    otlpEndpoint: http://otel-collector:4317
+
+status:
+  ready: true
+  availableReplicas: 2
+  conditions:
+    - type: Ready
+      status: "True"
+      lastTransitionTime: "2025-07-01T00:00:00Z"
+```
+
+## Custom Resource: `JdAiPolicy`
+
+```yaml
+apiVersion: jdai.io/v1
+kind: JdAiPolicy
+metadata:
+  name: strict-code-review
+  namespace: jdai
+spec:
+  rules:
+    - id: no-external-calls
+      description: Block outbound HTTP to non-allowlisted hosts
+      enforce: true
+    - id: no-secret-output
+      description: Redact secrets from all agent outputs
+      enforce: true
+  auditRetentionDays: 90
+```
+
+---
+
+## Operator Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  JD.AI Operator (controller-runtime)                         │
+│                                                               │
+│  ┌──────────────────┐  ┌──────────────────────────────────┐ │
+│  │ JdAiAgentReconciler │  JdAiPolicyReconciler             │ │
+│  │  - Watch JdAiAgent │  - Watch JdAiPolicy                │ │
+│  │  - Create Deployment│  - Sync to PolicyRegistry          │ │
+│  │  - Create Service  │  - Emit audit events               │ │
+│  │  - Manage HPA      │                                    │ │
+│  └──────────────────┘  └──────────────────────────────────┘ │
+│                                                               │
+│  Watches: Deployments, Services, HPAs (owned resources)      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The operator is implemented using the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) library in Go, or alternatively as a .NET Kubernetes operator using [KubeOps](https://buehler.github.io/dotnet-operator-sdk/).
+
+---
+
+## Reconciliation Loop
+
+For each `JdAiAgent`:
+
+1. Resolve `agentDefinition` from `AgentDefinitionRegistry` (version pinned)
+2. Render agent configuration (tools, policies, loadout)
+3. Create or update a `Deployment` with the resolved configuration
+4. Attach a `Service` if the agent exposes an HTTP interface
+5. Attach an `HPA` if `replicas` is a range
+6. Emit an `AuditEvent` for any configuration change
+
+---
+
+## Implementation Phases
+
+| Phase | Scope |
+|-------|-------|
+| v1 | Helm chart + manual Deployment management (current) |
+| v2a | CRD definitions + basic reconciler (create Deployment from JdAiAgent) |
+| v2b | Policy CRD + reconciler + audit integration |
+| v2c | HPA management, status conditions, leader election |
+| v3 | Multi-cluster federation, GitOps integration |
+
+---
+
+## References
+
+- [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) — standard Go operator framework
+- [KubeOps](https://buehler.github.io/dotnet-operator-sdk/) — .NET operator SDK
+- [Operator Pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) — Kubernetes documentation
+- [JD.AI Architecture — Kubernetes Integration](../README.md#kubernetes-integration)

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -119,6 +119,69 @@ docker build -f deploy/docker/Dockerfile.daemon -t jdai-daemon:local .
 docker build -f deploy/docker/Dockerfile.tui -t jdai-tui:local .
 ```
 
+## Observability / OTLP
+
+Enable OTLP export by setting `telemetry.enabled = true`:
+
+```yaml
+telemetry:
+  enabled: true
+  otlpEndpoint: http://otel-collector:4317
+  otlpProtocol: grpc
+  serviceName: jdai
+```
+
+The chart injects `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_SERVICE_NAME` as environment variables into all pods.
+
+## Distributed workflow workers
+
+Enable the distributed workflow worker pool:
+
+```yaml
+distributedWorker:
+  enabled: true
+  replicaCount: 3
+  transport: redis
+  redis:
+    connectionString: redis-master:6379
+    streamKey: jdai:workflows
+    consumerGroup: jdai-workers
+```
+
+Workers are stateless — replicas compete for messages via the consumer group. Scale horizontally by increasing `replicaCount`.
+
+## Batch/job mode
+
+Run a single agent workflow as a Kubernetes Job (exits 0/1 for CI/CD integration):
+
+```yaml
+batchJob:
+  enabled: true
+  agent: code-reviewer
+  workflow: pr-review
+```
+
+Or via `kubectl`:
+
+```bash
+kubectl create job pr-review \
+  --image=ghcr.io/jerrettdavis/jd.ai-daemon:latest \
+  -- dotnet JD.AI.Daemon.dll run --agent code-reviewer --workflow pr-review
+```
+
+## Kubernetes Operator (v2 — planned)
+
+A CRD-based operator for managing `JdAiAgent` custom resources is planned for v2.
+See [Kubernetes Operator Design](../architecture/kubernetes-operator-design.md) for the full design.
+
+## Root Dockerfile
+
+The repo root includes a `Dockerfile` that builds `JD.AI.Daemon` and is compatible with standard `docker build .` usage:
+
+```bash
+docker build -t jdai:local .
+```
+
 ## See also
 
 - [Service Deployment](deployment.md)


### PR DESCRIPTION
## Summary

Implements #207 - Kubernetes Integration.

### Changes

**Root Dockerfile**
- Standard multi-stage build targeting JD.AI.Daemon
- Compatible with docker build . out of the box

**Helm chart additions**
- telemetry section: OTLP endpoint, protocol, service name, custom resource attributes
- distributedWorker deployment template: Redis or Azure Service Bus transport, scales horizontally
- batchJob Helm job template: post-install hook, exit 0/1 for CI/CD
- configmap-telemetry.yaml: OTEL env var injection into all pods

**CI**
- helm-lint job added to containers.yml: runs helm lint + helm template on every push

**Documentation**
- kubernetes-operator-design.md: v2 CRD design doc with JdAiAgent and JdAiPolicy CRDs, operator architecture, reconciliation loop, phased roadmap
- docs/operations/kubernetes.md updated with OTLP, distributed worker, batch job, and operator sections

### OTLP example

telemetry:
  enabled: true
  otlpEndpoint: http://otel-collector:4317
  serviceName: jdai

### Distributed worker example

distributedWorker:
  enabled: true
  replicaCount: 3
  transport: redis
  redis:
    connectionString: redis-master:6379

### Batch job example

batchJob:
  enabled: true
  agent: code-reviewer
  workflow: pr-review

Closes #207
