### PR TITLE
feat(upss): add decision specification system (ADR)

### DIFF
--- a/specs/adrs/README.md
+++ b/specs/adrs/README.md
@@ -1,0 +1,71 @@
+# Decision Specification System (ADR)
+
+The Decision Specification captures canonical architecture decision records with machine-readable decision metadata and conflict semantics that agents and governance tools can consume directly.
+
+## Purpose
+
+Use `adrs.v1` to describe:
+
+- architecture decisions with structured context, rationale, and consequences
+- alternative options evaluated with pros and cons
+- conflict and supersession semantics between decisions
+- downstream links to implementation and governance artifacts
+
+## Repository Layout
+
+`/specs/adrs/README.md`
+`/specs/adrs/schema/adrs.schema.json`
+`/specs/adrs/examples/adrs.example.yaml`
+`/specs/adrs/index.yaml`
+
+## Authoring Contract
+
+ADR specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Adr`
+- `id`: `adr.<name>` identifier
+- `date`
+- `context`
+- `decision`
+- `alternatives[]`
+- `consequences[]`
+- `supersedes[]`
+- `conflictsWith[]`
+- `trace.upstream[]`
+- `trace.downstream.implementation[]`
+- `trace.downstream.governance[]`
+
+Each alternative must include:
+
+- `title`
+- `description`
+- `pros[]`
+- `cons[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/adrs/schema/adrs.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.AdrSpecificationValidator` for repo-native enforcement, including:
+   - required ADR fields and status values
+   - date format validation
+   - context and decision content requirements
+   - alternatives structure with non-blank titles
+   - consequences with at least one entry
+   - supersedes and conflictsWith entries matching the ADR ID pattern
+   - repository file validation for upstream, implementation, and governance links
+
+Invalid ADR specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-adr-curator`
+
+1. Read the upstream product context and architectural drivers.
+2. Document the decision context and rationale clearly.
+3. Enumerate alternatives with concrete pros and cons.
+4. State consequences that are testable or observable.
+5. Link only stable repository artifacts in downstream implementation and governance references.
+6. Run repository validation before opening a PR.

--- a/specs/adrs/examples/adrs.example.yaml
+++ b/specs/adrs/examples/adrs.example.yaml
@@ -1,0 +1,46 @@
+apiVersion: jdai.upss/v1
+kind: Adr
+id: adr.modular-monolith-architecture
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-adr-curator
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical ADR for the modular monolith architecture decision.
+date: 2026-03-07
+context: The system needs a well-defined architecture style that balances modularity, team autonomy, and operational simplicity during early product stages while preserving the ability to extract services later.
+decision: Adopt a modular monolith architecture where each bounded context is isolated by project boundaries and communicates through explicit public APIs, while sharing a single deployment unit.
+alternatives:
+  - title: Microservices from the start
+    description: Decompose the system into independently deployable services from day one.
+    pros:
+      - Independent scaling per service.
+      - Strong module isolation enforced by network boundaries.
+    cons:
+      - High operational overhead for a small team.
+      - Distributed system complexity introduced before domain boundaries are stable.
+  - title: Traditional layered monolith
+    description: Organize code by technical layer (controllers, services, repositories) without module boundaries.
+    pros:
+      - Simple initial setup and familiar to most developers.
+      - Single deployment unit reduces operational burden.
+    cons:
+      - Cross-cutting dependencies accumulate quickly.
+      - Difficult to extract services later without significant refactoring.
+consequences:
+  - All bounded contexts must communicate through well-defined public APIs rather than direct internal references.
+  - Future service extraction requires only replacing in-process calls with network calls at module boundaries.
+  - The team must enforce module boundaries through code review and automated validation until physical separation is warranted.
+supersedes: []
+conflictsWith: []
+trace:
+  upstream:
+    - specs/vision/examples/vision.example.yaml
+  downstream:
+    implementation:
+      - src/JD.AI.Core/Specifications/AdrSpecification.cs
+    governance:
+      - tests/JD.AI.Tests/Specifications/AdrSpecificationRepositoryTests.cs

--- a/specs/adrs/index.yaml
+++ b/specs/adrs/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: AdrIndex
+entries:
+  - id: adr.modular-monolith-architecture
+    title: Modular Monolith Architecture
+    path: specs/adrs/examples/adrs.example.yaml
+    status: draft

--- a/specs/adrs/schema/adrs.schema.json
+++ b/specs/adrs/schema/adrs.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Decision Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "date",
+    "context",
+    "decision",
+    "alternatives",
+    "consequences",
+    "supersedes",
+    "conflictsWith",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Adr" },
+    "id": {
+      "type": "string",
+      "pattern": "^adr\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "date": { "type": "string", "format": "date" },
+    "context": { "type": "string", "minLength": 1 },
+    "decision": { "type": "string", "minLength": 1 },
+    "alternatives": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "description", "pros", "cons"],
+        "properties": {
+          "title": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "pros": { "type": "array", "items": { "type": "string" } },
+          "cons": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "consequences": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "supersedes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^adr\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+      }
+    },
+    "conflictsWith": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^adr\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["implementation", "governance"],
+          "properties": {
+            "implementation": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "governance": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/AdrSpecification.cs
+++ b/src/JD.AI.Core/Specifications/AdrSpecification.cs
@@ -1,0 +1,263 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class AdrSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public AdrMetadata Metadata { get; set; } = new();
+    public string Date { get; set; } = string.Empty;
+    public string Context { get; set; } = string.Empty;
+    public string Decision { get; set; } = string.Empty;
+    public IList<AdrAlternative> Alternatives { get; init; } = [];
+    public IList<string> Consequences { get; init; } = [];
+    public IList<string> Supersedes { get; init; } = [];
+    public IList<string> ConflictsWith { get; init; } = [];
+    public AdrTraceability Trace { get; set; } = new();
+}
+
+public sealed class AdrMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class AdrAlternative
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public IList<string> Pros { get; init; } = [];
+    public IList<string> Cons { get; init; } = [];
+}
+
+public sealed class AdrTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public AdrDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class AdrDownstreamTrace
+{
+    public IList<string> Implementation { get; init; } = [];
+    public IList<string> Governance { get; init; } = [];
+}
+
+public sealed class AdrSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<AdrSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class AdrSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class AdrSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static AdrSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<AdrSpecification>(yaml);
+    }
+
+    public static AdrSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static AdrSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<AdrSpecificationIndex>(yaml);
+    }
+
+    public static AdrSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class AdrSpecificationValidator
+{
+    private static readonly Regex AdrIdPattern = new(
+        @"^adr\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    public static IReadOnlyList<string> Validate(AdrSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new AdrMetadata();
+        var trace = document.Trace ?? new AdrTraceability();
+        var downstream = trace.Downstream ?? new AdrDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Adr", StringComparison.Ordinal), "kind must be 'Adr'.", errors);
+        Require(AdrIdPattern.IsMatch(document.Id), "id must match adr.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(DateOnly.TryParse(document.Date, out _), "date must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.Context), "context is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.Decision), "decision is required.", errors);
+        Require(document.Alternatives.Count > 0, "alternatives must contain at least one alternative.", errors);
+        RequireHasValues(document.Consequences, "consequences must contain at least one consequence.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Implementation.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.implementation entries must not be blank.", errors);
+        Require(downstream.Governance.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.governance entries must not be blank.", errors);
+
+        ValidateAlternatives(document.Alternatives, errors);
+        ValidateAdrIdReferences(document.Supersedes, "supersedes", errors);
+        ValidateAdrIdReferences(document.ConflictsWith, "conflictsWith", errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "adrs", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "adrs", "schema", "adrs.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/adrs/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/adrs/schema/adrs.schema.json.");
+
+        AdrSpecificationIndex index;
+        try
+        {
+            index = AdrSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/adrs/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Adr index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "AdrIndex", StringComparison.Ordinal), "Adr index kind must be 'AdrIndex'.", errors);
+        Require(index.Entries.Count > 0, "Adr index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Adr spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            AdrSpecification spec;
+            try
+            {
+                spec = AdrSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse adr spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Implementation ?? [], entry.Path, "trace.downstream.implementation", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Governance ?? [], entry.Path, "trace.downstream.governance", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateAlternatives(IList<AdrAlternative> alternatives, List<string> errors)
+    {
+        for (var i = 0; i < alternatives.Count; i++)
+        {
+            var alternative = alternatives[i] ?? new AdrAlternative();
+            var prefix = $"alternatives[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(alternative.Title), $"{prefix}.title is required.", errors);
+        }
+    }
+
+    private static void ValidateAdrIdReferences(IList<string> ids, string fieldName, List<string> errors)
+    {
+        for (var i = 0; i < ids.Count; i++)
+        {
+            var id = ids[i];
+            Require(AdrIdPattern.IsMatch(id ?? string.Empty), $"{fieldName}[{i}] must match adr.<name> convention.", errors);
+        }
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/AdrSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/AdrSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class AdrSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryAdrArtifacts_ValidateSuccessfully()
+    {
+        var errors = AdrSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AdrSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "adrs", "schema", "adrs.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Decision Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "date", "context", "decision", "alternatives", "consequences", "supersedes", "conflictsWith", "trace"]);
+    }
+
+    [Fact]
+    public void AdrExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "adrs", "examples", "adrs.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "adrs", "schema", "adrs.schema.json");
+
+        var spec = AdrSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/AdrSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/AdrSpecificationValidatorTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class AdrSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidAdrSpecification_RoundTripsFields()
+    {
+        var spec = AdrSpecificationParser.Parse(ValidAdrYaml());
+
+        spec.Id.Should().Be("adr.modular-monolith-architecture");
+        spec.Date.Should().Be("2026-03-07");
+        spec.Context.Should().Contain("architecture style");
+        spec.Decision.Should().Contain("modular monolith");
+        spec.Alternatives.Should().HaveCount(2);
+        spec.Consequences.Should().HaveCountGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public void Validate_ValidAdrSpecification_ReturnsNoErrors()
+    {
+        var spec = AdrSpecificationParser.Parse(ValidAdrYaml());
+
+        var errors = AdrSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidAdrSpecification_ReturnsErrors()
+    {
+        var spec = AdrSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Adr
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            date: not-a-date
+            context: ""
+            decision: ""
+            alternatives: []
+            consequences: []
+            supersedes:
+              - bad-id
+            conflictsWith: []
+            trace:
+              upstream: []
+              downstream:
+                implementation: []
+                governance: []
+            """);
+
+        var errors = AdrSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match adr.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("version must be greater than or equal to 1", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("context is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("decision is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("date must be a valid", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("alternatives must contain at least one alternative", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("consequences must contain at least one consequence", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("supersedes[0] must match adr.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = AdrSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingImplementationReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/adrs/examples/adrs.example.yaml",
+            ValidAdrYaml(implementationRefs: ["src/missing.cs"]));
+
+        var errors = AdrSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", "vision");
+        _fixture.CreateFile("specs/adrs/schema/adrs.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/adrs/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: AdrIndex
+            entries:
+              - id: adr.modular-monolith-architecture
+                title: Modular Monolith Architecture
+                path: specs/adrs/examples/adrs.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/adrs/examples/adrs.example.yaml", ValidAdrYaml());
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/AdrSpecification.cs", "code");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/AdrSpecificationRepositoryTests.cs", "test");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidAdrYaml(IReadOnlyList<string>? implementationRefs = null)
+    {
+        var implLines = string.Join(Environment.NewLine, (implementationRefs ?? ["src/JD.AI.Core/Specifications/AdrSpecification.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Adr
+            id: adr.modular-monolith-architecture
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-adr-curator
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical ADR specifications for JD.AI.
+            date: 2026-03-07
+            context: The system needs a well-defined architecture style that balances modularity and simplicity.
+            decision: Adopt a modular monolith architecture with explicit module boundaries.
+            alternatives:
+              - title: Microservices from the start
+                description: Decompose the system into independently deployable services from day one.
+                pros:
+                  - Independent scaling per service.
+                cons:
+                  - High operational overhead for a small team.
+              - title: Traditional layered monolith
+                description: Organize code by technical layer without module boundaries.
+                pros:
+                  - Simple initial setup.
+                cons:
+                  - Cross-cutting dependencies accumulate quickly.
+            consequences:
+              - All bounded contexts must communicate through well-defined public APIs.
+              - Future service extraction requires only replacing in-process calls with network calls.
+            supersedes: []
+            conflictsWith: []
+            trace:
+              upstream:
+                - specs/vision/examples/vision.example.yaml
+              downstream:
+                implementation:
+            {{implLines}}
+                governance:
+                  - tests/JD.AI.Tests/Specifications/AdrSpecificationRepositoryTests.cs
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Add ADR (Architecture Decision Record) specification type to the UPSS framework with full spec directory (`specs/adrs/`), JSON schema, example YAML, and index
- Implement `AdrSpecification.cs` with model classes, parser, and validator following the established behavior spec pattern
- Add validator and repository test suites (`AdrSpecificationValidatorTests`, `AdrSpecificationRepositoryTests`) with 8 passing tests

Closes #270

## Test plan
- [x] All 8 new ADR specification tests pass
- [x] Solution builds with zero warnings/errors
- [x] Example YAML conforms to JSON schema shape
- [x] Repository validation passes on checked-in artifacts
- [x] Invalid spec detection works (bad id, version:0, empty context/decision, bad date, empty alternatives/consequences, invalid supersedes pattern)
- [x] Missing implementation reference detection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)