### PR TITLE
feat(upss): add testing specification system

### DIFF
--- a/specs/testing/README.md
+++ b/specs/testing/README.md
@@ -1,0 +1,73 @@
+# Testing Specification System
+
+The Testing Specification maps verification strategies to behavioral specifications, interface contracts, and quality targets so that agents and CI pipelines know exactly what to test and how.
+
+## Purpose
+
+Use `testing.v1` to describe:
+
+- verification levels required for a feature or workflow
+- references to the behavioral specs and quality specs being verified
+- coverage targets with scope, metric, and threshold
+- generation rules that declare whether tests are generated, manual, or hybrid
+- downstream links to CI test files and release implementation artifacts
+
+## Repository Layout
+
+`/specs/testing/README.md`
+`/specs/testing/schema/testing.schema.json`
+`/specs/testing/examples/testing.example.yaml`
+`/specs/testing/index.yaml`
+
+## Authoring Contract
+
+Testing specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Testing`
+- `id`: `testing.<name>` identifier
+- `verificationLevels[]`
+- `behaviorRefs[]`
+- `qualityRefs[]`
+- `coverageTargets[]`
+- `generationRules[]`
+- `trace.upstream[]`
+- `trace.downstream.ci[]`
+- `trace.downstream.release[]`
+
+Each coverage target must include:
+
+- `scope`
+- `target`
+- `metric` (optional)
+
+Each generation rule must include:
+
+- `source`
+- `strategy` (one of `generated`, `manual`, `hybrid`)
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/testing/schema/testing.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.TestingSpecificationValidator` for repo-native enforcement, including:
+   - required testing fields and status values
+   - verification level values constrained to the allowed set
+   - behavioral and quality reference pattern integrity
+   - coverage target non-blank scope and target
+   - generation rule strategy constrained to the allowed set
+   - repository file validation for upstream, ci, and release links
+
+Invalid testing specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-testing-strategy-agent`
+
+1. Read the upstream behavior and quality specification context.
+2. Select verification levels appropriate for the workflow under test.
+3. Define coverage targets with concrete scopes and thresholds.
+4. Declare generation rules for each test source.
+5. Link only stable repository artifacts in downstream ci and release references.
+6. Run repository validation before opening a PR.

--- a/specs/testing/examples/testing.example.yaml
+++ b/specs/testing/examples/testing.example.yaml
@@ -1,0 +1,33 @@
+apiVersion: jdai.upss/v1
+kind: Testing
+id: testing.specification-validation
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-testing-strategy-agent
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical testing specification for specification validation workflows.
+verificationLevels:
+  - unit
+  - integration
+behaviorRefs:
+  - behavior.validate-pull-request
+qualityRefs: []
+coverageTargets:
+  - scope: JD.AI.Core.Specifications
+    target: "80%"
+    metric: line
+generationRules:
+  - source: specs/testing/examples/testing.example.yaml
+    strategy: manual
+trace:
+  upstream:
+    - specs/behavior/examples/behavior.example.yaml
+  downstream:
+    ci:
+      - tests/JD.AI.Tests/Specifications/TestingSpecificationRepositoryTests.cs
+    release:
+      - src/JD.AI.Core/Specifications/TestingSpecification.cs

--- a/specs/testing/index.yaml
+++ b/specs/testing/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: TestingIndex
+entries:
+  - id: testing.specification-validation
+    title: Specification Validation Testing
+    path: specs/testing/examples/testing.example.yaml
+    status: draft

--- a/specs/testing/schema/testing.schema.json
+++ b/specs/testing/schema/testing.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Testing Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "verificationLevels",
+    "behaviorRefs",
+    "qualityRefs",
+    "coverageTargets",
+    "generationRules",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Testing" },
+    "id": {
+      "type": "string",
+      "pattern": "^testing\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "verificationLevels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["unit", "integration", "acceptance", "performance", "security", "e2e"]
+      }
+    },
+    "behaviorRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^behavior\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+      }
+    },
+    "qualityRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^quality\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+      }
+    },
+    "coverageTargets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scope", "target"],
+        "properties": {
+          "scope": { "type": "string", "minLength": 1 },
+          "target": { "type": "string", "minLength": 1 },
+          "metric": { "type": "string" }
+        }
+      }
+    },
+    "generationRules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "strategy"],
+        "properties": {
+          "source": { "type": "string", "minLength": 1 },
+          "strategy": {
+            "type": "string",
+            "enum": ["generated", "manual", "hybrid"]
+          }
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ci", "release"],
+          "properties": {
+            "ci": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "release": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/TestingSpecification.cs
+++ b/src/JD.AI.Core/Specifications/TestingSpecification.cs
@@ -1,0 +1,271 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class TestingSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public BehaviorMetadata Metadata { get; set; } = new();
+    public IList<string> VerificationLevels { get; init; } = [];
+    public IList<string> BehaviorRefs { get; init; } = [];
+    public IList<string> QualityRefs { get; init; } = [];
+    public IList<TestingCoverageTarget> CoverageTargets { get; init; } = [];
+    public IList<TestingGenerationRule> GenerationRules { get; init; } = [];
+    public TestingTraceability Trace { get; set; } = new();
+}
+
+public sealed class TestingCoverageTarget
+{
+    public string Scope { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+    public string Metric { get; set; } = string.Empty;
+}
+
+public sealed class TestingGenerationRule
+{
+    public string Source { get; set; } = string.Empty;
+    public string Strategy { get; set; } = string.Empty;
+}
+
+public sealed class TestingTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public TestingDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class TestingDownstreamTrace
+{
+    public IList<string> Ci { get; init; } = [];
+    public IList<string> Release { get; init; } = [];
+}
+
+public sealed class TestingSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<BehaviorSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public static class TestingSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static TestingSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<TestingSpecification>(yaml);
+    }
+
+    public static TestingSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static TestingSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<TestingSpecificationIndex>(yaml);
+    }
+
+    public static TestingSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class TestingSpecificationValidator
+{
+    private static readonly Regex TestingIdPattern = new(
+        "^testing\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex BehaviorIdPattern = new(
+        "^behavior\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex QualityIdPattern = new(
+        "^quality\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedVerificationLevels =
+    [
+        "unit",
+        "integration",
+        "acceptance",
+        "performance",
+        "security",
+        "e2e",
+    ];
+
+    private static readonly HashSet<string> AllowedStrategies =
+    [
+        "generated",
+        "manual",
+        "hybrid",
+    ];
+
+    public static IReadOnlyList<string> Validate(TestingSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new BehaviorMetadata();
+        var trace = document.Trace ?? new TestingTraceability();
+        var downstream = trace.Downstream ?? new TestingDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Testing", StringComparison.Ordinal), "kind must be 'Testing'.", errors);
+        Require(TestingIdPattern.IsMatch(document.Id), "id must match testing.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+
+        Require(document.VerificationLevels.Count > 0, "verificationLevels must contain at least one level.", errors);
+        foreach (var level in document.VerificationLevels)
+            Require(AllowedVerificationLevels.Contains(level), $"verificationLevels entry '{level}' is not allowed. Must be one of: unit, integration, acceptance, performance, security, e2e.", errors);
+
+        foreach (var behaviorRef in document.BehaviorRefs)
+            Require(BehaviorIdPattern.IsMatch(behaviorRef), $"behaviorRefs entry '{behaviorRef}' must match behavior.<name> convention.", errors);
+
+        foreach (var qualityRef in document.QualityRefs)
+            Require(QualityIdPattern.IsMatch(qualityRef), $"qualityRefs entry '{qualityRef}' must match quality.<name> convention.", errors);
+
+        Require(document.CoverageTargets.Count > 0, "coverageTargets must contain at least one target.", errors);
+        for (var i = 0; i < document.CoverageTargets.Count; i++)
+        {
+            var target = document.CoverageTargets[i] ?? new TestingCoverageTarget();
+            Require(!string.IsNullOrWhiteSpace(target.Scope), $"coverageTargets[{i}].scope is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(target.Target), $"coverageTargets[{i}].target is required.", errors);
+        }
+
+        foreach (var rule in document.GenerationRules)
+        {
+            var r = rule ?? new TestingGenerationRule();
+            Require(AllowedStrategies.Contains(r.Strategy), $"generationRules entry strategy '{r.Strategy}' is not allowed. Must be one of: generated, manual, hybrid.", errors);
+        }
+
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Ci.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.ci entries must not be blank.", errors);
+        Require(downstream.Release.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.release entries must not be blank.", errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "testing", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "testing", "schema", "testing.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/testing/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/testing/schema/testing.schema.json.");
+
+        TestingSpecificationIndex index;
+        try
+        {
+            index = TestingSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/testing/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Testing index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "TestingIndex", StringComparison.Ordinal), "Testing index kind must be 'TestingIndex'.", errors);
+        Require(index.Entries.Count > 0, "Testing index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Testing spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            TestingSpecification spec;
+            try
+            {
+                spec = TestingSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse testing spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Ci ?? [], entry.Path, "trace.downstream.ci", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Release ?? [], entry.Path, "trace.downstream.release", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/TestingSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/TestingSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class TestingSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryTestingArtifacts_ValidateSuccessfully()
+    {
+        var errors = TestingSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TestingSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "testing", "schema", "testing.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Testing Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "verificationLevels", "behaviorRefs", "qualityRefs", "coverageTargets", "generationRules", "trace"]);
+    }
+
+    [Fact]
+    public void TestingExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "testing", "examples", "testing.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "testing", "schema", "testing.schema.json");
+
+        var spec = TestingSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/TestingSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/TestingSpecificationValidatorTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class TestingSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidTestingSpecification_RoundTripsFields()
+    {
+        var spec = TestingSpecificationParser.Parse(ValidTestingYaml());
+
+        spec.Id.Should().Be("testing.specification-validation");
+        spec.VerificationLevels.Should().Contain("unit");
+        spec.BehaviorRefs.Should().ContainSingle(r => r == "behavior.validate-pull-request");
+        spec.CoverageTargets.Should().ContainSingle(t => t.Scope == "JD.AI.Core.Specifications");
+        spec.GenerationRules.Should().ContainSingle(r => r.Strategy == "manual");
+    }
+
+    [Fact]
+    public void Validate_ValidTestingSpecification_ReturnsNoErrors()
+    {
+        var spec = TestingSpecificationParser.Parse(ValidTestingYaml());
+
+        var errors = TestingSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidTestingSpecification_ReturnsErrors()
+    {
+        var spec = TestingSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Testing
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            verificationLevels:
+              - unknown
+            behaviorRefs:
+              - bad-ref
+            qualityRefs:
+              - bad-quality
+            coverageTargets: []
+            generationRules:
+              - source: foo
+                strategy: invalid
+            trace:
+              upstream: []
+              downstream:
+                ci: []
+                release: []
+            """);
+
+        var errors = TestingSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match testing.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("verificationLevels entry 'unknown'", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("behaviorRefs entry 'bad-ref'", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("qualityRefs entry 'bad-quality'", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("coverageTargets must contain at least one target", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("generationRules entry strategy 'invalid'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = TestingSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingCiReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/testing/examples/testing.example.yaml",
+            ValidTestingYaml(ciRefs: ["tests/missing.cs"]));
+
+        var errors = TestingSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("tests/missing.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingReleaseReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/testing/examples/testing.example.yaml",
+            ValidTestingYaml(releaseRefs: ["src/missing.cs"]));
+
+        var errors = TestingSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/testing/schema/testing.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/testing/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: TestingIndex
+            entries:
+              - id: testing.specification-validation
+                title: Specification Validation Testing
+                path: specs/testing/examples/testing.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/testing/examples/testing.example.yaml", ValidTestingYaml());
+        _fixture.CreateFile("specs/behavior/examples/behavior.example.yaml", "behavior");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/TestingSpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/TestingSpecification.cs", "code");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidTestingYaml(
+        IReadOnlyList<string>? ciRefs = null,
+        IReadOnlyList<string>? releaseRefs = null)
+    {
+        var ciLines = string.Join(Environment.NewLine, (ciRefs ?? ["tests/JD.AI.Tests/Specifications/TestingSpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+        var releaseLines = string.Join(Environment.NewLine, (releaseRefs ?? ["src/JD.AI.Core/Specifications/TestingSpecification.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Testing
+            id: testing.specification-validation
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-testing-strategy-agent
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical testing specifications for JD.AI.
+            verificationLevels:
+              - unit
+              - integration
+            behaviorRefs:
+              - behavior.validate-pull-request
+            qualityRefs: []
+            coverageTargets:
+              - scope: JD.AI.Core.Specifications
+                target: "80%"
+                metric: line
+            generationRules:
+              - source: specs/testing/examples/testing.example.yaml
+                strategy: manual
+            trace:
+              upstream:
+                - specs/behavior/examples/behavior.example.yaml
+              downstream:
+                ci:
+            {{ciLines}}
+                release:
+            {{releaseLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the UPSS Testing Specification type (`testing.v1`) for mapping verification strategies to behavior specs, quality targets, and coverage goals
- Implements `TestingSpecification`, `TestingSpecificationParser`, and `TestingSpecificationValidator` in `JD.AI.Core` following the established behavior spec pattern
- Includes JSON schema, example YAML, index, README, and full test coverage (9 tests) with both validator and repository validation

## Test plan
- [x] `dotnet build` succeeds with zero warnings and zero errors
- [x] All 9 new tests pass (`TestingSpecificationValidatorTests` + `TestingSpecificationRepositoryTests`)
- [x] Repository validation confirms checked-in artifacts resolve correctly
- [x] Schema validation confirms example YAML conforms to JSON schema shape
- [x] Invalid specification detection covers: bad verification levels, bad behaviorRef patterns, empty coverage targets, invalid strategies

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)