### PR TITLE
feat(upss): add domain model specification system

### DIFF
--- a/specs/domain/README.md
+++ b/specs/domain/README.md
@@ -1,0 +1,84 @@
+# Domain Model Specification System
+
+The Domain Model Specification captures entities, value objects, aggregates, invariants, and relationships that define the core domain model of a bounded context.
+
+## Purpose
+
+Use `domain.v1` to describe:
+
+- entities with their identifying properties
+- value objects that represent immutable domain concepts
+- aggregates that enforce consistency boundaries
+- invariants that must hold across the domain model
+- downstream links to tests, interfaces, and implementation artifacts
+
+## Repository Layout
+
+`/specs/domain/README.md`
+`/specs/domain/schema/domain.schema.json`
+`/specs/domain/examples/domain.example.yaml`
+`/specs/domain/index.yaml`
+
+## Authoring Contract
+
+Domain specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Domain`
+- `id`: `domain.<name>` identifier
+- `version`: integer >= 1
+- `status`: draft | active | deprecated | retired
+- `metadata.owners[]`
+- `metadata.reviewers[]`
+- `metadata.lastReviewed`
+- `metadata.changeReason`
+- `boundedContext`
+- `entities[]`
+- `valueObjects[]`
+- `aggregates[]`
+- `invariants[]`
+- `trace.upstream[]`
+- `trace.downstream.data[]`
+- `trace.downstream.interfaces[]`
+- `trace.downstream.architecture[]`
+
+Each entity must include:
+
+- `name`
+- `description`
+- `properties[]`
+
+Each value object must include:
+
+- `name`
+- `description`
+- `properties[]`
+
+Each aggregate must include:
+
+- `name`
+- `rootEntity`
+- `members[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/domain/schema/domain.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.DomainSpecificationValidator` for repo-native enforcement, including:
+   - required domain fields and status values
+   - bounded context non-blank constraint
+   - entity and aggregate structural integrity
+   - repository file validation for upstream and all downstream links
+
+Invalid domain specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-domain-model-architect`
+
+1. Read the upstream capability context.
+2. Model entities, value objects, and aggregates for the bounded context.
+3. Express domain invariants as concrete, testable statements.
+4. Link only stable repository artifacts in downstream data, interfaces, and architecture references.
+5. Run repository validation before opening a PR.

--- a/specs/domain/examples/domain.example.yaml
+++ b/specs/domain/examples/domain.example.yaml
@@ -1,0 +1,44 @@
+apiVersion: jdai.upss/v1
+kind: Domain
+id: domain.session-management
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-domain-model-architect
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical domain model specification.
+boundedContext: session-management
+entities:
+  - name: Session
+    description: Represents an active user interaction session.
+    properties:
+      - sessionId
+      - userId
+      - createdAt
+      - expiresAt
+valueObjects:
+  - name: SessionToken
+    description: Immutable token identifying a session.
+    properties:
+      - value
+      - issuedAt
+aggregates:
+  - name: SessionAggregate
+    rootEntity: Session
+    members:
+      - SessionToken
+invariants:
+  - A session must have a non-expired token to be considered active.
+  - Session expiry must be after creation time.
+trace:
+  upstream:
+    - specs/capabilities/examples/capabilities.example.yaml
+  downstream:
+    data:
+      - tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs
+    interfaces: []
+    architecture:
+      - src/JD.AI.Core/Specifications/DomainSpecification.cs

--- a/specs/domain/index.yaml
+++ b/specs/domain/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: DomainIndex
+entries:
+  - id: domain.session-management
+    title: Session Management Domain Model
+    path: specs/domain/examples/domain.example.yaml
+    status: draft

--- a/specs/domain/schema/domain.schema.json
+++ b/specs/domain/schema/domain.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jd.ai/schemas/upss/domain.schema.json",
+  "title": "JD.AI Domain Model Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "boundedContext",
+    "entities",
+    "valueObjects",
+    "aggregates",
+    "invariants",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Domain" },
+    "id": {
+      "type": "string",
+      "pattern": "^domain\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "boundedContext": {
+      "type": "string",
+      "minLength": 1
+    },
+    "entities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "description", "properties"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "properties": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "valueObjects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "description", "properties"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "properties": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "aggregates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "rootEntity", "members"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "rootEntity": { "type": "string", "minLength": 1 },
+          "members": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["data", "interfaces", "architecture"],
+          "properties": {
+            "data": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "interfaces": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "architecture": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/DomainSpecification.cs
+++ b/src/JD.AI.Core/Specifications/DomainSpecification.cs
@@ -1,0 +1,262 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class DomainSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DomainMetadata Metadata { get; set; } = new();
+    public string BoundedContext { get; set; } = string.Empty;
+    public IList<DomainEntity> Entities { get; init; } = [];
+    public IList<DomainValueObject> ValueObjects { get; init; } = [];
+    public IList<DomainAggregate> Aggregates { get; init; } = [];
+    public IList<string> Invariants { get; init; } = [];
+    public DomainTraceability Trace { get; set; } = new();
+}
+
+public sealed class DomainMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class DomainEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public IList<string> Properties { get; init; } = [];
+}
+
+public sealed class DomainValueObject
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public IList<string> Properties { get; init; } = [];
+}
+
+public sealed class DomainAggregate
+{
+    public string Name { get; set; } = string.Empty;
+    public string RootEntity { get; set; } = string.Empty;
+    public IList<string> Members { get; init; } = [];
+}
+
+public sealed class DomainTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public DomainDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class DomainDownstreamTrace
+{
+    public IList<string> Data { get; init; } = [];
+    public IList<string> Interfaces { get; init; } = [];
+    public IList<string> Architecture { get; init; } = [];
+}
+
+public sealed class DomainSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<DomainSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class DomainSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class DomainSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static DomainSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DomainSpecification>(yaml);
+    }
+
+    public static DomainSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static DomainSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DomainSpecificationIndex>(yaml);
+    }
+
+    public static DomainSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class DomainSpecificationValidator
+{
+    private static readonly Regex DomainIdPattern = new(
+        @"^domain\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    public static IReadOnlyList<string> Validate(DomainSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new DomainMetadata();
+        var trace = document.Trace ?? new DomainTraceability();
+        var downstream = trace.Downstream ?? new DomainDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Domain", StringComparison.Ordinal), "kind must be 'Domain'.", errors);
+        Require(DomainIdPattern.IsMatch(document.Id), "id must match domain.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.BoundedContext), "boundedContext is required.", errors);
+        Require(document.Entities.Count > 0, "entities must contain at least one entity.", errors);
+        RequireHasValues(document.Invariants, "invariants must contain at least one invariant.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Interfaces.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.interfaces entries must not be blank.", errors);
+
+        for (var i = 0; i < document.Entities.Count; i++)
+        {
+            var entity = document.Entities[i] ?? new DomainEntity();
+            Require(!string.IsNullOrWhiteSpace(entity.Name), $"entities[{i}].name is required.", errors);
+        }
+
+        for (var i = 0; i < document.Aggregates.Count; i++)
+        {
+            var aggregate = document.Aggregates[i] ?? new DomainAggregate();
+            Require(!string.IsNullOrWhiteSpace(aggregate.Name), $"aggregates[{i}].name is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(aggregate.RootEntity), $"aggregates[{i}].rootEntity is required.", errors);
+        }
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "domain", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "domain", "schema", "domain.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/domain/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/domain/schema/domain.schema.json.");
+
+        DomainSpecificationIndex index;
+        try
+        {
+            index = DomainSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/domain/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Domain index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "DomainIndex", StringComparison.Ordinal), "Domain index kind must be 'DomainIndex'.", errors);
+        Require(index.Entries.Count > 0, "Domain index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Domain spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            DomainSpecification spec;
+            try
+            {
+                spec = DomainSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse domain spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Data ?? [], entry.Path, "trace.downstream.data", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Interfaces ?? [], entry.Path, "trace.downstream.interfaces", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Architecture ?? [], entry.Path, "trace.downstream.architecture", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DomainSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryDomainArtifacts_ValidateSuccessfully()
+    {
+        var errors = DomainSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DomainSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "domain", "schema", "domain.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Domain Model Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "boundedContext", "entities", "valueObjects", "aggregates", "invariants", "trace"]);
+    }
+
+    [Fact]
+    public void DomainExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "domain", "examples", "domain.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "domain", "schema", "domain.schema.json");
+
+        var spec = DomainSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DomainSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DomainSpecificationValidatorTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DomainSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidDomainSpecification_RoundTripsFields()
+    {
+        var spec = DomainSpecificationParser.Parse(ValidDomainYaml());
+
+        spec.Id.Should().Be("domain.session-management");
+        spec.BoundedContext.Should().Be("session-management");
+        spec.Entities.Should().ContainSingle(entity => entity.Name == "Session");
+        spec.Aggregates.Should().ContainSingle(aggregate => aggregate.RootEntity == "Session");
+    }
+
+    [Fact]
+    public void Validate_ValidDomainSpecification_ReturnsNoErrors()
+    {
+        var spec = DomainSpecificationParser.Parse(ValidDomainYaml());
+
+        var errors = DomainSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidDomainSpecification_ReturnsErrors()
+    {
+        var spec = DomainSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Domain
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            boundedContext: ""
+            entities:
+              - name: ""
+                description: ""
+                properties: []
+            valueObjects: []
+            aggregates:
+              - name: ""
+                rootEntity: ""
+                members: []
+            invariants: []
+            trace:
+              upstream: []
+              downstream:
+                data: []
+                interfaces: []
+                architecture: []
+            """);
+
+        var errors = DomainSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match domain.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("version must be greater than or equal to 1", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("status must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("boundedContext is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("entities[0].name is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("aggregates[0].name is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("aggregates[0].rootEntity is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("invariants must contain at least one invariant", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("trace.upstream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = DomainSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingDownstreamReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/domain/examples/domain.example.yaml",
+            ValidDomainYaml(architectureRefs: ["src/missing.cs"]));
+
+        var errors = DomainSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/domain/schema/domain.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/domain/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: DomainIndex
+            entries:
+              - id: domain.session-management
+                title: Session Management Domain Model
+                path: specs/domain/examples/domain.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/domain/examples/domain.example.yaml", ValidDomainYaml());
+        _fixture.CreateFile("specs/capabilities/examples/capabilities.example.yaml", "capability");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/DomainSpecification.cs", "code");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidDomainYaml(
+        IReadOnlyList<string>? architectureRefs = null)
+    {
+        var architectureLines = string.Join(Environment.NewLine, (architectureRefs ?? ["src/JD.AI.Core/Specifications/DomainSpecification.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Domain
+            id: domain.session-management
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-domain-model-architect
+              lastReviewed: 2026-03-07
+              changeReason: Establish the first canonical domain model specification.
+            boundedContext: session-management
+            entities:
+              - name: Session
+                description: Represents an active user interaction session.
+                properties:
+                  - sessionId
+                  - userId
+                  - createdAt
+                  - expiresAt
+            valueObjects:
+              - name: SessionToken
+                description: Immutable token identifying a session.
+                properties:
+                  - value
+                  - issuedAt
+            aggregates:
+              - name: SessionAggregate
+                rootEntity: Session
+                members:
+                  - SessionToken
+            invariants:
+              - A session must have a non-expired token to be considered active.
+              - Session expiry must be after creation time.
+            trace:
+              upstream:
+                - specs/capabilities/examples/capabilities.example.yaml
+              downstream:
+                data:
+                  - tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs
+                interfaces: []
+                architecture:
+            {{architectureLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the UPSS Domain Model Specification system following the exact pattern from the existing `behavior` spec type
- Introduces `domain.v1` kind for describing entities, value objects, aggregates, invariants, and relationships within bounded contexts
- Includes JSON schema, example YAML, index, C# model/parser/validator, and comprehensive tests (8 passing)

## Changes
- `specs/domain/` - README, JSON schema (`domain.schema.json`), example YAML (`domain.example.yaml`), and index (`index.yaml`)
- `src/JD.AI.Core/Specifications/DomainSpecification.cs` - Model classes, parser, and validator following `BehaviorSpecification.cs` patterns
- `tests/JD.AI.Tests/Specifications/DomainSpecificationRepositoryTests.cs` - 3 repository validation tests
- `tests/JD.AI.Tests/Specifications/DomainSpecificationValidatorTests.cs` - 5 validator unit tests

## Test plan
- [x] All 8 domain specification tests pass
- [x] Full solution builds with zero warnings and zero errors
- [x] Repository validation confirms all trace references resolve correctly
- [x] JSON schema shape conformance verified via `OutputSchemaValidator`

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)