### PR TITLE
test(commands): cover CLI handlers and fix update help markup parsing

### DIFF
--- a/src/JD.AI/Commands/UpdateCliHandler.cs
+++ b/src/JD.AI/Commands/UpdateCliHandler.cs
@@ -10,6 +10,15 @@ namespace JD.AI.Commands;
 /// </summary>
 internal static class UpdateCliHandler
 {
+    internal static Func<CancellationToken, Task<InstallationInfo>> DetectInstallationAsync { get; set; } =
+        InstallationDetector.DetectAsync;
+
+    internal static Func<InstallationInfo, IInstallStrategy> UpdateStrategyFactory { get; set; } =
+        InstallerFactory.Create;
+
+    internal static Func<InstallationInfo, IInstallStrategy> InstallStrategyFactory { get; set; } =
+        static info => new GitHubReleaseStrategy(info.RuntimeId, info.ExecutablePath);
+
     public static async Task<int> RunAsync(string subcommand, string[] args)
     {
         using var cts = new CancellationTokenSource();
@@ -32,7 +41,7 @@ internal static class UpdateCliHandler
 
         if (args.Contains("--help") || args.Contains("-h"))
         {
-            AnsiConsole.MarkupLine("[bold]Usage:[/] jdai update [--check] [--force]");
+            AnsiConsole.MarkupLine("[bold]Usage:[/] jdai update [[--check]] [[--force]]");
             AnsiConsole.MarkupLine("  [dim]--check[/]   Check for updates without applying");
             AnsiConsole.MarkupLine("  [dim]--force[/]   Force update even if already on latest");
             return 0;
@@ -43,10 +52,10 @@ internal static class UpdateCliHandler
             .Spinner(Spinner.Known.Dots)
             .SpinnerStyle(Style.Parse("blue"))
             .StartAsync("Detecting installation...", async _ =>
-                await InstallationDetector.DetectAsync(ct).ConfigureAwait(false))
+                await DetectInstallationAsync(ct).ConfigureAwait(false))
             .ConfigureAwait(false);
 
-        var strategy = InstallerFactory.Create(info);
+        var strategy = UpdateStrategyFactory(info);
 
         AnsiConsole.MarkupLine(
             $"[dim]Installed via[/] [bold]{strategy.Name}[/] " +
@@ -123,7 +132,7 @@ internal static class UpdateCliHandler
     {
         if (args.Contains("--help") || args.Contains("-h"))
         {
-            AnsiConsole.MarkupLine("[bold]Usage:[/] jdai install [version] [--force]");
+            AnsiConsole.MarkupLine("[bold]Usage:[/] jdai install [[version]] [[--force]]");
             AnsiConsole.MarkupLine("  [dim]version[/]   Version to install (default: latest)");
             AnsiConsole.MarkupLine("  [dim]--force[/]   Force reinstall even if same version");
             AnsiConsole.WriteLine();
@@ -142,7 +151,7 @@ internal static class UpdateCliHandler
             .Spinner(Spinner.Known.Dots)
             .SpinnerStyle(Style.Parse("blue"))
             .StartAsync("Detecting installation...", async _ =>
-                await InstallationDetector.DetectAsync(ct).ConfigureAwait(false))
+                await DetectInstallationAsync(ct).ConfigureAwait(false))
             .ConfigureAwait(false);
 
         AnsiConsole.MarkupLine(
@@ -150,7 +159,7 @@ internal static class UpdateCliHandler
             $"[dim]Current:[/] [bold]{Markup.Escape(info.CurrentVersion)}[/]");
 
         // For `install`, always use GitHub releases (that's the whole point — no dotnet required)
-        var strategy = new GitHubReleaseStrategy(info.RuntimeId, info.ExecutablePath);
+        var strategy = InstallStrategyFactory(info);
 
         if (targetVersion is null && !force)
         {

--- a/tests/JD.AI.Tests/Commands/AgentsCliHandlerTests.cs
+++ b/tests/JD.AI.Tests/Commands/AgentsCliHandlerTests.cs
@@ -1,0 +1,132 @@
+using JD.AI.Commands;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Commands;
+
+[Collection("DataDirectories")]
+public sealed class AgentsCliHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _originalDataDir;
+
+    public AgentsCliHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-agents-cli-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _originalDataDir = Environment.GetEnvironmentVariable("JDAI_DATA_DIR") ?? string.Empty;
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR", _tempDir);
+        DataDirectories.Reset();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR",
+            string.IsNullOrEmpty(_originalDataDir) ? null : _originalDataDir);
+        DataDirectories.Reset();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task HelpAndUnknownSubcommands_ReturnExpectedExitCodes()
+    {
+        var help = await CaptureStdoutAsync(() => AgentsCliHandler.RunAsync(["help"]));
+        var unknown = await CaptureStderrAsync(() => AgentsCliHandler.RunAsync(["bogus"]));
+
+        Assert.Equal(0, help.ExitCode);
+        Assert.Contains("jdai agents", help.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, unknown.ExitCode);
+        Assert.Contains("Unknown agents command", unknown.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task List_WhenNoAgents_ReturnsHint()
+    {
+        var result = await CaptureStdoutAsync(() => AgentsCliHandler.RunAsync(["list", "--env", "dev"]));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("No agents registered", result.Output, StringComparison.Ordinal);
+        Assert.Contains("Hint: place .agent.yaml files", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TagPromoteAndRemove_ExecuteSuccessfully()
+    {
+        var registry = new FileAgentDefinitionRegistry(Path.Combine(DataDirectories.Root, "agents"));
+        await registry.RegisterAsync(new AgentDefinition
+        {
+            Name = "reviewer",
+            Version = "1.0.0",
+            Description = "PR reviewer",
+            Model = new AgentModelSpec { Provider = "Test", Id = "model-a" },
+        }, AgentEnvironments.Dev);
+
+        var tag = await CaptureStdoutAsync(
+            () => AgentsCliHandler.RunAsync(["tag", "reviewer", "1.1.0", "--env", "dev"]));
+        var promote = await CaptureStdoutAsync(
+            () => AgentsCliHandler.RunAsync(["promote", "reviewer", "1.1.0", "--from", "dev", "--to", "staging"]));
+        var remove = await CaptureStdoutAsync(
+            () => AgentsCliHandler.RunAsync(["remove", "reviewer", "1.1.0", "--env", "staging"]));
+
+        Assert.Equal(0, tag.ExitCode);
+        Assert.Contains("Tagged 'reviewer' as v1.1.0", tag.Output, StringComparison.Ordinal);
+
+        Assert.Equal(0, promote.ExitCode);
+        Assert.Contains("Promoted 'reviewer@1.1.0'", promote.Output, StringComparison.Ordinal);
+
+        Assert.Equal(0, remove.ExitCode);
+        Assert.Contains("Removed 'reviewer@1.1.0'", remove.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MissingArgsAndInvalidPromotionPath_ReturnErrors()
+    {
+        var tagUsage = await CaptureStderrAsync(() => AgentsCliHandler.RunAsync(["tag"]));
+        var removeUsage = await CaptureStderrAsync(() => AgentsCliHandler.RunAsync(["remove", "reviewer"]));
+        var promoteHighest = await CaptureStderrAsync(
+            () => AgentsCliHandler.RunAsync(["promote", "reviewer", "--from", "prod"]));
+
+        Assert.Equal(1, tagUsage.ExitCode);
+        Assert.Contains("Usage: jdai agents tag", tagUsage.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, removeUsage.ExitCode);
+        Assert.Contains("Usage: jdai agents remove", removeUsage.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, promoteHighest.ExitCode);
+        Assert.Contains("highest environment", promoteHighest.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStdoutAsync(Func<Task<int>> action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStderrAsync(Func<Task<int>> action)
+    {
+        var original = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+    }
+}

--- a/tests/JD.AI.Tests/Commands/PluginCliHandlerTests.cs
+++ b/tests/JD.AI.Tests/Commands/PluginCliHandlerTests.cs
@@ -1,0 +1,130 @@
+using JD.AI.Commands;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Commands;
+
+[Collection("DataDirectories")]
+public sealed class PluginCliHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _originalDataDir;
+
+    public PluginCliHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-plugin-cli-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _originalDataDir = Environment.GetEnvironmentVariable("JDAI_DATA_DIR") ?? string.Empty;
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR", _tempDir);
+        DataDirectories.Reset();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR",
+            string.IsNullOrEmpty(_originalDataDir) ? null : _originalDataDir);
+        DataDirectories.Reset();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task HelpUnknownAndListPaths_AreHandled()
+    {
+        var help = await CaptureStdoutAsync(() => PluginCliHandler.RunAsync(["help"]));
+        var unknown = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["bogus"]));
+        var list = await CaptureStdoutAsync(() => PluginCliHandler.RunAsync(["list"]));
+
+        Assert.Equal(0, help.ExitCode);
+        Assert.Contains("jdai plugin", help.Output, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal(1, unknown.ExitCode);
+        Assert.Contains("Unknown plugin subcommand", unknown.Output, StringComparison.Ordinal);
+
+        Assert.Equal(0, list.ExitCode);
+        Assert.Contains("No plugins installed", list.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MissingArguments_ReturnUsageErrors()
+    {
+        var install = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["install"]));
+        var enable = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["enable"]));
+        var disable = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["disable"]));
+        var uninstall = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["uninstall"]));
+        var info = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["info"]));
+
+        Assert.Equal(1, install.ExitCode);
+        Assert.Contains("Usage: jdai plugin install", install.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, enable.ExitCode);
+        Assert.Contains("Usage: jdai plugin enable", enable.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, disable.ExitCode);
+        Assert.Contains("Usage: jdai plugin disable", disable.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, uninstall.ExitCode);
+        Assert.Contains("Usage: jdai plugin uninstall", uninstall.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, info.ExitCode);
+        Assert.Contains("Usage: jdai plugin info", info.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InfoAndUninstall_ForUnknownPlugin_ReturnExpectedErrors()
+    {
+        var info = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["info", "missing-plugin"]));
+        var uninstall = await CaptureStdoutAsync(() => PluginCliHandler.RunAsync(["uninstall", "missing-plugin"]));
+        var updateAll = await CaptureStdoutAsync(() => PluginCliHandler.RunAsync(["update"]));
+
+        Assert.Equal(1, info.ExitCode);
+        Assert.Contains("not found", info.Output, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal(1, uninstall.ExitCode);
+        Assert.Contains("is not installed", uninstall.Output, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Equal(0, updateAll.ExitCode);
+        Assert.Contains("Updated 0 plugin(s)", updateAll.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InstallInvalidSource_UsesTopLevelErrorHandler()
+    {
+        var result = await CaptureStderrAsync(() => PluginCliHandler.RunAsync(["install", "not-a-plugin-source"]));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Plugin command failed", result.Output, StringComparison.Ordinal);
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStdoutAsync(Func<Task<int>> action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStderrAsync(Func<Task<int>> action)
+    {
+        var original = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+    }
+}

--- a/tests/JD.AI.Tests/Commands/PolicyCliHandlerTests.cs
+++ b/tests/JD.AI.Tests/Commands/PolicyCliHandlerTests.cs
@@ -1,0 +1,129 @@
+using JD.AI.Commands;
+using JD.AI.Core.Config;
+
+namespace JD.AI.Tests.Commands;
+
+[Collection("DataDirectories")]
+public sealed class PolicyCliHandlerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _originalDataDir;
+    private readonly string _originalCurrentDirectory = Directory.GetCurrentDirectory();
+
+    public PolicyCliHandlerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jdai-policy-cli-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _originalDataDir = Environment.GetEnvironmentVariable("JDAI_DATA_DIR") ?? string.Empty;
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR", _tempDir);
+        DataDirectories.Reset();
+        Directory.SetCurrentDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalCurrentDirectory);
+        Environment.SetEnvironmentVariable("JDAI_DATA_DIR",
+            string.IsNullOrEmpty(_originalDataDir) ? null : _originalDataDir);
+        DataDirectories.Reset();
+        try { Directory.Delete(_tempDir, recursive: true); }
+        catch { /* best effort */ }
+    }
+
+    [Fact]
+    public async Task PolicySubcommand_HelpAndUnknown_AreHandled()
+    {
+        var help = await CaptureStdoutAsync(() => PolicySubcommandHandler.RunAsync(["help"]));
+        var unknown = await CaptureStderrAsync(() => PolicySubcommandHandler.RunAsync(["bogus"]));
+
+        Assert.Equal(0, help.ExitCode);
+        Assert.Contains("jdai policy", help.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, unknown.ExitCode);
+        Assert.Contains("Unknown policy command", unknown.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Compliance_ListAndHelp_AreRendered()
+    {
+        var list = await CaptureStdoutAsync(() => PolicyComplianceCliHandler.RunAsync(["list"]));
+        var help = await CaptureStdoutAsync(() => PolicyComplianceCliHandler.RunAsync(["help"]));
+
+        Assert.Equal(0, list.ExitCode);
+        Assert.Contains("Built-in compliance presets", list.Output, StringComparison.Ordinal);
+        Assert.Contains("jdai/compliance/soc2", list.Output, StringComparison.Ordinal);
+
+        Assert.Equal(0, help.ExitCode);
+        Assert.Contains("jdai policy compliance", help.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Compliance_Check_ValidAndInvalidProfiles_ReturnExpectedCodes()
+    {
+        var missing = await CaptureStderrAsync(() => PolicyComplianceCliHandler.RunAsync(["check"]));
+        var unknown = await CaptureStderrAsync(
+            () => PolicyComplianceCliHandler.RunAsync(["check", "--profile", "not-a-real-profile"]));
+        var known = await CaptureStdoutAsync(
+            () => PolicyComplianceCliHandler.RunAsync(["check", "--profile", "soc2"]));
+
+        Assert.Equal(1, missing.ExitCode);
+        Assert.Contains("--profile is required", missing.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, unknown.ExitCode);
+        Assert.Contains("Unknown or unsupported profile", unknown.Output, StringComparison.Ordinal);
+
+        Assert.Equal(1, known.ExitCode);
+        Assert.Contains("Compliance Check — jdai/compliance/soc2", known.Output, StringComparison.Ordinal);
+        Assert.Contains("Result:", known.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Compliance_UnknownSubcommand_ReturnsOne()
+    {
+        var unknown = await CaptureStderrAsync(() => PolicyComplianceCliHandler.RunAsync(["bogus"]));
+
+        Assert.Equal(1, unknown.ExitCode);
+        Assert.Contains("Unknown compliance command", unknown.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PolicySubcommand_DelegatesToComplianceHandler()
+    {
+        var result = await CaptureStdoutAsync(() => PolicySubcommandHandler.RunAsync(["compliance", "list"]));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Built-in compliance presets", result.Output, StringComparison.Ordinal);
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStdoutAsync(Func<Task<int>> action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureStderrAsync(Func<Task<int>> action)
+    {
+        var original = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            var code = await action().ConfigureAwait(false);
+            return (code, writer.ToString());
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+    }
+}

--- a/tests/JD.AI.Tests/Commands/UpdateCliHandlerTests.cs
+++ b/tests/JD.AI.Tests/Commands/UpdateCliHandlerTests.cs
@@ -1,0 +1,180 @@
+using JD.AI.Commands;
+using JD.AI.Core.Installation;
+
+namespace JD.AI.Tests.Commands;
+
+public sealed class UpdateCliHandlerTests : IDisposable
+{
+    private readonly Func<CancellationToken, Task<InstallationInfo>> _originalDetect = UpdateCliHandler.DetectInstallationAsync;
+    private readonly Func<InstallationInfo, IInstallStrategy> _originalUpdateFactory = UpdateCliHandler.UpdateStrategyFactory;
+    private readonly Func<InstallationInfo, IInstallStrategy> _originalInstallFactory = UpdateCliHandler.InstallStrategyFactory;
+
+    [Fact]
+    public async Task RunAsync_WithUnknownSubcommand_ReturnsZero()
+    {
+        var code = await UpdateCliHandler.RunAsync("unknown", []);
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task RunAsync_UpdateHelp_ReturnsZero()
+    {
+        var code = await UpdateCliHandler.RunAsync("update", ["--help"]);
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task RunAsync_InstallHelp_ReturnsZero()
+    {
+        var code = await UpdateCliHandler.RunAsync("install", ["--help"]);
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task Update_CheckOnly_WithNewerVersion_ReturnsZeroWithoutApplying()
+    {
+        var strategy = CreateStrategy(latest: "1.1.0", applySuccess: true);
+        ConfigureHandlers(currentVersion: "1.0.0", updateStrategy: strategy);
+
+        var code = await UpdateCliHandler.RunAsync("update", ["--check"]);
+
+        Assert.Equal(0, code);
+        Assert.Equal(0, strategy.ApplyCalls);
+    }
+
+    [Fact]
+    public async Task Update_WhenLatestVersionUnknown_ReturnsOneUnlessForced()
+    {
+        ConfigureHandlers(
+            currentVersion: "1.0.0",
+            updateStrategy: CreateStrategy(latest: null, applySuccess: true));
+
+        var code = await UpdateCliHandler.RunAsync("update", []);
+
+        Assert.Equal(1, code);
+    }
+
+    [Fact]
+    public async Task Update_WhenAlreadyOnLatest_ReturnsZero()
+    {
+        ConfigureHandlers(
+            currentVersion: "1.0.0",
+            updateStrategy: CreateStrategy(latest: "1.0.0", applySuccess: true));
+
+        var code = await UpdateCliHandler.RunAsync("update", []);
+
+        Assert.Equal(0, code);
+    }
+
+    [Fact]
+    public async Task Update_ApplyPath_ReturnsZeroOnSuccess_AndOneOnFailure()
+    {
+        var ok = CreateStrategy(latest: "1.2.0", applySuccess: true);
+        ConfigureHandlers(currentVersion: "1.0.0", updateStrategy: ok);
+        var successCode = await UpdateCliHandler.RunAsync("update", []);
+
+        var fail = CreateStrategy(latest: "1.3.0", applySuccess: false);
+        ConfigureHandlers(currentVersion: "1.0.0", updateStrategy: fail);
+        var failureCode = await UpdateCliHandler.RunAsync("update", []);
+
+        Assert.Equal(0, successCode);
+        Assert.Equal(1, failureCode);
+        Assert.Equal(1, ok.ApplyCalls);
+        Assert.Equal(1, fail.ApplyCalls);
+    }
+
+    [Fact]
+    public async Task Install_WhenLatestCannotBeResolved_ReturnsOne()
+    {
+        ConfigureHandlers(
+            currentVersion: "1.0.0",
+            installStrategy: CreateStrategy(latest: null, applySuccess: true));
+
+        var code = await UpdateCliHandler.RunAsync("install", []);
+
+        Assert.Equal(1, code);
+    }
+
+    [Fact]
+    public async Task Install_WhenAlreadyLatest_ReturnsZeroWithoutApplying()
+    {
+        var strategy = CreateStrategy(latest: "1.0.0", applySuccess: true);
+        ConfigureHandlers(currentVersion: "1.0.0", installStrategy: strategy);
+
+        var code = await UpdateCliHandler.RunAsync("install", []);
+
+        Assert.Equal(0, code);
+        Assert.Equal(0, strategy.ApplyCalls);
+    }
+
+    [Fact]
+    public async Task Install_WithExplicitVersion_UsesApplyResult()
+    {
+        var success = CreateStrategy(latest: "9.9.9", applySuccess: true);
+        ConfigureHandlers(currentVersion: "1.0.0", installStrategy: success);
+        var successCode = await UpdateCliHandler.RunAsync("install", ["2.0.0", "--force"]);
+
+        var failure = CreateStrategy(latest: "9.9.9", applySuccess: false);
+        ConfigureHandlers(currentVersion: "1.0.0", installStrategy: failure);
+        var failureCode = await UpdateCliHandler.RunAsync("install", ["2.0.0", "--force"]);
+
+        Assert.Equal(0, successCode);
+        Assert.Equal(1, failureCode);
+        Assert.Equal("2.0.0", success.LastTargetVersion);
+        Assert.Equal("2.0.0", failure.LastTargetVersion);
+    }
+
+    public void Dispose()
+    {
+        UpdateCliHandler.DetectInstallationAsync = _originalDetect;
+        UpdateCliHandler.UpdateStrategyFactory = _originalUpdateFactory;
+        UpdateCliHandler.InstallStrategyFactory = _originalInstallFactory;
+    }
+
+    private static FakeInstallStrategy CreateStrategy(string? latest, bool applySuccess) =>
+        new("fake", latest, new InstallResult(
+            Success: applySuccess,
+            Output: applySuccess ? "ok" : "failed",
+            RequiresRestart: applySuccess));
+
+    private static void ConfigureHandlers(
+        string currentVersion,
+        FakeInstallStrategy? updateStrategy = null,
+        FakeInstallStrategy? installStrategy = null)
+    {
+        var info = new InstallationInfo(
+            InstallKind.Unknown,
+            ExecutablePath: "/tmp/jdai",
+            CurrentVersion: currentVersion,
+            RuntimeId: "linux-x64");
+
+        UpdateCliHandler.DetectInstallationAsync = _ => Task.FromResult(info);
+        UpdateCliHandler.UpdateStrategyFactory = _ => updateStrategy ?? CreateStrategy("1.0.0", true);
+        UpdateCliHandler.InstallStrategyFactory = _ => installStrategy ?? CreateStrategy("1.0.0", true);
+    }
+
+    private sealed class FakeInstallStrategy(
+        string name,
+        string? latestVersion,
+        InstallResult applyResult) : IInstallStrategy
+    {
+        private readonly string? _latestVersion = latestVersion;
+        private readonly InstallResult _applyResult = applyResult;
+
+        public string Name { get; } = name;
+
+        public int ApplyCalls { get; private set; }
+
+        public string? LastTargetVersion { get; private set; }
+
+        public Task<string?> GetLatestVersionAsync(CancellationToken ct = default) =>
+            Task.FromResult(_latestVersion);
+
+        public Task<InstallResult> ApplyAsync(string? targetVersion = null, CancellationToken ct = default)
+        {
+            ApplyCalls++;
+            LastTargetVersion = targetVersion;
+            return Task.FromResult(_applyResult);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic CLI tests for `agents`, `policy`, `plugin`, and `update` subcommand handlers
- cover success and error/usage paths for each handler
- fix a real bug in `UpdateCliHandler` help rendering by escaping bracketed arguments for Spectre markup (`[--check]`, `[version]`, etc.)
- add injectable strategy delegates in `UpdateCliHandler` to enable deterministic tests without network access

## Issue
- Closes #240

## Validation
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter "FullyQualifiedName~JD.AI.Tests.Commands.AgentsCliHandlerTests|FullyQualifiedName~JD.AI.Tests.Commands.PolicyCliHandlerTests|FullyQualifiedName~JD.AI.Tests.Commands.PluginCliHandlerTests|FullyQualifiedName~JD.AI.Tests.Commands.UpdateCliHandlerTests"`
- `dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ... --collect:"XPlat Code Coverage"`
- `dotnet format JD.AI.slnx --severity warn --verify-no-changes`

## Command Handler Coverage (command-focused run)
- `AgentsCliHandler`: `76.1%`
- `PluginCliHandler`: `71.1%`
- `PolicyComplianceCliHandler`: `96.0%`
- `PolicySubcommandHandler`: `100%`
- `UpdateCliHandler`: `84.6%`

## Notes
- A full local `Category!=Integration` run in this environment surfaced unrelated pre-existing failures in non-command tests (`ProviderDetectorTests`, `AgentLoopTracingTests`), not introduced by this change.