### PR TITLE
feat(upss): add security specification system

### DIFF
--- a/specs/security/README.md
+++ b/specs/security/README.md
@@ -1,0 +1,87 @@
+# Security Specification System
+
+The Security Specification captures authentication, authorization, trust zones, threat models, and controls that agents and test runners can consume directly.
+
+## Purpose
+
+Use `security.v1` to describe:
+
+- authentication models for system boundaries
+- authorization strategies and access control patterns
+- trust zones and their classification levels
+- threat models with severity and mitigation mappings
+- security controls and their categorization
+- residual risks with justification
+- downstream links to tests, deployment, operations, and implementation artifacts
+
+## Repository Layout
+
+`/specs/security/README.md`
+`/specs/security/schema/security.schema.json`
+`/specs/security/examples/security.example.yaml`
+`/specs/security/index.yaml`
+
+## Authoring Contract
+
+Security specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Security`
+- `id`: `security.<name>` identifier
+- `authnModel`
+- `authzModel`
+- `trustZones[]`
+- `threats[]`
+- `controls[]`
+- `residualRisks[]`
+- `trace.upstream[]`
+- `trace.downstream.deployment[]`
+- `trace.downstream.operations[]`
+- `trace.downstream.testing[]`
+
+Each trust zone must include:
+
+- `name`
+- `level`
+
+Each threat must include:
+
+- `id`
+- `description`
+- `severity`
+- `mitigatedBy[]`
+
+Each control must include:
+
+- `id`
+- `description`
+- `type`
+
+Each residual risk must include:
+
+- `threatId`
+- `justification`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/security/schema/security.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.SecuritySpecificationValidator` for repo-native enforcement, including:
+   - required security fields and status values
+   - authentication and authorization model validation against allowed sets
+   - trust zone, threat, and control integrity checks
+   - repository file validation for upstream, deployment, operations, and testing links
+
+Invalid security specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-security-architecture-agent`
+
+1. Read the upstream capability context.
+2. Define authentication and authorization models for the system boundary.
+3. Enumerate trust zones, threats, and controls with concrete mappings.
+4. Document residual risks with clear justification.
+5. Link only stable repository artifacts in downstream deployment, operations, and testing references.
+6. Run repository validation before opening a PR.

--- a/specs/security/examples/security.example.yaml
+++ b/specs/security/examples/security.example.yaml
@@ -1,0 +1,56 @@
+apiVersion: jdai.upss/v1
+kind: Security
+id: security.api-gateway
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-security-architecture-agent
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical security specification for API gateway authentication and authorization.
+authnModel: oauth2
+authzModel: rbac
+trustZones:
+  - name: public-internet
+    level: public
+  - name: api-gateway
+    level: dmz
+  - name: backend-services
+    level: internal
+  - name: secrets-store
+    level: restricted
+threats:
+  - id: threat.token-theft
+    description: An attacker steals an OAuth2 access token via XSS or network interception.
+    severity: critical
+    mitigatedBy:
+      - ctrl.short-lived-tokens
+      - ctrl.tls-enforcement
+  - id: threat.privilege-escalation
+    description: A user modifies their role claim to access restricted resources.
+    severity: high
+    mitigatedBy:
+      - ctrl.server-side-rbac
+controls:
+  - id: ctrl.short-lived-tokens
+    description: Access tokens expire within 15 minutes and require refresh token rotation.
+    type: preventive
+  - id: ctrl.tls-enforcement
+    description: All traffic between trust zones is encrypted with TLS 1.3.
+    type: preventive
+  - id: ctrl.server-side-rbac
+    description: Role-based access control is enforced server-side on every request.
+    type: preventive
+residualRisks:
+  - threatId: threat.token-theft
+    justification: Short-lived tokens limit the blast radius but cannot prevent in-flight token use during the validity window.
+trace:
+  upstream:
+    - specs/capabilities/examples/capabilities.example.yaml
+  downstream:
+    deployment: []
+    operations: []
+    testing:
+      - tests/JD.AI.Tests/Specifications/SecuritySpecificationRepositoryTests.cs

--- a/specs/security/index.yaml
+++ b/specs/security/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: SecurityIndex
+entries:
+  - id: security.api-gateway
+    title: API Gateway Security
+    path: specs/security/examples/security.example.yaml
+    status: draft

--- a/specs/security/schema/security.schema.json
+++ b/specs/security/schema/security.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Security Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "authnModel",
+    "authzModel",
+    "trustZones",
+    "threats",
+    "controls",
+    "residualRisks",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Security" },
+    "id": {
+      "type": "string",
+      "pattern": "^security\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "authnModel": {
+      "type": "string",
+      "enum": ["oauth2", "oidc", "api-key", "mtls", "saml", "none"]
+    },
+    "authzModel": {
+      "type": "string",
+      "enum": ["rbac", "abac", "pbac", "acl", "none"]
+    },
+    "trustZones": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "level"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "level": {
+            "type": "string",
+            "enum": ["public", "dmz", "internal", "restricted"]
+          }
+        }
+      }
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "description", "severity", "mitigatedBy"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"]
+          },
+          "mitigatedBy": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "controls": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "description", "type"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "type": {
+            "type": "string",
+            "enum": ["preventive", "detective", "corrective"]
+          }
+        }
+      }
+    },
+    "residualRisks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["threatId", "justification"],
+        "properties": {
+          "threatId": { "type": "string", "minLength": 1 },
+          "justification": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["deployment", "operations", "testing"],
+          "properties": {
+            "deployment": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "operations": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "testing": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/SecuritySpecification.cs
+++ b/src/JD.AI.Core/Specifications/SecuritySpecification.cs
@@ -1,0 +1,357 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class SecuritySpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public SecurityMetadata Metadata { get; set; } = new();
+    public string AuthnModel { get; set; } = string.Empty;
+    public string AuthzModel { get; set; } = string.Empty;
+    public IList<SecurityTrustZone> TrustZones { get; init; } = [];
+    public IList<SecurityThreat> Threats { get; init; } = [];
+    public IList<SecurityControl> Controls { get; init; } = [];
+    public IList<SecurityResidualRisk> ResidualRisks { get; init; } = [];
+    public SecurityTraceability Trace { get; set; } = new();
+}
+
+public sealed class SecurityMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class SecurityTrustZone
+{
+    public string Name { get; set; } = string.Empty;
+    public string Level { get; set; } = string.Empty;
+}
+
+public sealed class SecurityThreat
+{
+    public string Id { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Severity { get; set; } = string.Empty;
+    public IList<string> MitigatedBy { get; init; } = [];
+}
+
+public sealed class SecurityControl
+{
+    public string Id { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+}
+
+public sealed class SecurityResidualRisk
+{
+    public string ThreatId { get; set; } = string.Empty;
+    public string Justification { get; set; } = string.Empty;
+}
+
+public sealed class SecurityTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public SecurityDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class SecurityDownstreamTrace
+{
+    public IList<string> Deployment { get; init; } = [];
+    public IList<string> Operations { get; init; } = [];
+    public IList<string> Testing { get; init; } = [];
+}
+
+public sealed class SecuritySpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<SecuritySpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class SecuritySpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class SecuritySpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static SecuritySpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<SecuritySpecification>(yaml);
+    }
+
+    public static SecuritySpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static SecuritySpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<SecuritySpecificationIndex>(yaml);
+    }
+
+    public static SecuritySpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class SecuritySpecificationValidator
+{
+    private static readonly Regex SecurityIdPattern = new(
+        "^security\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedAuthnModels =
+    [
+        "oauth2",
+        "oidc",
+        "api-key",
+        "mtls",
+        "saml",
+        "none",
+    ];
+
+    private static readonly HashSet<string> AllowedAuthzModels =
+    [
+        "rbac",
+        "abac",
+        "pbac",
+        "acl",
+        "none",
+    ];
+
+    private static readonly HashSet<string> AllowedTrustLevels =
+    [
+        "public",
+        "dmz",
+        "internal",
+        "restricted",
+    ];
+
+    private static readonly HashSet<string> AllowedThreatSeverities =
+    [
+        "critical",
+        "high",
+        "medium",
+        "low",
+    ];
+
+    private static readonly HashSet<string> AllowedControlTypes =
+    [
+        "preventive",
+        "detective",
+        "corrective",
+    ];
+
+    public static IReadOnlyList<string> Validate(SecuritySpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new SecurityMetadata();
+        var trace = document.Trace ?? new SecurityTraceability();
+        var downstream = trace.Downstream ?? new SecurityDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Security", StringComparison.Ordinal), "kind must be 'Security'.", errors);
+        Require(SecurityIdPattern.IsMatch(document.Id), "id must match security.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(AllowedAuthnModels.Contains(document.AuthnModel), "authnModel must be one of: oauth2, oidc, api-key, mtls, saml, none.", errors);
+        Require(AllowedAuthzModels.Contains(document.AuthzModel), "authzModel must be one of: rbac, abac, pbac, acl, none.", errors);
+        Require(document.TrustZones.Count > 0, "trustZones must contain at least one trust zone.", errors);
+        Require(document.Threats.Count > 0, "threats must contain at least one threat.", errors);
+        Require(document.Controls.Count > 0, "controls must contain at least one control.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Deployment.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.deployment entries must not be blank.", errors);
+        Require(downstream.Operations.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.operations entries must not be blank.", errors);
+        Require(downstream.Testing.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.testing entries must not be blank.", errors);
+
+        ValidateTrustZones(document.TrustZones, errors);
+        ValidateThreats(document.Threats, errors);
+        ValidateControls(document.Controls, errors);
+        ValidateResidualRisks(document.ResidualRisks, errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "security", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "security", "schema", "security.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/security/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/security/schema/security.schema.json.");
+
+        SecuritySpecificationIndex index;
+        try
+        {
+            index = SecuritySpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/security/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Security index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "SecurityIndex", StringComparison.Ordinal), "Security index kind must be 'SecurityIndex'.", errors);
+        Require(index.Entries.Count > 0, "Security index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Security spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            SecuritySpecification spec;
+            try
+            {
+                spec = SecuritySpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse security spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Deployment ?? [], entry.Path, "trace.downstream.deployment", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Operations ?? [], entry.Path, "trace.downstream.operations", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Testing ?? [], entry.Path, "trace.downstream.testing", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateTrustZones(IList<SecurityTrustZone> trustZones, List<string> errors)
+    {
+        for (var i = 0; i < trustZones.Count; i++)
+        {
+            var zone = trustZones[i] ?? new SecurityTrustZone();
+            var prefix = $"trustZones[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(zone.Name), $"{prefix}.name is required.", errors);
+            Require(AllowedTrustLevels.Contains(zone.Level), $"{prefix}.level must be one of: public, dmz, internal, restricted.", errors);
+        }
+    }
+
+    private static void ValidateThreats(IList<SecurityThreat> threats, List<string> errors)
+    {
+        for (var i = 0; i < threats.Count; i++)
+        {
+            var threat = threats[i] ?? new SecurityThreat();
+            var prefix = $"threats[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(threat.Id), $"{prefix}.id is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(threat.Description), $"{prefix}.description is required.", errors);
+            Require(AllowedThreatSeverities.Contains(threat.Severity), $"{prefix}.severity must be one of: critical, high, medium, low.", errors);
+        }
+    }
+
+    private static void ValidateControls(IList<SecurityControl> controls, List<string> errors)
+    {
+        for (var i = 0; i < controls.Count; i++)
+        {
+            var control = controls[i] ?? new SecurityControl();
+            var prefix = $"controls[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(control.Id), $"{prefix}.id is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(control.Description), $"{prefix}.description is required.", errors);
+            Require(AllowedControlTypes.Contains(control.Type), $"{prefix}.type must be one of: preventive, detective, corrective.", errors);
+        }
+    }
+
+    private static void ValidateResidualRisks(IList<SecurityResidualRisk> risks, List<string> errors)
+    {
+        for (var i = 0; i < risks.Count; i++)
+        {
+            var risk = risks[i] ?? new SecurityResidualRisk();
+            var prefix = $"residualRisks[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(risk.ThreatId), $"{prefix}.threatId is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(risk.Justification), $"{prefix}.justification is required.", errors);
+        }
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/SecuritySpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/SecuritySpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class SecuritySpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositorySecurityArtifacts_ValidateSuccessfully()
+    {
+        var errors = SecuritySpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SecuritySchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "security", "schema", "security.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Security Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "authnModel", "authzModel", "trustZones", "threats", "controls", "residualRisks", "trace"]);
+    }
+
+    [Fact]
+    public void SecurityExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "security", "examples", "security.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "security", "schema", "security.schema.json");
+
+        var spec = SecuritySpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/SecuritySpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/SecuritySpecificationValidatorTests.cs
@@ -1,0 +1,216 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class SecuritySpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidSecuritySpecification_RoundTripsFields()
+    {
+        var spec = SecuritySpecificationParser.Parse(ValidSecurityYaml());
+
+        spec.Id.Should().Be("security.api-gateway");
+        spec.AuthnModel.Should().Be("oauth2");
+        spec.AuthzModel.Should().Be("rbac");
+        spec.TrustZones.Should().ContainSingle(zone => zone.Name == "api-gateway");
+        spec.Threats.Should().ContainSingle(threat => threat.Id == "threat.token-theft");
+        spec.Controls.Should().ContainSingle(control => control.Id == "ctrl.short-lived-tokens");
+        spec.ResidualRisks.Should().ContainSingle(risk => risk.ThreatId == "threat.token-theft");
+    }
+
+    [Fact]
+    public void Validate_ValidSecuritySpecification_ReturnsNoErrors()
+    {
+        var spec = SecuritySpecificationParser.Parse(ValidSecurityYaml());
+
+        var errors = SecuritySpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidSecuritySpecification_ReturnsErrors()
+    {
+        var spec = SecuritySpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Security
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            authnModel: kerberos
+            authzModel: custom
+            trustZones: []
+            threats: []
+            controls: []
+            residualRisks: []
+            trace:
+              upstream: []
+              downstream:
+                deployment: []
+                operations: []
+                testing: []
+            """);
+
+        var errors = SecuritySpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match security.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("authnModel", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("authzModel", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("trustZones must contain at least one", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("threats must contain at least one", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("controls must contain at least one", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_InvalidEnumValues_ReturnsErrors()
+    {
+        var spec = SecuritySpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Security
+            id: security.test
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - reviewer
+              lastReviewed: 2026-03-07
+              changeReason: test
+            authnModel: oauth2
+            authzModel: rbac
+            trustZones:
+              - name: zone1
+                level: top-secret
+            threats:
+              - id: threat.1
+                description: A threat
+                severity: extreme
+                mitigatedBy: []
+            controls:
+              - id: ctrl.1
+                description: A control
+                type: reactive
+            residualRisks: []
+            trace:
+              upstream:
+                - specs/capabilities/examples/capabilities.example.yaml
+              downstream:
+                deployment: []
+                operations: []
+                testing: []
+            """);
+
+        var errors = SecuritySpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("trustZones[0].level must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("threats[0].severity must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("controls[0].type must be one of", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = SecuritySpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingTestingReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/security/examples/security.example.yaml",
+            ValidSecurityYaml(testingRefs: ["tests/missing.cs"]));
+
+        var errors = SecuritySpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("tests/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/security/schema/security.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/security/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: SecurityIndex
+            entries:
+              - id: security.api-gateway
+                title: API Gateway Security
+                path: specs/security/examples/security.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/security/examples/security.example.yaml", ValidSecurityYaml());
+        _fixture.CreateFile("specs/capabilities/examples/capabilities.example.yaml", "capability");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/SecuritySpecificationRepositoryTests.cs", "test");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidSecurityYaml(IReadOnlyList<string>? testingRefs = null)
+    {
+        var testingLines = string.Join(Environment.NewLine, (testingRefs ?? ["tests/JD.AI.Tests/Specifications/SecuritySpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Security
+            id: security.api-gateway
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-security-architecture-agent
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical security specification for JD.AI.
+            authnModel: oauth2
+            authzModel: rbac
+            trustZones:
+              - name: api-gateway
+                level: dmz
+            threats:
+              - id: threat.token-theft
+                description: An attacker steals an OAuth2 access token.
+                severity: critical
+                mitigatedBy:
+                  - ctrl.short-lived-tokens
+            controls:
+              - id: ctrl.short-lived-tokens
+                description: Access tokens expire within 15 minutes.
+                type: preventive
+            residualRisks:
+              - threatId: threat.token-theft
+                justification: Short-lived tokens limit blast radius but cannot prevent in-flight use.
+            trace:
+              upstream:
+                - specs/capabilities/examples/capabilities.example.yaml
+              downstream:
+                deployment: []
+                operations: []
+                testing:
+            {{testingLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Add UPSS Security Specification System with `security.v1` kind for authentication, authorization, trust zones, threat models, and controls
- Implement `SecuritySpecification.cs` with model classes, parser, and validator following the existing behavior spec pattern
- Add JSON schema, example YAML, index, and README documentation under `specs/security/`
- Add repository and validator test coverage (9 tests, all passing)

Closes #272

## Test plan
- [x] All 9 new security specification tests pass
- [x] Solution builds with zero warnings and zero errors
- [x] Repository validation test confirms checked-in artifacts are valid
- [x] Schema contract test confirms required fields are present
- [x] Example YAML conforms to JSON schema shape
- [x] Invalid specification tests verify error detection for bad authnModel, authzModel, empty trustZones/threats/controls, and invalid enum values
- [x] Missing file reference test verifies repository validation catches broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)