### PR TITLE
feat(upss): add vision specification system

### DIFF
--- a/specs/vision/README.md
+++ b/specs/vision/README.md
@@ -1,0 +1,70 @@
+# Vision Specification System
+
+The Vision Specification is the canonical source of product intent for JD.AI. It captures why a product exists, who it serves, what value it creates, how success is measured, and which constraints and non-goals bound future design work.
+
+## Purpose
+
+Use `vision.v1` to anchor downstream specifications and implementation work. A valid vision spec should:
+
+- state the product problem and mission clearly
+- identify target users and their needs
+- define value proposition and measurable success metrics
+- record constraints and explicit non-goals
+- trace upstream context and downstream capability references
+
+## Repository Layout
+
+`/specs/vision/README.md`
+`/specs/vision/schema/vision.schema.json`
+`/specs/vision/examples/vision.example.yaml`
+`/specs/vision/index.yaml`
+
+## Authoring Contract
+
+Vision specs use YAML with the following top-level shape:
+
+- `apiVersion`: must be `jdai.upss/v1`
+- `kind`: must be `Vision`
+- `id`: `vision.<domain>` style identifier
+- `version`: integer revision of the spec payload
+- `status`: `draft`, `active`, `deprecated`, or `retired`
+- `metadata`: owners, reviewers, review date, and change reason
+- `problemStatement`
+- `mission`
+- `targetUsers[]`
+- `valueProposition`
+- `successMetrics[]`
+- `constraints[]`
+- `nonGoals[]`
+- `trace.upstream[]`
+- `trace.downstream.capabilities[]`
+
+## Validation
+
+Validation is enforced in two layers:
+
+1. `specs/vision/schema/vision.schema.json` provides the machine-readable contract for humans, agents, and external tooling.
+2. `JD.AI.Core.Specifications.VisionSpecificationValidator` enforces repo-native rules in CI, including:
+   - required fields and allowed status values
+   - ID conventions for vision, user, metric, and capability references
+   - upstream file reference existence
+   - downstream capability referential integrity when `/specs/capabilities/index.yaml` exists
+   - index-to-file consistency for checked-in vision specs
+
+The merge gate is the repository test suite. Invalid vision specs fail `dotnet test JD.AI.slnx`.
+
+## Agent Workflow
+
+Assigned agent: `upss-vision-architect`
+
+Expected workflow:
+
+1. Read the current repository context and any upstream strategy documents.
+2. Update `index.yaml` and the target vision spec file together.
+3. Keep success metrics measurable and non-goals explicit.
+4. Add downstream capability references once the corresponding capability artifacts exist.
+5. Run repository validation before opening a PR.
+
+## Example
+
+See `specs/vision/examples/vision.example.yaml` for the canonical `vision.v1` example used by repository validation.

--- a/specs/vision/examples/vision.example.yaml
+++ b/specs/vision/examples/vision.example.yaml
@@ -1,0 +1,55 @@
+apiVersion: jdai.upss/v1
+kind: Vision
+id: vision.jdai.product
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-vision-architect
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical UPSS artifact for repo-native product intent.
+problemStatement: JD.AI lacks a single authoritative product-intent artifact that humans and agents can both consume and validate.
+mission: Enable safe, agent-driven software delivery from repo-native specifications.
+targetUsers:
+  - id: user.product-owner
+    name: Product owners
+    needs:
+      - Define product direction, scope, and measures of success in a durable repository artifact.
+  - id: user.delivery-agent
+    name: Delivery agents
+    needs:
+      - Read product intent directly from the repository and trace implementation work back to it.
+  - id: user.governance-reviewer
+    name: Governance reviewers
+    needs:
+      - Audit whether capabilities, tests, and operational changes remain aligned with approved product intent.
+valueProposition:
+  summary: JD.AI turns the repository into the authoritative product blueprint so intent, implementation, and validation evolve together.
+  differentiators:
+    - Product intent lives beside code, tests, and deployment assets instead of in disconnected planning systems.
+    - Structured specs are machine-readable for agents while remaining legible to human reviewers.
+    - Traceability and validation can be enforced in CI to reduce specification drift.
+successMetrics:
+  - id: metric.traceability-coverage
+    name: Traceability coverage
+    target: ">=95% of implementation artifacts map back to approved product intent."
+    measurement: Automated traceability audits across specs, code, tests, and deployment artifacts.
+  - id: metric.validation-adoption
+    name: Validation adoption
+    target: "All new canonical spec types ship with repo-native validation before general use."
+    measurement: CI enforcement coverage across UPSS spec directories.
+constraints:
+  - Specifications must be stored in-repo and versioned with the product they describe.
+  - Every canonical spec type must support both human-readable guidance and machine-readable structure.
+  - Validation must run in CI without depending on external control planes.
+nonGoals:
+  - Replace human approval for high-risk releases or security-sensitive changes.
+  - Encode sprint plans, milestones, or staffing decisions inside the vision layer.
+trace:
+  upstream:
+    - docs/index.md
+    - docs/architecture/index.md
+  downstream:
+    capabilities: []

--- a/specs/vision/index.yaml
+++ b/specs/vision/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: VisionIndex
+entries:
+  - id: vision.jdai.product
+    title: JD.AI Product Vision
+    path: specs/vision/examples/vision.example.yaml
+    status: draft

--- a/specs/vision/schema/vision.schema.json
+++ b/specs/vision/schema/vision.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jd.ai/schemas/upss/vision.schema.json",
+  "title": "JD.AI Vision Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "problemStatement",
+    "mission",
+    "targetUsers",
+    "valueProposition",
+    "successMetrics",
+    "constraints",
+    "nonGoals",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "jdai.upss/v1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "Vision"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^vision\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "reviewers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "lastReviewed": {
+          "type": "string"
+        },
+        "changeReason": {
+          "type": "string"
+        }
+      }
+    },
+    "problemStatement": {
+      "type": "string"
+    },
+    "mission": {
+      "type": "string"
+    },
+    "targetUsers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "needs"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "needs": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "valueProposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "differentiators"],
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "differentiators": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "successMetrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "target", "measurement"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "measurement": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "nonGoals": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["capabilities"],
+          "properties": {
+            "capabilities": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/VisionSpecification.cs
+++ b/src/JD.AI.Core/Specifications/VisionSpecification.cs
@@ -1,0 +1,394 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class VisionSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public VisionMetadata Metadata { get; set; } = new();
+    public string ProblemStatement { get; set; } = string.Empty;
+    public string Mission { get; set; } = string.Empty;
+    public List<VisionTargetUser> TargetUsers { get; set; } = [];
+    public VisionValueProposition ValueProposition { get; set; } = new();
+    public List<VisionSuccessMetric> SuccessMetrics { get; set; } = [];
+    public List<string> Constraints { get; set; } = [];
+    public List<string> NonGoals { get; set; } = [];
+    public VisionTraceability Trace { get; set; } = new();
+}
+
+public sealed class VisionMetadata
+{
+    public List<string> Owners { get; set; } = [];
+    public List<string> Reviewers { get; set; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class VisionTargetUser
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Needs { get; set; } = [];
+}
+
+public sealed class VisionValueProposition
+{
+    public string Summary { get; set; } = string.Empty;
+    public List<string> Differentiators { get; set; } = [];
+}
+
+public sealed class VisionSuccessMetric
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string Measurement { get; set; } = string.Empty;
+}
+
+public sealed class VisionTraceability
+{
+    public List<string> Upstream { get; set; } = [];
+    public VisionDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class VisionDownstreamTrace
+{
+    public List<string> Capabilities { get; set; } = [];
+}
+
+public sealed class VisionSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public List<VisionSpecificationIndexEntry> Entries { get; set; } = [];
+}
+
+public sealed class VisionSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public sealed class CapabilitySpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public List<CapabilitySpecificationIndexEntry> Entries { get; set; } = [];
+}
+
+public sealed class CapabilitySpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+}
+
+public static class VisionSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static VisionSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<VisionSpecification>(yaml);
+    }
+
+    public static VisionSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static VisionSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<VisionSpecificationIndex>(yaml);
+    }
+
+    public static VisionSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+
+    public static CapabilitySpecificationIndex ParseCapabilityIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<CapabilitySpecificationIndex>(yaml);
+    }
+
+    public static CapabilitySpecificationIndex ParseCapabilityIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseCapabilityIndex(File.ReadAllText(path));
+    }
+}
+
+public static class VisionSpecificationValidator
+{
+    private static readonly Regex VisionIdPattern = new(
+        "^vision\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TargetUserIdPattern = new(
+        "^user\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex MetricIdPattern = new(
+        "^metric\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex CapabilityIdPattern = new(
+        "^capability\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    public static IReadOnlyList<string> Validate(VisionSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var errors = new List<string>();
+
+        var metadata = document.Metadata ?? new VisionMetadata();
+        var valueProposition = document.ValueProposition ?? new VisionValueProposition();
+        var trace = document.Trace ?? new VisionTraceability();
+        var downstream = trace.Downstream ?? new VisionDownstreamTrace();
+        var targetUsers = document.TargetUsers ?? [];
+        var successMetrics = document.SuccessMetrics ?? [];
+        var constraints = document.Constraints ?? [];
+        var nonGoals = document.NonGoals ?? [];
+        var differentiators = valueProposition.Differentiators ?? [];
+        var capabilityRefs = downstream.Capabilities ?? [];
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Vision", StringComparison.Ordinal), "kind must be 'Vision'.", errors);
+        Require(VisionIdPattern.IsMatch(document.Id), "id must match vision.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        Require(document.Metadata is not null, "metadata is required.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(IsIsoDate(metadata.LastReviewed), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.ProblemStatement), "problemStatement is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.Mission), "mission is required.", errors);
+        Require(targetUsers.Count > 0, "targetUsers must contain at least one actor.", errors);
+        Require(successMetrics.Count > 0, "successMetrics must contain at least one metric.", errors);
+        RequireHasValues(constraints, "constraints must contain at least one constraint.", errors);
+        RequireHasValues(nonGoals, "nonGoals must contain at least one non-goal.", errors);
+        Require(document.ValueProposition is not null, "valueProposition is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(valueProposition.Summary), "valueProposition.summary is required.", errors);
+        RequireHasValues(differentiators, "valueProposition.differentiators must contain at least one item.", errors);
+
+        for (var i = 0; i < targetUsers.Count; i++)
+        {
+            var user = targetUsers[i];
+            Require(TargetUserIdPattern.IsMatch(user.Id), $"targetUsers[{i}].id must match user.<name> convention.", errors);
+            Require(!string.IsNullOrWhiteSpace(user.Name), $"targetUsers[{i}].name is required.", errors);
+            RequireHasValues(user.Needs, $"targetUsers[{i}].needs must contain at least one need.", errors);
+        }
+
+        for (var i = 0; i < successMetrics.Count; i++)
+        {
+            var metric = successMetrics[i];
+            Require(MetricIdPattern.IsMatch(metric.Id), $"successMetrics[{i}].id must match metric.<name> convention.", errors);
+            Require(!string.IsNullOrWhiteSpace(metric.Name), $"successMetrics[{i}].name is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(metric.Target), $"successMetrics[{i}].target is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(metric.Measurement), $"successMetrics[{i}].measurement is required.", errors);
+        }
+
+        for (var i = 0; i < capabilityRefs.Count; i++)
+        {
+            var capabilityId = capabilityRefs[i];
+            Require(
+                CapabilityIdPattern.IsMatch(capabilityId),
+                $"trace.downstream.capabilities[{i}] must match capability.<name> convention.",
+                errors);
+        }
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "vision", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "vision", "schema", "vision.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/vision/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/vision/schema/vision.schema.json.");
+
+        VisionSpecificationIndex index;
+        try
+        {
+            index = VisionSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/vision/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Vision index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "VisionIndex", StringComparison.Ordinal), "Vision index kind must be 'VisionIndex'.", errors);
+        Require(index.Entries.Count > 0, "Vision index must contain at least one entry.", errors);
+
+        var capabilityIds = LoadCapabilityIds(repoRoot, errors);
+
+        foreach (var entry in index.Entries)
+        {
+            if (!VisionIdPattern.IsMatch(entry.Id))
+            {
+                errors.Add($"Vision index entry id '{entry.Id}' does not match vision.<name> convention.");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Path))
+            {
+                errors.Add($"Vision index entry '{entry.Id}' is missing a path.");
+                continue;
+            }
+
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Vision spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            VisionSpecification spec;
+            try
+            {
+                spec = VisionSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse vision spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateUpstreamReferences(repoRoot, spec, entry.Path, errors);
+            ValidateCapabilityReferences(capabilityIds, spec, entry.Path, errors);
+        }
+
+        return errors;
+    }
+
+    private static HashSet<string> LoadCapabilityIds(string repoRoot, List<string> errors)
+    {
+        var capabilityIndexPath = Path.Combine(repoRoot, "specs", "capabilities", "index.yaml");
+        if (!File.Exists(capabilityIndexPath))
+            return [];
+
+        try
+        {
+            var index = VisionSpecificationParser.ParseCapabilityIndexFile(capabilityIndexPath);
+            return index.Entries
+                .Select(entry => entry.Id)
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .ToHashSet(StringComparer.Ordinal);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/capabilities/index.yaml: {ex.Message}");
+            return [];
+        }
+    }
+
+    private static void ValidateUpstreamReferences(
+        string repoRoot,
+        VisionSpecification spec,
+        string specPath,
+        List<string> errors)
+    {
+        var upstreamReferences = spec.Trace?.Upstream ?? [];
+
+        foreach (var reference in upstreamReferences)
+        {
+            if (string.IsNullOrWhiteSpace(reference))
+            {
+                errors.Add($"{specPath}: trace.upstream entries must not be blank.");
+                continue;
+            }
+
+            if (Uri.TryCreate(reference, UriKind.Absolute, out var uri) && uri.Scheme is "http" or "https")
+                continue;
+
+            var fullPath = Path.Combine(repoRoot, reference.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: trace.upstream reference '{reference}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void ValidateCapabilityReferences(
+        HashSet<string> capabilityIds,
+        VisionSpecification spec,
+        string specPath,
+        List<string> errors)
+    {
+        var capabilityReferences = spec.Trace?.Downstream?.Capabilities ?? [];
+
+        if (capabilityReferences.Count == 0)
+            return;
+
+        if (capabilityIds.Count == 0)
+        {
+            errors.Add($"{specPath}: trace.downstream.capabilities declared but specs/capabilities/index.yaml is missing.");
+            return;
+        }
+
+        foreach (var capabilityId in capabilityReferences)
+        {
+            if (!capabilityIds.Contains(capabilityId))
+                errors.Add($"{specPath}: capability reference '{capabilityId}' was not found in specs/capabilities/index.yaml.");
+        }
+    }
+
+    private static bool IsIsoDate(string value) =>
+        DateOnly.TryParse(value, out _);
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IReadOnlyList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/VisionSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/VisionSpecificationRepositoryTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class VisionSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryVisionArtifacts_ValidateSuccessfully()
+    {
+        var errors = VisionSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty("checked-in vision specs should be valid and traceable");
+    }
+
+    [Fact]
+    public void VisionSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "vision", "schema", "vision.schema.json");
+        var schemaText = File.ReadAllText(schemaPath);
+        var schema = JsonNode.Parse(schemaText)!.AsObject();
+
+        schema["$schema"]!.GetValue<string>().Should().Contain("json-schema.org");
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Vision Specification");
+        schema["type"]!.GetValue<string>().Should().Be("object");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "version", "status", "metadata"]);
+
+        var properties = schema["properties"]!.AsObject();
+        properties.ContainsKey("problemStatement").Should().BeTrue();
+        properties.ContainsKey("mission").Should().BeTrue();
+        properties.ContainsKey("targetUsers").Should().BeTrue();
+        properties.ContainsKey("successMetrics").Should().BeTrue();
+        properties.ContainsKey("trace").Should().BeTrue();
+    }
+
+    [Fact]
+    public void VisionExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "vision", "examples", "vision.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "vision", "schema", "vision.schema.json");
+
+        var spec = VisionSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/VisionSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/VisionSpecificationValidatorTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class VisionSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidVisionSpecification_RoundTripsFields()
+    {
+        var spec = VisionSpecificationParser.Parse(ValidVisionYaml());
+
+        spec.ApiVersion.Should().Be("jdai.upss/v1");
+        spec.Kind.Should().Be("Vision");
+        spec.Id.Should().Be("vision.jdai.product");
+        spec.Metadata.Owners.Should().Contain("JerrettDavis");
+        spec.TargetUsers.Should().HaveCount(2);
+        spec.SuccessMetrics.Should().HaveCount(2);
+        spec.Trace.Upstream.Should().Contain("docs/index.md");
+    }
+
+    [Fact]
+    public void Validate_ValidVisionSpecification_ReturnsNoErrors()
+    {
+        var spec = VisionSpecificationParser.Parse(ValidVisionYaml());
+
+        var errors = VisionSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidVisionSpecification_ReturnsFieldErrors()
+    {
+        var spec = VisionSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Vision
+            id: invalid-id
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: not-a-date
+              changeReason: ""
+            problemStatement: ""
+            mission: ""
+            targetUsers: []
+            valueProposition:
+              summary: ""
+              differentiators: []
+            successMetrics: []
+            constraints: []
+            nonGoals: []
+            trace:
+              upstream: []
+              downstream:
+                capabilities:
+                  - bad-capability
+            """);
+
+        var errors = VisionSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match vision.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("version must be greater", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("status must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("metadata.owners", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("metadata.reviewers", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("metadata.lastReviewed", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("problemStatement", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("trace.downstream.capabilities", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_ValidRepositoryArtifacts_ReturnNoErrors()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("docs/index.md", "# Docs");
+        _fixture.CreateFile("specs/vision/schema/vision.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/vision/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: VisionIndex
+            entries:
+              - id: vision.jdai.product
+                title: JD.AI Product Vision
+                path: specs/vision/examples/vision.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", ValidVisionYaml());
+
+        var errors = VisionSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingCapabilityIndex_FailsWhenCapabilityRefsExist()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("docs/index.md", "# Docs");
+        _fixture.CreateFile("specs/vision/schema/vision.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/vision/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: VisionIndex
+            entries:
+              - id: vision.jdai.product
+                title: JD.AI Product Vision
+                path: specs/vision/examples/vision.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile(
+            "specs/vision/examples/vision.example.yaml",
+            ValidVisionYaml(["capability.agent-workflow"]));
+
+        var errors = VisionSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error =>
+            error.Contains("specs/capabilities/index.yaml is missing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_UnknownCapabilityReference_Fails()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("docs/index.md", "# Docs");
+        _fixture.CreateFile("specs/vision/schema/vision.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/vision/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: VisionIndex
+            entries:
+              - id: vision.jdai.product
+                title: JD.AI Product Vision
+                path: specs/vision/examples/vision.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/capabilities/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: CapabilityIndex
+            entries:
+              - id: capability.other-flow
+                path: specs/capabilities/examples/other.yaml
+            """);
+        _fixture.CreateFile(
+            "specs/vision/examples/vision.example.yaml",
+            ValidVisionYaml(["capability.agent-workflow"]));
+
+        var errors = VisionSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error =>
+            error.Contains("capability.agent-workflow", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingUpstreamReference_Fails()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/vision/schema/vision.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/vision/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: VisionIndex
+            entries:
+              - id: vision.jdai.product
+                title: JD.AI Product Vision
+                path: specs/vision/examples/vision.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile(
+            "specs/vision/examples/vision.example.yaml",
+            ValidVisionYaml(upstream: ["docs/missing.md"]));
+
+        var errors = VisionSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error =>
+            error.Contains("docs/missing.md", StringComparison.Ordinal));
+    }
+
+    private static string ValidVisionYaml(
+        IReadOnlyList<string>? capabilities = null,
+        IReadOnlyList<string>? upstream = null)
+    {
+        var upstreamLines = string.Join(
+            Environment.NewLine,
+            (upstream ?? ["docs/index.md"]).Select(item => $"    - {item}"));
+
+        var capabilityItems = capabilities ?? Array.Empty<string>();
+        var capabilityBlock = capabilityItems.Count == 0
+            ? "    capabilities: []"
+            : "    capabilities:" + Environment.NewLine + string.Join(
+                Environment.NewLine,
+                capabilityItems.Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Vision
+            id: vision.jdai.product
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-vision-architect
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical repo-native product intent for JD.AI.
+            problemStatement: Product intent is currently spread across issues, docs, and code without a single canonical blueprint.
+            mission: Enable safe, agent-driven software delivery from repo-native specifications.
+            targetUsers:
+              - id: user.product-owner
+                name: Product owners
+                needs:
+                  - Define product direction in a traceable, enforceable format.
+              - id: user.delivery-agent
+                name: Delivery agents
+                needs:
+                  - Read canonical product intent and trace implementations back to it.
+            valueProposition:
+              summary: JD.AI should let teams define products in-repo so humans and agents share one authoritative blueprint.
+              differentiators:
+                - Repo-native specs stay versioned beside code and tests.
+                - Machine-readable structure enables validation, drift detection, and agent workflows.
+            successMetrics:
+              - id: metric.traceability-coverage
+                name: Traceability coverage
+                target: ">=95% of implementation artifacts map back to product intent."
+                measurement: Traceability audit across specs, code, tests, and deployment assets.
+              - id: metric.agent-delivery-readiness
+                name: Agent delivery readiness
+                target: "All new capabilities can be scaffolded from validated specs."
+                measurement: Agent workflow dry-runs succeed without manual reconstruction of product intent.
+            constraints:
+              - Specifications must be human-readable Markdown plus machine-readable YAML/JSON.
+              - Validation must run inside repository CI without external services.
+            nonGoals:
+              - Replace human approval for high-risk architectural or release decisions.
+              - Encode sprint planning or delivery scheduling inside the vision spec.
+            trace:
+              upstream:
+            {{upstreamLines}}
+              downstream:
+            {{capabilityBlock}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- add the first canonical UPSS slice under `specs/vision`
- add a typed parser and repo-native validator for `vision.v1`
- gate the checked-in vision artifacts through repository tests so invalid specs fail CI

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~VisionSpecification"
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --no-restore

Closes #261
