### PR TITLE
feat(upss): add policy specification system

### DIFF
--- a/specs/policies/README.md
+++ b/specs/policies/README.md
@@ -1,0 +1,62 @@
+# Policy Specification System
+
+The Policy Specification defines enforceable security, compliance, and validation constraints that govern repository artifacts and agent workflows.
+
+## Purpose
+
+Use `policies.v1` to describe:
+
+- security baselines and access-control constraints
+- compliance rules that must hold before code ships
+- quality gates and code-hygiene policies
+- operational guardrails for deployment and runtime behavior
+
+## Repository Layout
+
+`/specs/policies/README.md`
+`/specs/policies/schema/policies.schema.json`
+`/specs/policies/examples/policies.example.yaml`
+`/specs/policies/index.yaml`
+
+## Authoring Contract
+
+Policy specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Policy`
+- `id`: `policy.<name>` identifier
+- `policyType`: one of `security`, `compliance`, `quality`, `operational`
+- `severity`: one of `critical`, `high`, `medium`, `low`
+- `scope[]`
+- `rules[]` each with `id`, `description`, `expression`
+- `exceptions[]` each with `ruleId`, `reason`, `expiresAt`
+- `enforcement.mode`: one of `enforce`, `warn`, `audit`
+- `trace.upstream[]`
+- `trace.downstream.ci[]`
+- `trace.downstream.enforcement[]`
+- `trace.downstream.operations[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/policies/schema/policies.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.PolicySpecificationValidator` for repo-native enforcement, including:
+   - required policy fields and status values
+   - policyType and severity membership checks
+   - scope must contain at least one item
+   - rules must contain at least one rule with id and description
+   - enforcement mode membership check
+   - repository file validation for upstream, ci, enforcement, and operations links
+
+Invalid policy specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-policy-rules-architect`
+
+1. Read the upstream vision and capability context.
+2. Express constraints as typed rules with concrete expressions.
+3. Define enforcement mode and severity to signal CI behavior.
+4. Link only stable repository artifacts in downstream ci, enforcement, and operations references.
+5. Run repository validation before opening a PR.

--- a/specs/policies/examples/policies.example.yaml
+++ b/specs/policies/examples/policies.example.yaml
@@ -1,0 +1,36 @@
+apiVersion: jdai.upss/v1
+kind: Policy
+id: policy.api-security-baseline
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-policy-rules-architect
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical policy specification for API security baselines.
+policyType: security
+severity: high
+scope:
+  - src/JD.AI.Core
+  - src/JD.AI.Cli
+rules:
+  - id: require-auth-on-endpoints
+    description: All public API endpoints must require authentication.
+    expression: endpoint.auth != null
+  - id: no-plaintext-secrets
+    description: Configuration values must not contain plaintext secrets.
+    expression: config.values.none(v => v.matches('password|secret|key'))
+exceptions: []
+enforcement:
+  mode: enforce
+trace:
+  upstream:
+    - specs/vision/examples/vision.example.yaml
+  downstream:
+    ci:
+      - tests/JD.AI.Tests/Specifications/PolicySpecificationRepositoryTests.cs
+    enforcement:
+      - src/JD.AI.Core/Specifications/PolicySpecification.cs
+    operations: []

--- a/specs/policies/index.yaml
+++ b/specs/policies/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: PolicyIndex
+entries:
+  - id: policy.api-security-baseline
+    title: API Security Baseline Policy
+    path: specs/policies/examples/policies.example.yaml
+    status: draft

--- a/specs/policies/schema/policies.schema.json
+++ b/specs/policies/schema/policies.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Policy Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "policyType",
+    "severity",
+    "scope",
+    "rules",
+    "exceptions",
+    "enforcement",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Policy" },
+    "id": {
+      "type": "string",
+      "pattern": "^policy\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "policyType": {
+      "type": "string",
+      "enum": ["security", "compliance", "quality", "operational"]
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low"]
+    },
+    "scope": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "description", "expression"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "expression": { "type": "string" }
+        }
+      }
+    },
+    "exceptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ruleId", "reason", "expiresAt"],
+        "properties": {
+          "ruleId": { "type": "string", "minLength": 1 },
+          "reason": { "type": "string", "minLength": 1 },
+          "expiresAt": { "type": "string" }
+        }
+      }
+    },
+    "enforcement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["enforce", "warn", "audit"]
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ci", "enforcement", "operations"],
+          "properties": {
+            "ci": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "enforcement": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "operations": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/PolicySpecification.cs
+++ b/src/JD.AI.Core/Specifications/PolicySpecification.cs
@@ -1,0 +1,288 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class PolicySpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public PolicyMetadata Metadata { get; set; } = new();
+    public string PolicyType { get; set; } = string.Empty;
+    public string Severity { get; set; } = string.Empty;
+    public IList<string> Scope { get; init; } = [];
+    public IList<PolicyRule> Rules { get; init; } = [];
+    public IList<PolicyException> Exceptions { get; init; } = [];
+    public PolicyEnforcement Enforcement { get; set; } = new();
+    public PolicyTraceability Trace { get; set; } = new();
+}
+
+public sealed class PolicyMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class PolicyRule
+{
+    public string Id { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Expression { get; set; } = string.Empty;
+}
+
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix -- domain model, not a System.Exception
+public sealed class PolicyException
+#pragma warning restore CA1711
+{
+    public string RuleId { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+    public string ExpiresAt { get; set; } = string.Empty;
+}
+
+public sealed class PolicyEnforcement
+{
+    public string Mode { get; set; } = string.Empty;
+}
+
+public sealed class PolicyTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public PolicyDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class PolicyDownstreamTrace
+{
+    public IList<string> Ci { get; init; } = [];
+    public IList<string> Enforcement { get; init; } = [];
+    public IList<string> Operations { get; init; } = [];
+}
+
+public sealed class PolicySpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<PolicySpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class PolicySpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class PolicySpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static PolicySpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<PolicySpecification>(yaml);
+    }
+
+    public static PolicySpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static PolicySpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<PolicySpecificationIndex>(yaml);
+    }
+
+    public static PolicySpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class PolicySpecificationValidator
+{
+    private static readonly Regex PolicyIdPattern = new(
+        "^policy\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedPolicyTypes =
+    [
+        "security",
+        "compliance",
+        "quality",
+        "operational",
+    ];
+
+    private static readonly HashSet<string> AllowedSeverities =
+    [
+        "critical",
+        "high",
+        "medium",
+        "low",
+    ];
+
+    private static readonly HashSet<string> AllowedEnforcementModes =
+    [
+        "enforce",
+        "warn",
+        "audit",
+    ];
+
+    public static IReadOnlyList<string> Validate(PolicySpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new PolicyMetadata();
+        var enforcement = document.Enforcement ?? new PolicyEnforcement();
+        var trace = document.Trace ?? new PolicyTraceability();
+        var downstream = trace.Downstream ?? new PolicyDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Policy", StringComparison.Ordinal), "kind must be 'Policy'.", errors);
+        Require(PolicyIdPattern.IsMatch(document.Id), "id must match policy.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(AllowedPolicyTypes.Contains(document.PolicyType), "policyType must be one of: security, compliance, quality, operational.", errors);
+        Require(AllowedSeverities.Contains(document.Severity), "severity must be one of: critical, high, medium, low.", errors);
+        RequireHasValues(document.Scope, "scope must contain at least one item.", errors);
+        Require(document.Rules.Count > 0, "rules must contain at least one rule.", errors);
+
+        for (var i = 0; i < document.Rules.Count; i++)
+        {
+            var rule = document.Rules[i] ?? new PolicyRule();
+            var prefix = $"rules[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(rule.Id), $"{prefix}.id is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(rule.Description), $"{prefix}.description is required.", errors);
+        }
+
+        Require(AllowedEnforcementModes.Contains(enforcement.Mode), "enforcement.mode must be one of: enforce, warn, audit.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Ci.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.ci entries must not be blank.", errors);
+        Require(downstream.Enforcement.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.enforcement entries must not be blank.", errors);
+        Require(downstream.Operations.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.operations entries must not be blank.", errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "policies", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "policies", "schema", "policies.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/policies/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/policies/schema/policies.schema.json.");
+
+        PolicySpecificationIndex index;
+        try
+        {
+            index = PolicySpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/policies/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Policy index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "PolicyIndex", StringComparison.Ordinal), "Policy index kind must be 'PolicyIndex'.", errors);
+        Require(index.Entries.Count > 0, "Policy index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Policy spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            PolicySpecification spec;
+            try
+            {
+                spec = PolicySpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse policy spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Ci ?? [], entry.Path, "trace.downstream.ci", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Enforcement ?? [], entry.Path, "trace.downstream.enforcement", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Operations ?? [], entry.Path, "trace.downstream.operations", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/PolicySpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/PolicySpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class PolicySpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryPolicyArtifacts_ValidateSuccessfully()
+    {
+        var errors = PolicySpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PolicySchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "policies", "schema", "policies.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Policy Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "policyType", "severity", "scope", "rules", "exceptions", "enforcement", "trace"]);
+    }
+
+    [Fact]
+    public void PolicyExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "policies", "examples", "policies.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "policies", "schema", "policies.schema.json");
+
+        var spec = PolicySpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/PolicySpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/PolicySpecificationValidatorTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class PolicySpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidPolicySpecification_RoundTripsFields()
+    {
+        var spec = PolicySpecificationParser.Parse(ValidPolicyYaml());
+
+        spec.Id.Should().Be("policy.api-security-baseline");
+        spec.PolicyType.Should().Be("security");
+        spec.Severity.Should().Be("high");
+        spec.Scope.Should().Contain("src/JD.AI.Core");
+        spec.Rules.Should().ContainSingle(rule => rule.Id == "require-auth-on-endpoints");
+        spec.Enforcement.Mode.Should().Be("enforce");
+    }
+
+    [Fact]
+    public void Validate_ValidPolicySpecification_ReturnsNoErrors()
+    {
+        var spec = PolicySpecificationParser.Parse(ValidPolicyYaml());
+
+        var errors = PolicySpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidPolicySpecification_ReturnsErrors()
+    {
+        var spec = PolicySpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Policy
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            policyType: unknown
+            severity: extreme
+            scope: []
+            rules: []
+            exceptions: []
+            enforcement:
+              mode: invalid
+            trace:
+              upstream: []
+              downstream:
+                ci: []
+                enforcement: []
+                operations: []
+            """);
+
+        var errors = PolicySpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match policy.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("policyType", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("severity", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("scope", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("rules must contain at least one rule", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("enforcement.mode", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = PolicySpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingEnforcementReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/policies/examples/policies.example.yaml",
+            ValidPolicyYaml(enforcementRefs: ["src/missing.cs"]));
+
+        var errors = PolicySpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingCiReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/policies/examples/policies.example.yaml",
+            ValidPolicyYaml(ciRefs: ["tests/missing.cs"]));
+
+        var errors = PolicySpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("tests/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/policies/schema/policies.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/policies/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: PolicyIndex
+            entries:
+              - id: policy.api-security-baseline
+                title: API Security Baseline Policy
+                path: specs/policies/examples/policies.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/policies/examples/policies.example.yaml", ValidPolicyYaml());
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", "vision");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/PolicySpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/PolicySpecification.cs", "code");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidPolicyYaml(
+        IReadOnlyList<string>? ciRefs = null,
+        IReadOnlyList<string>? enforcementRefs = null)
+    {
+        var ciLines = string.Join(Environment.NewLine, (ciRefs ?? ["tests/JD.AI.Tests/Specifications/PolicySpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+        var enforcementLines = string.Join(Environment.NewLine, (enforcementRefs ?? ["src/JD.AI.Core/Specifications/PolicySpecification.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Policy
+            id: policy.api-security-baseline
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-policy-rules-architect
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical policy specifications for JD.AI.
+            policyType: security
+            severity: high
+            scope:
+              - src/JD.AI.Core
+            rules:
+              - id: require-auth-on-endpoints
+                description: All public API endpoints must require authentication.
+                expression: endpoint.auth != null
+            exceptions: []
+            enforcement:
+              mode: enforce
+            trace:
+              upstream:
+                - specs/vision/examples/vision.example.yaml
+              downstream:
+                ci:
+            {{ciLines}}
+                enforcement:
+            {{enforcementLines}}
+                operations: []
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Add new UPSS Policy Specification type for enforceable security, compliance, quality, and operational constraints
- Include JSON schema (`policies.schema.json`), example YAML, index, and README under `specs/policies/`
- Implement `PolicySpecification.cs` with model classes, parser, and validator following the existing behavior spec pattern
- Add 9 tests covering parsing, validation (valid + invalid), repository validation, and file-reference integrity

Closes #271

## Test plan
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] All 9 policy specification tests pass (`PolicySpecificationRepositoryTests` + `PolicySpecificationValidatorTests`)
- [x] Invalid spec test covers bad policyType, severity, empty rules, and invalid enforcement mode
- [x] Repository validation tests cover missing CI and enforcement file references
- [ ] CI pipeline passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)