### PR TITLE
test(startup): raise startup coverage with deterministic module tests

### DIFF
--- a/tests/JD.AI.Tests/Startup/GovernanceInitializerTests.cs
+++ b/tests/JD.AI.Tests/Startup/GovernanceInitializerTests.cs
@@ -1,0 +1,82 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Agents.Checkpointing;
+using JD.AI.Core.Config;
+using JD.AI.Core.Tools;
+using JD.AI.Startup;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Tests.Startup;
+
+[Collection("DataDirectories")]
+public sealed class GovernanceInitializerTests : IDisposable
+{
+    private readonly string _originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+    [Fact]
+    public void Initialize_ConfiguresSessionAndAppliesAllowedToolFiltering()
+    {
+        using var fixture = new JD.AI.Tests.Fixtures.TempDirectoryFixture();
+        DataDirectories.SetRoot(fixture.GetPath("jdai-root"));
+
+        var cwd = fixture.CreateSubdirectory("workspace");
+        Directory.SetCurrentDirectory(cwd);
+
+        var model = new JD.AI.Core.Providers.ProviderModelInfo("model-a", "Model A", "TestProvider");
+        var (registry, _, _) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", model));
+        var kernel = registry.BuildKernel(model);
+        kernel.ImportPluginFromObject(new MemoryTools(), "memory");
+        kernel.ImportPluginFromObject(new TaskTools(), "tasks");
+
+        var session = new AgentSession(registry, kernel, model);
+        var options = new CliOptions
+        {
+            PrintMode = true,
+            AllowedTools = ["memory"],
+        };
+
+        var setup = GovernanceInitializer.Initialize(cwd, session, kernel, options, maxBudgetUsd: 5m);
+
+        Assert.Null(setup.PolicyEvaluator);
+        Assert.NotNull(setup.AuditService);
+        Assert.NotNull(session.AuditService);
+        Assert.NotNull(session.LoadoutRegistry);
+        Assert.NotNull(session.AllPlugins);
+        Assert.NotNull(session.ApprovalService);
+        Assert.IsType<DirectoryCheckpointStrategy>(setup.CheckpointStrategy);
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("memory", StringComparison.Ordinal));
+        Assert.DoesNotContain(kernel.Plugins, p => p.Name.Equals("tasks", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Initialize_UsesStashCheckpointStrategyWhenGitDirectoryExists()
+    {
+        using var fixture = new JD.AI.Tests.Fixtures.TempDirectoryFixture();
+        DataDirectories.SetRoot(fixture.GetPath("jdai-root"));
+
+        var projectPath = fixture.CreateSubdirectory("project");
+        Directory.SetCurrentDirectory(projectPath);
+        Directory.CreateDirectory(Path.Combine(projectPath, ".git"));
+
+        var model = new JD.AI.Core.Providers.ProviderModelInfo("model-a", "Model A", "TestProvider");
+        var (registry, _, _) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", model));
+        var kernel = registry.BuildKernel(model);
+        var session = new AgentSession(registry, kernel, model);
+
+        var setup = GovernanceInitializer.Initialize(
+            projectPath,
+            session,
+            kernel,
+            new CliOptions { PrintMode = true },
+            maxBudgetUsd: null);
+
+        Assert.IsType<StashCheckpointStrategy>(setup.CheckpointStrategy);
+    }
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalCurrentDirectory);
+        DataDirectories.Reset();
+    }
+}

--- a/tests/JD.AI.Tests/Startup/PrintModeRunnerTests.cs
+++ b/tests/JD.AI.Tests/Startup/PrintModeRunnerTests.cs
@@ -1,0 +1,72 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Providers;
+using JD.AI.Core.Skills;
+using JD.AI.Startup;
+
+namespace JD.AI.Tests.Startup;
+
+public sealed class PrintModeRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsErrorWhenNoQueryOrPipedInputProvided()
+    {
+        var model = new ProviderModelInfo("test-model", "Test Model", "TestProvider");
+        var (registry, _, _) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", model));
+        var session = new AgentSession(registry, registry.BuildKernel(model), model);
+        using var skills = new SkillLifecycleManager([]);
+
+        var originalError = Console.Error;
+        using var error = new StringWriter();
+        Console.SetError(error);
+
+        try
+        {
+            var exitCode = await PrintModeRunner.RunAsync(new CliOptions(), session, model, skills);
+            Assert.Equal(1, exitCode);
+            Assert.Contains("--print requires a query argument or piped input", error.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_StopsBeforeTurnExecutionWhenMaxTurnsExceeded()
+    {
+        var model = new ProviderModelInfo("test-model", "Test Model", "TestProvider");
+        var (registry, _, _) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", model));
+        var session = new AgentSession(registry, registry.BuildKernel(model), model);
+        using var skills = new SkillLifecycleManager([]);
+
+        var originalError = Console.Error;
+        using var error = new StringWriter();
+        Console.SetError(error);
+
+        try
+        {
+            var options = new CliOptions
+            {
+                PrintQuery = "hello",
+                MaxTurns = 0,
+            };
+
+            var exitCode = await PrintModeRunner.RunAsync(options, session, model, skills);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("max turns (0) exceeded", error.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+
+    [Fact]
+    public void JsonOptions_Indented_IsWriteIndented()
+    {
+        Assert.True(JsonOptions.Indented.WriteIndented);
+    }
+}

--- a/tests/JD.AI.Tests/Startup/SessionConfiguratorTests.cs
+++ b/tests/JD.AI.Tests/Startup/SessionConfiguratorTests.cs
@@ -1,0 +1,73 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Providers;
+using JD.AI.Startup;
+
+namespace JD.AI.Tests.Startup;
+
+[Collection("DataDirectories")]
+public sealed class SessionConfiguratorTests
+{
+    [Fact]
+    public async Task ConfigureAsync_AppliesCliFlagsAndExplicitFallbackModels()
+    {
+        var primaryModel = new ProviderModelInfo("primary-model", "Primary Model", "TestProvider");
+        var (registry, providerConfig, metadataProvider) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", primaryModel));
+        var providerSetup = new ProviderSetup(
+            registry,
+            providerConfig,
+            metadataProvider,
+            [primaryModel],
+            primaryModel,
+            ["route-fallback-1"],
+            registry.BuildKernel(primaryModel));
+
+        var options = new CliOptions
+        {
+            SkipPermissions = true,
+            VerboseMode = true,
+            PermissionModeStr = "plan",
+            FallbackModels = ["fallback-a", "fallback-b"],
+            NoSessionPersistence = true,
+            MaxBudgetUsd = 12.34m,
+            PrintMode = true,
+            DebugMode = true,
+            DebugCategories = "agent,tools",
+        };
+
+        var setup = await SessionConfigurator.ConfigureAsync(options, providerSetup);
+
+        Assert.Equal(primaryModel, setup.SelectedModel);
+        Assert.Equal(registry.BuildKernel(primaryModel).Plugins.Count, setup.Kernel.Plugins.Count);
+        Assert.True(setup.Session.SkipPermissions);
+        Assert.True(setup.Session.Verbose);
+        Assert.Equal(PermissionMode.Plan, setup.Session.PermissionMode);
+        Assert.Equal(["fallback-a", "fallback-b"], setup.Session.FallbackModels);
+        Assert.True(setup.Session.NoSessionPersistence);
+        Assert.Equal(12.34m, setup.Session.MaxBudgetUsd);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_UsesRoutedFallbackModelsWhenCliFallbackNotProvided()
+    {
+        var primaryModel = new ProviderModelInfo("primary-model", "Primary Model", "TestProvider");
+        var (registry, providerConfig, metadataProvider) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", primaryModel));
+        var providerSetup = new ProviderSetup(
+            registry,
+            providerConfig,
+            metadataProvider,
+            [primaryModel],
+            primaryModel,
+            ["route-fallback-1", "route-fallback-2"],
+            registry.BuildKernel(primaryModel));
+
+        var setup = await SessionConfigurator.ConfigureAsync(
+            new CliOptions { NoSessionPersistence = true, PrintMode = true },
+            providerSetup);
+
+        Assert.Equal(["route-fallback-1", "route-fallback-2"], setup.Session.FallbackModels);
+        Assert.Equal(Directory.GetCurrentDirectory(), setup.ProjectPath);
+        Assert.Null(setup.WorktreeManager);
+    }
+}

--- a/tests/JD.AI.Tests/Startup/StartupTestProviderFactory.cs
+++ b/tests/JD.AI.Tests/Startup/StartupTestProviderFactory.cs
@@ -1,0 +1,61 @@
+using JD.AI.Core.Providers;
+using JD.AI.Core.Providers.Credentials;
+using JD.AI.Core.Providers.Metadata;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Tests.Startup;
+
+internal static class StartupTestProviderFactory
+{
+    public static ProviderInfo AvailableProvider(string providerName, params ProviderModelInfo[] models)
+    {
+        return new ProviderInfo(
+            providerName,
+            IsAvailable: true,
+            StatusMessage: "ready",
+            Models: models);
+    }
+
+    public static (
+        ProviderRegistry Registry,
+        ProviderConfigurationManager ProviderConfig,
+        ModelMetadataProvider MetadataProvider)
+        CreateRegistry(params ProviderInfo[] providers)
+    {
+        var metadataProvider = new ModelMetadataProvider();
+        var detectors = providers.Select(p => new FakeDetector(p.Name, p)).ToArray();
+        var registry = new ProviderRegistry(detectors, metadataProvider);
+        var providerConfig = new ProviderConfigurationManager(new StubCredentialStore());
+        return (registry, providerConfig, metadataProvider);
+    }
+
+    private sealed class FakeDetector(string providerName, ProviderInfo result) : IProviderDetector
+    {
+        public string ProviderName => providerName;
+
+        public Task<ProviderInfo> DetectAsync(CancellationToken ct = default) =>
+            Task.FromResult(result);
+
+        public Kernel BuildKernel(ProviderModelInfo model) =>
+            Kernel.CreateBuilder().Build();
+    }
+
+    private sealed class StubCredentialStore : ICredentialStore
+    {
+        public bool IsAvailable => true;
+
+        public string StoreName => "Stub";
+
+        public Task<string?> GetAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult<string?>(null);
+
+        public Task SetAsync(string key, string value, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task RemoveAsync(string key, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<string>> ListKeysAsync(string prefix, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+}

--- a/tests/JD.AI.Tests/Startup/SystemPromptBuilderTests.cs
+++ b/tests/JD.AI.Tests/Startup/SystemPromptBuilderTests.cs
@@ -1,0 +1,63 @@
+using JD.AI.Core.Agents;
+using JD.AI.Startup;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Startup;
+
+public sealed class SystemPromptBuilderTests
+{
+    [Fact]
+    public async Task BuildAsync_UsesExplicitOverrideBeforeFilePrompt()
+    {
+        using var fixture = new TempDirectoryFixture();
+        var systemFile = fixture.CreateFile("system.txt", "file prompt should not win");
+
+        var options = new CliOptions
+        {
+            SystemPromptOverride = "override prompt",
+            SystemPromptFile = systemFile,
+            AppendSystemPrompt = "append tail",
+        };
+
+        var prompt = await SystemPromptBuilder.BuildAsync(options, new InstructionsResult(), planMode: false);
+
+        Assert.StartsWith("override prompt", prompt, StringComparison.Ordinal);
+        Assert.Contains("append tail", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("file prompt should not win", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_LoadsPromptAndAppendsFileAndPlanModeInstruction()
+    {
+        using var fixture = new TempDirectoryFixture();
+        var systemFile = fixture.CreateFile("system.txt", "base prompt");
+        var appendFile = fixture.CreateFile("append.txt", "append from file");
+
+        var options = new CliOptions
+        {
+            SystemPromptFile = systemFile,
+            AppendSystemPrompt = "append inline",
+            AppendSystemPromptFile = appendFile,
+        };
+
+        var prompt = await SystemPromptBuilder.BuildAsync(options, new InstructionsResult(), planMode: true);
+
+        Assert.Contains("base prompt", prompt, StringComparison.Ordinal);
+        Assert.Contains("append inline", prompt, StringComparison.Ordinal);
+        Assert.Contains("append from file", prompt, StringComparison.Ordinal);
+        Assert.Contains("You are in plan mode.", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BuildAsync_UsesDefaultPromptAndInjectsInstructions()
+    {
+        var instructions = new InstructionsResult();
+        instructions.Add(new InstructionFile("AGENTS.md", "/tmp/AGENTS.md", "Follow AGENTS rules"));
+
+        var prompt = await SystemPromptBuilder.BuildAsync(new CliOptions(), instructions, planMode: false);
+
+        Assert.Contains("You are jdai, a helpful AI coding assistant", prompt, StringComparison.Ordinal);
+        Assert.Contains("Project Instructions (AGENTS.md)", prompt, StringComparison.Ordinal);
+        Assert.Contains("Follow AGENTS rules", prompt, StringComparison.Ordinal);
+    }
+}

--- a/tests/JD.AI.Tests/Startup/ToolRegistrarTests.cs
+++ b/tests/JD.AI.Tests/Startup/ToolRegistrarTests.cs
@@ -1,0 +1,36 @@
+using JD.AI.Core.Agents;
+using JD.AI.Core.Providers;
+using JD.AI.Startup;
+
+namespace JD.AI.Tests.Startup;
+
+public sealed class ToolRegistrarTests
+{
+    [Fact]
+    public void RegisterAll_RegistersStatefulAndChannelPlugins_AndTracksModelSwitches()
+    {
+        var modelA = new ProviderModelInfo("model-a", "Model A", "TestProvider");
+        var modelB = new ProviderModelInfo("model-b", "Model B", "TestProvider");
+        var (registry, _, _) = StartupTestProviderFactory.CreateRegistry(
+            StartupTestProviderFactory.AvailableProvider("TestProvider", modelA, modelB));
+        var kernel = registry.BuildKernel(modelA);
+        var session = new AgentSession(registry, kernel, modelA);
+
+        var registration = ToolRegistrar.RegisterAll(kernel, session, modelA);
+        registration.UsageTools.RecordUsage(42, 24, 3);
+
+        session.SwitchModel(modelB);
+        var usageReport = registration.UsageTools.GetUsage();
+
+        Assert.Contains("Model B", usageReport, StringComparison.Ordinal);
+        Assert.Contains("Turns: 1", usageReport, StringComparison.Ordinal);
+
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("memory", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("tasks", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("usage", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("runtime", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("channels", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("gateway", StringComparison.Ordinal));
+        Assert.Contains(kernel.Plugins, p => p.Name.Equals("openclaw", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
- add startup-focused tests for:
  - SystemPromptBuilder
  - PrintModeRunner guard and max-turn behavior
  - SessionConfigurator option application and routed fallback behavior
  - GovernanceInitializer setup + tool filtering + checkpoint strategy
  - ToolRegistrar plugin registration and model-switch usage tracking
- add shared startup test provider factory for deterministic registry/session setup

## Issue
- Closes #239

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ""FullyQualifiedName~JD.AI.Tests.Startup""
- dotnet test JD.AI.slnx --configuration Release --filter ""Category!=Integration"" --collect:""XPlat Code Coverage"" ...
- dotnet format JD.AI.slnx --severity warn --verify-no-changes

## Coverage Delta (JD.AI assembly)
- line coverage: 43.2% -> 47.0%
- branch coverage: 35.3% -> 37.8%
- method coverage: 62.6% -> 66.5%

## Not Yet Covered (follow-up)
- Program and InteractiveLoop remain at 0% in CI coverage and need dedicated harnessing.