### PR TITLE
feat(upss): add data specification system

### DIFF
--- a/specs/data/README.md
+++ b/specs/data/README.md
@@ -1,0 +1,67 @@
+# Data Specification System
+
+The Data Specification describes logical models, migrations, indexes, and constraints for relational and event-based persistence layers.
+
+## Purpose
+
+Use `data.v1` to describe:
+
+- logical schemas and their field inventories
+- migration sequences with reversibility metadata
+- index definitions tied to tables and column sets
+- integrity constraints that the persistence layer must enforce
+- downstream links to deployments, operations, and testing artifacts
+
+## Repository Layout
+
+`/specs/data/README.md`
+`/specs/data/schema/data.schema.json`
+`/specs/data/examples/data.example.yaml`
+`/specs/data/index.yaml`
+
+## Authoring Contract
+
+Data specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Data`
+- `id`: `data.<name>` identifier
+- `version`: integer >= 1
+- `status`: draft | active | deprecated | retired
+- `metadata.owners[]`
+- `metadata.reviewers[]`
+- `metadata.lastReviewed`
+- `metadata.changeReason`
+- `modelType`: relational | document | event | graph
+- `schemas[]` with name, description, and fields
+- `migrations[]` with version, description, and reversible flag
+- `indexes[]` with name, table, and columns
+- `constraints[]`
+- `trace.upstream[]`
+- `trace.downstream.deployment[]`
+- `trace.downstream.operations[]`
+- `trace.downstream.testing[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/data/schema/data.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.DataSpecificationValidator` for repo-native enforcement, including:
+   - required data fields and status values
+   - model type membership
+   - schema name presence
+   - repository file validation for all downstream arrays
+
+Invalid data specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-data-spec-architect`
+
+1. Read the upstream behavioral or use case context.
+2. Define the logical schemas with field inventories.
+3. Express migration sequences with reversibility metadata.
+4. Declare indexes and constraints for query and integrity needs.
+5. Link only stable repository artifacts in downstream deployment, operations, and testing references.
+6. Run repository validation before opening a PR.

--- a/specs/data/examples/data.example.yaml
+++ b/specs/data/examples/data.example.yaml
@@ -1,0 +1,46 @@
+apiVersion: jdai.upss/v1
+kind: Data
+id: data.session-store
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-data-spec-architect
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical data specification for session persistence.
+modelType: relational
+schemas:
+  - name: Sessions
+    description: Tracks active user sessions with expiration metadata.
+    fields:
+      - Id (uniqueidentifier, PK)
+      - UserId (nvarchar(256), NOT NULL)
+      - Token (nvarchar(512), NOT NULL)
+      - CreatedAt (datetimeoffset, NOT NULL)
+      - ExpiresAt (datetimeoffset, NOT NULL)
+migrations:
+  - version: "1.0.0"
+    description: Create Sessions table with primary key and expiration columns.
+    reversible: true
+indexes:
+  - name: IX_Sessions_UserId
+    table: Sessions
+    columns:
+      - UserId
+  - name: IX_Sessions_ExpiresAt
+    table: Sessions
+    columns:
+      - ExpiresAt
+constraints:
+  - ExpiresAt must be greater than CreatedAt.
+  - Token values must be unique across active sessions.
+trace:
+  upstream:
+    - specs/behavior/examples/behavior.example.yaml
+  downstream:
+    deployment: []
+    operations: []
+    testing:
+      - tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs

--- a/specs/data/index.yaml
+++ b/specs/data/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: DataIndex
+entries:
+  - id: data.session-store
+    title: Session Store Data Model
+    path: specs/data/examples/data.example.yaml
+    status: draft

--- a/specs/data/schema/data.schema.json
+++ b/specs/data/schema/data.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Data Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "modelType",
+    "schemas",
+    "migrations",
+    "indexes",
+    "constraints",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Data" },
+    "id": {
+      "type": "string",
+      "pattern": "^data\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "modelType": {
+      "type": "string",
+      "enum": ["relational", "document", "event", "graph"]
+    },
+    "schemas": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "description", "fields"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "fields": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "migrations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["version", "description", "reversible"],
+        "properties": {
+          "version": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "reversible": { "type": "boolean" }
+        }
+      }
+    },
+    "indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "table", "columns"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "table": { "type": "string" },
+          "columns": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["deployment", "operations", "testing"],
+          "properties": {
+            "deployment": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "operations": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "testing": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/DataSpecification.cs
+++ b/src/JD.AI.Core/Specifications/DataSpecification.cs
@@ -1,0 +1,261 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class DataSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DataMetadata Metadata { get; set; } = new();
+    public string ModelType { get; set; } = string.Empty;
+    public IList<DataSchema> Schemas { get; init; } = [];
+    public IList<DataMigration> Migrations { get; init; } = [];
+    public IList<DataIndexDefinition> Indexes { get; init; } = [];
+    public IList<string> Constraints { get; init; } = [];
+    public DataTraceability Trace { get; set; } = new();
+}
+
+public sealed class DataMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class DataSchema
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public IList<string> Fields { get; init; } = [];
+}
+
+public sealed class DataMigration
+{
+    public string Version { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public bool Reversible { get; set; }
+}
+
+public sealed class DataIndexDefinition
+{
+    public string Name { get; set; } = string.Empty;
+    public string Table { get; set; } = string.Empty;
+    public IList<string> Columns { get; init; } = [];
+}
+
+public sealed class DataTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public DataDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class DataDownstreamTrace
+{
+    public IList<string> Deployment { get; init; } = [];
+    public IList<string> Operations { get; init; } = [];
+    public IList<string> Testing { get; init; } = [];
+}
+
+public sealed class DataSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<DataSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class DataSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class DataSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static DataSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DataSpecification>(yaml);
+    }
+
+    public static DataSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static DataSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DataSpecificationIndex>(yaml);
+    }
+
+    public static DataSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class DataSpecificationValidator
+{
+    private static readonly Regex DataIdPattern = new(
+        "^data\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedModelTypes =
+    [
+        "relational",
+        "document",
+        "event",
+        "graph",
+    ];
+
+    public static IReadOnlyList<string> Validate(DataSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new DataMetadata();
+        var trace = document.Trace ?? new DataTraceability();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Data", StringComparison.Ordinal), "kind must be 'Data'.", errors);
+        Require(DataIdPattern.IsMatch(document.Id), "id must match data.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(AllowedModelTypes.Contains(document.ModelType), "modelType must be one of: relational, document, event, graph.", errors);
+        Require(document.Schemas.Count > 0, "schemas must contain at least one schema.", errors);
+        RequireHasValues(document.Constraints, "constraints must contain at least one constraint.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+
+        for (var i = 0; i < document.Schemas.Count; i++)
+        {
+            var schema = document.Schemas[i] ?? new DataSchema();
+            Require(!string.IsNullOrWhiteSpace(schema.Name), $"schemas[{i}].name is required.", errors);
+        }
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "data", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "data", "schema", "data.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/data/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/data/schema/data.schema.json.");
+
+        DataSpecificationIndex index;
+        try
+        {
+            index = DataSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/data/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Data index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "DataIndex", StringComparison.Ordinal), "Data index kind must be 'DataIndex'.", errors);
+        Require(index.Entries.Count > 0, "Data index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Data spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            DataSpecification spec;
+            try
+            {
+                spec = DataSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse data spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Deployment ?? [], entry.Path, "trace.downstream.deployment", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Operations ?? [], entry.Path, "trace.downstream.operations", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Testing ?? [], entry.Path, "trace.downstream.testing", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DataSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryDataArtifacts_ValidateSuccessfully()
+    {
+        var errors = DataSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DataSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "data", "schema", "data.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Data Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "modelType", "schemas", "migrations", "indexes", "constraints", "trace"]);
+    }
+
+    [Fact]
+    public void DataExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "data", "examples", "data.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "data", "schema", "data.schema.json");
+
+        var spec = DataSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DataSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DataSpecificationValidatorTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DataSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidDataSpecification_RoundTripsFields()
+    {
+        var spec = DataSpecificationParser.Parse(ValidDataYaml());
+
+        spec.Id.Should().Be("data.session-store");
+        spec.ModelType.Should().Be("relational");
+        spec.Schemas.Should().ContainSingle(schema => schema.Name == "Sessions");
+        spec.Migrations.Should().ContainSingle(migration => migration.Version == "1.0.0");
+        spec.Indexes.Should().Contain(index => index.Name == "IX_Sessions_UserId");
+        spec.Constraints.Should().Contain(constraint => constraint.Contains("ExpiresAt", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ValidDataSpecification_ReturnsNoErrors()
+    {
+        var spec = DataSpecificationParser.Parse(ValidDataYaml());
+
+        var errors = DataSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidDataSpecification_ReturnsErrors()
+    {
+        var spec = DataSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Data
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            modelType: invalid
+            schemas: []
+            migrations: []
+            indexes: []
+            constraints: []
+            trace:
+              upstream: []
+              downstream:
+                deployment: []
+                operations: []
+                testing: []
+            """);
+
+        var errors = DataSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match data.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("version must be greater than or equal to 1", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("modelType", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("schemas must contain at least one schema", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("constraints must contain at least one constraint", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_BlankSchemaName_ReturnsError()
+    {
+        var spec = DataSpecificationParser.Parse(ValidDataYaml(schemaName: ""));
+
+        var errors = DataSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("schemas[0].name is required", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = DataSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingTestingReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/data/examples/data.example.yaml",
+            ValidDataYaml(testingRefs: ["tests/missing.cs"]));
+
+        var errors = DataSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("tests/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/behavior/examples/behavior.example.yaml", "behavior");
+        _fixture.CreateFile("specs/data/schema/data.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/data/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: DataIndex
+            entries:
+              - id: data.session-store
+                title: Session Store Data Model
+                path: specs/data/examples/data.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/data/examples/data.example.yaml", ValidDataYaml());
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs", "test");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidDataYaml(
+        string schemaName = "Sessions",
+        IReadOnlyList<string>? testingRefs = null)
+    {
+        var testingLines = string.Join(Environment.NewLine, (testingRefs ?? ["tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Data
+            id: data.session-store
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-data-spec-architect
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical data specification for session persistence.
+            modelType: relational
+            schemas:
+              - name: {{schemaName}}
+                description: Tracks active user sessions.
+                fields:
+                  - Id (uniqueidentifier, PK)
+                  - UserId (nvarchar(256), NOT NULL)
+            migrations:
+              - version: "1.0.0"
+                description: Create Sessions table.
+                reversible: true
+            indexes:
+              - name: IX_Sessions_UserId
+                table: Sessions
+                columns:
+                  - UserId
+            constraints:
+              - ExpiresAt must be greater than CreatedAt.
+            trace:
+              upstream:
+                - specs/behavior/examples/behavior.example.yaml
+              downstream:
+                deployment: []
+                operations: []
+                testing:
+            {{testingLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the UPSS Data Specification system (`data.v1` kind) for describing logical models, migrations, indexes, and constraints for relational and event-based persistence
- Implements JSON schema, YAML example, index, C# model/parser/validator, and full test coverage (9 tests)
- Follows the exact pattern established by the `behavior` specification type

## Files Added
- `specs/data/README.md` - Data specification system documentation
- `specs/data/schema/data.schema.json` - JSON schema with `additionalProperties: false` throughout
- `specs/data/examples/data.example.yaml` - Example spec for `data.session-store` (relational model)
- `specs/data/index.yaml` - DataIndex with one entry
- `src/JD.AI.Core/Specifications/DataSpecification.cs` - Model classes, parser (CamelCaseNamingConvention), and validator
- `tests/JD.AI.Tests/Specifications/DataSpecificationRepositoryTests.cs` - 3 repository tests
- `tests/JD.AI.Tests/Specifications/DataSpecificationValidatorTests.cs` - 6 validator tests

## Test plan
- [x] `dotnet build -p:CI=true` succeeds with 0 warnings, 0 errors
- [x] `dotnet test --filter DataSpecification` passes all 9 tests
- [x] Repository validation test confirms all checked-in artifacts are valid
- [x] Schema contract test verifies required fields in `data.schema.json`
- [x] Example conformance test round-trips YAML through JSON schema validation
- [x] Invalid specification test covers bad id, version:0, invalid modelType, empty schemas, empty constraints
- [x] Blank schema name test verifies per-schema validation

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)