### PR TITLE
feat(upss): add deployment specification system

### DIFF
--- a/specs/deployment/README.md
+++ b/specs/deployment/README.md
@@ -1,0 +1,79 @@
+# Deployment Specification System
+
+The Deployment Specification captures environments, CI/CD pipelines, infrastructure configuration, promotion gates, and rollback strategies as repo-native artifacts that agents and automation can consume directly.
+
+## Purpose
+
+Use `deployment.v1` to describe:
+
+- target environments and their types (development, staging, production, DR)
+- pipeline stages and their execution order
+- promotion gates with criteria for environment-to-environment promotion
+- infrastructure references linking specs to provisioning artifacts
+- rollback strategies governing failure recovery
+- downstream links to tests, implementation, and observability artifacts
+
+## Repository Layout
+
+`/specs/deployment/README.md`
+`/specs/deployment/schema/deployment.schema.json`
+`/specs/deployment/examples/deployment.example.yaml`
+`/specs/deployment/index.yaml`
+
+## Authoring Contract
+
+Deployment specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Deployment`
+- `id`: `deployment.<name>` identifier
+- `environments[]`
+- `pipelineStages[]`
+- `promotionGates[]`
+- `infrastructureRefs[]`
+- `rollbackStrategy`
+- `trace.upstream[]`
+- `trace.downstream.operations[]`
+- `trace.downstream.observability[]`
+
+Each environment must include:
+
+- `name`
+- `type`
+- `region`
+
+Each pipeline stage must include:
+
+- `name`
+- `order`
+- `automated`
+
+Each promotion gate must include:
+
+- `fromEnv`
+- `toEnv`
+- `criteria[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/deployment/schema/deployment.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.DeploymentSpecificationValidator` for repo-native enforcement, including:
+   - required deployment fields and status values
+   - environment type validation against allowed types
+   - pipeline stage integrity
+   - rollback strategy validation against allowed strategies
+   - repository file validation for upstream, operations, and observability links
+
+Invalid deployment specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-deployment-topology-agent`
+
+1. Read the upstream vision and capability context.
+2. Define environments, pipeline stages, and promotion gates.
+3. Specify rollback strategy appropriate for the deployment topology.
+4. Link only stable repository artifacts in downstream operations and observability references.
+5. Run repository validation before opening a PR.

--- a/specs/deployment/examples/deployment.example.yaml
+++ b/specs/deployment/examples/deployment.example.yaml
@@ -1,0 +1,42 @@
+apiVersion: jdai.upss/v1
+kind: Deployment
+id: deployment.jdai-gateway
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-deployment-topology-agent
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical deployment specification for the JD.AI gateway service.
+environments:
+  - name: staging
+    type: staging
+    region: us-east-1
+  - name: production
+    type: production
+    region: us-east-1
+pipelineStages:
+  - name: Build and Test
+    order: 1
+    automated: true
+  - name: Deploy to Staging
+    order: 2
+    automated: true
+promotionGates:
+  - fromEnv: staging
+    toEnv: production
+    criteria:
+      - All integration tests pass in staging environment.
+infrastructureRefs:
+  - infra/gateway/main.tf
+rollbackStrategy: blue-green
+trace:
+  upstream:
+    - specs/vision/examples/vision.example.yaml
+  downstream:
+    operations:
+      - tests/JD.AI.Tests/Specifications/DeploymentSpecificationRepositoryTests.cs
+    observability:
+      - src/JD.AI.Core/Specifications/DeploymentSpecification.cs

--- a/specs/deployment/index.yaml
+++ b/specs/deployment/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: DeploymentIndex
+entries:
+  - id: deployment.jdai-gateway
+    title: JD.AI Gateway Deployment
+    path: specs/deployment/examples/deployment.example.yaml
+    status: draft

--- a/specs/deployment/schema/deployment.schema.json
+++ b/specs/deployment/schema/deployment.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Deployment Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "environments",
+    "pipelineStages",
+    "promotionGates",
+    "infrastructureRefs",
+    "rollbackStrategy",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Deployment" },
+    "id": {
+      "type": "string",
+      "pattern": "^deployment\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "environments": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "type", "region"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "enum": ["development", "staging", "production", "dr"] },
+          "region": { "type": "string" }
+        }
+      }
+    },
+    "pipelineStages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "order", "automated"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "order": { "type": "integer", "minimum": 1 },
+          "automated": { "type": "boolean" }
+        }
+      }
+    },
+    "promotionGates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["fromEnv", "toEnv", "criteria"],
+        "properties": {
+          "fromEnv": { "type": "string", "minLength": 1 },
+          "toEnv": { "type": "string", "minLength": 1 },
+          "criteria": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "infrastructureRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "rollbackStrategy": {
+      "type": "string",
+      "enum": ["blue-green", "canary", "rolling", "recreate", "manual"]
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operations", "observability"],
+          "properties": {
+            "operations": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "observability": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/DeploymentSpecification.cs
+++ b/src/JD.AI.Core/Specifications/DeploymentSpecification.cs
@@ -1,0 +1,291 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class DeploymentSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DeploymentMetadata Metadata { get; set; } = new();
+    public IList<DeploymentEnvironment> Environments { get; init; } = [];
+    public IList<DeploymentPipelineStage> PipelineStages { get; init; } = [];
+    public IList<DeploymentPromotionGate> PromotionGates { get; init; } = [];
+    public IList<string> InfrastructureRefs { get; init; } = [];
+    public string RollbackStrategy { get; set; } = string.Empty;
+    public DeploymentTraceability Trace { get; set; } = new();
+}
+
+public sealed class DeploymentMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class DeploymentEnvironment
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Region { get; set; } = string.Empty;
+}
+
+public sealed class DeploymentPipelineStage
+{
+    public string Name { get; set; } = string.Empty;
+    public int Order { get; set; }
+    public bool Automated { get; set; }
+}
+
+public sealed class DeploymentPromotionGate
+{
+    public string FromEnv { get; set; } = string.Empty;
+    public string ToEnv { get; set; } = string.Empty;
+    public IList<string> Criteria { get; init; } = [];
+}
+
+public sealed class DeploymentTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public DeploymentDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class DeploymentDownstreamTrace
+{
+    public IList<string> Operations { get; init; } = [];
+    public IList<string> Observability { get; init; } = [];
+}
+
+public sealed class DeploymentSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<DeploymentSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class DeploymentSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class DeploymentSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static DeploymentSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DeploymentSpecification>(yaml);
+    }
+
+    public static DeploymentSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static DeploymentSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<DeploymentSpecificationIndex>(yaml);
+    }
+
+    public static DeploymentSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class DeploymentSpecificationValidator
+{
+    private static readonly Regex DeploymentIdPattern = new(
+        "^deployment\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedEnvironmentTypes =
+    [
+        "development",
+        "staging",
+        "production",
+        "dr",
+    ];
+
+    private static readonly HashSet<string> AllowedRollbackStrategies =
+    [
+        "blue-green",
+        "canary",
+        "rolling",
+        "recreate",
+        "manual",
+    ];
+
+    public static IReadOnlyList<string> Validate(DeploymentSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new DeploymentMetadata();
+        var trace = document.Trace ?? new DeploymentTraceability();
+        var downstream = trace.Downstream ?? new DeploymentDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Deployment", StringComparison.Ordinal), "kind must be 'Deployment'.", errors);
+        Require(DeploymentIdPattern.IsMatch(document.Id), "id must match deployment.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(document.Environments.Count > 0, "environments must contain at least one environment.", errors);
+        Require(document.PipelineStages.Count > 0, "pipelineStages must contain at least one stage.", errors);
+        Require(AllowedRollbackStrategies.Contains(document.RollbackStrategy), "rollbackStrategy must be one of: blue-green, canary, rolling, recreate, manual.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Operations.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.operations entries must not be blank.", errors);
+        Require(downstream.Observability.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.observability entries must not be blank.", errors);
+
+        ValidateEnvironments(document.Environments, errors);
+        ValidatePipelineStages(document.PipelineStages, errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "deployment", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "deployment", "schema", "deployment.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/deployment/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/deployment/schema/deployment.schema.json.");
+
+        DeploymentSpecificationIndex index;
+        try
+        {
+            index = DeploymentSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/deployment/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Deployment index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "DeploymentIndex", StringComparison.Ordinal), "Deployment index kind must be 'DeploymentIndex'.", errors);
+        Require(index.Entries.Count > 0, "Deployment index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Deployment spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            DeploymentSpecification spec;
+            try
+            {
+                spec = DeploymentSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse deployment spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Operations ?? [], entry.Path, "trace.downstream.operations", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Observability ?? [], entry.Path, "trace.downstream.observability", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateEnvironments(IList<DeploymentEnvironment> environments, List<string> errors)
+    {
+        for (var i = 0; i < environments.Count; i++)
+        {
+            var env = environments[i] ?? new DeploymentEnvironment();
+            var prefix = $"environments[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(env.Name), $"{prefix}.name is required.", errors);
+            Require(AllowedEnvironmentTypes.Contains(env.Type), $"{prefix}.type must be one of: development, staging, production, dr.", errors);
+        }
+    }
+
+    private static void ValidatePipelineStages(IList<DeploymentPipelineStage> stages, List<string> errors)
+    {
+        for (var i = 0; i < stages.Count; i++)
+        {
+            var stage = stages[i] ?? new DeploymentPipelineStage();
+            var prefix = $"pipelineStages[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(stage.Name), $"{prefix}.name is required.", errors);
+        }
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DeploymentSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DeploymentSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DeploymentSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryDeploymentArtifacts_ValidateSuccessfully()
+    {
+        var errors = DeploymentSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DeploymentSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "deployment", "schema", "deployment.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Deployment Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "environments", "pipelineStages", "promotionGates", "infrastructureRefs", "rollbackStrategy", "trace"]);
+    }
+
+    [Fact]
+    public void DeploymentExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "deployment", "examples", "deployment.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "deployment", "schema", "deployment.schema.json");
+
+        var spec = DeploymentSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/DeploymentSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/DeploymentSpecificationValidatorTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class DeploymentSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidDeploymentSpecification_RoundTripsFields()
+    {
+        var spec = DeploymentSpecificationParser.Parse(ValidDeploymentYaml());
+
+        spec.Id.Should().Be("deployment.jdai-gateway");
+        spec.RollbackStrategy.Should().Be("blue-green");
+        spec.Environments.Should().HaveCount(2);
+        spec.PipelineStages.Should().HaveCount(2);
+        spec.PromotionGates.Should().ContainSingle(gate => gate.FromEnv == "staging");
+    }
+
+    [Fact]
+    public void Validate_ValidDeploymentSpecification_ReturnsNoErrors()
+    {
+        var spec = DeploymentSpecificationParser.Parse(ValidDeploymentYaml());
+
+        var errors = DeploymentSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidDeploymentSpecification_ReturnsErrors()
+    {
+        var spec = DeploymentSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Deployment
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            environments:
+              - name: ""
+                type: invalid-type
+                region: us-east-1
+            pipelineStages:
+              - name: ""
+                order: 1
+                automated: true
+            promotionGates: []
+            infrastructureRefs: []
+            rollbackStrategy: invalid-strategy
+            trace:
+              upstream: []
+              downstream:
+                operations: []
+                observability: []
+            """);
+
+        var errors = DeploymentSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match deployment.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("rollbackStrategy must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("environments[0].type must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("environments[0].name is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("pipelineStages[0].name is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("trace.upstream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_EmptyEnvironments_ReturnsError()
+    {
+        var spec = DeploymentSpecificationParser.Parse(ValidDeploymentYaml(environments: "environments: []"));
+
+        var errors = DeploymentSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("environments must contain at least one environment", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_EmptyPipelineStages_ReturnsError()
+    {
+        var spec = DeploymentSpecificationParser.Parse(ValidDeploymentYaml(pipelineStages: "pipelineStages: []"));
+
+        var errors = DeploymentSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("pipelineStages must contain at least one stage", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = DeploymentSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingOperationsReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/deployment/examples/deployment.example.yaml",
+            ValidDeploymentYaml(operationsRefs: ["src/missing.cs"]));
+
+        var errors = DeploymentSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/deployment/schema/deployment.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/deployment/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: DeploymentIndex
+            entries:
+              - id: deployment.jdai-gateway
+                title: JD.AI Gateway Deployment
+                path: specs/deployment/examples/deployment.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/deployment/examples/deployment.example.yaml", ValidDeploymentYaml());
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", "vision");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/DeploymentSpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/DeploymentSpecification.cs", "code");
+        _fixture.CreateFile("infra/gateway/main.tf", "infra");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidDeploymentYaml(
+        string? environments = null,
+        string? pipelineStages = null,
+        IReadOnlyList<string>? operationsRefs = null)
+    {
+        var operationsLines = string.Join(Environment.NewLine, (operationsRefs ?? ["tests/JD.AI.Tests/Specifications/DeploymentSpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+
+        var envBlock = environments ?? """
+            environments:
+              - name: staging
+                type: staging
+                region: us-east-1
+              - name: production
+                type: production
+                region: us-east-1
+            """;
+
+        var stagesBlock = pipelineStages ?? """
+            pipelineStages:
+              - name: Build and Test
+                order: 1
+                automated: true
+              - name: Deploy to Staging
+                order: 2
+                automated: true
+            """;
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Deployment
+            id: deployment.jdai-gateway
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-deployment-topology-agent
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical deployment specifications for JD.AI.
+            {{envBlock}}
+            {{stagesBlock}}
+            promotionGates:
+              - fromEnv: staging
+                toEnv: production
+                criteria:
+                  - All integration tests pass in staging environment.
+            infrastructureRefs:
+              - infra/gateway/main.tf
+            rollbackStrategy: blue-green
+            trace:
+              upstream:
+                - specs/vision/examples/vision.example.yaml
+              downstream:
+                operations:
+            {{operationsLines}}
+                observability:
+                  - src/JD.AI.Core/Specifications/DeploymentSpecification.cs
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new UPSS Deployment Specification type (`deployment.v1`) covering environments, CI/CD pipelines, promotion gates, infrastructure references, and rollback strategies
- Implements `DeploymentSpecificationValidator` with document-level and repository-level validation following the existing behavior spec pattern
- Includes JSON schema, example YAML, index, README, and 10 passing tests

## Test plan
- [x] All 10 new deployment specification tests pass (`dotnet test --filter DeploymentSpecification`)
- [x] Full solution builds cleanly
- [x] Validator tests cover: valid round-trip parsing, valid document validation, invalid document detection (bad id, bad rollback strategy, bad environment type, empty arrays), repository validation with checked-in artifacts, and missing file reference detection

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)