### PR TITLE
feat(upss): add operational specification system

### DIFF
--- a/specs/operations/README.md
+++ b/specs/operations/README.md
@@ -1,0 +1,78 @@
+# Operational Specification System
+
+The Operational Specification captures runbooks, incident response procedures, escalation policies, and response SLOs that agents and operators can consume directly.
+
+## Purpose
+
+Use `operations.v1` to describe:
+
+- runbooks with trigger conditions and step-by-step procedures
+- incident severity levels and expected response times
+- response SLOs for acknowledgement and resolution windows
+- escalation paths with contact chains
+- downstream links to governance and audit artifacts
+
+## Repository Layout
+
+`/specs/operations/README.md`
+`/specs/operations/schema/operations.schema.json`
+`/specs/operations/examples/operations.example.yaml`
+`/specs/operations/index.yaml`
+
+## Authoring Contract
+
+Operations specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Operations`
+- `id`: `operations.<name>` identifier
+- `service`
+- `runbooks[]`
+- `incidentLevels[]`
+- `responseSlos[]`
+- `escalationPaths[]`
+- `trace.upstream[]`
+- `trace.downstream.governance[]`
+- `trace.downstream.audits[]`
+
+Each runbook must include:
+
+- `name`
+- `triggerCondition`
+- `steps[]`
+
+Each incident level must include:
+
+- `level` (one of: sev1, sev2, sev3, sev4)
+- `description`
+- `responseTime`
+
+Each escalation path must include:
+
+- `level`
+- `contacts[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/operations/schema/operations.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.OperationsSpecificationValidator` for repo-native enforcement, including:
+   - required operations fields and status values
+   - service field must not be blank
+   - runbook integrity for name, trigger condition, and steps
+   - incident level validation against allowed severity levels
+   - escalation path integrity for level and contacts
+   - repository file validation for upstream, governance, and audit links
+
+Invalid operations specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-operations-runbook-agent`
+
+1. Read the upstream vision and capability context.
+2. Define runbooks with clear trigger conditions and actionable steps.
+3. Map incident severity levels to response time expectations.
+4. Establish escalation paths with concrete contact chains.
+5. Run repository validation before opening a PR.

--- a/specs/operations/examples/operations.example.yaml
+++ b/specs/operations/examples/operations.example.yaml
@@ -1,0 +1,47 @@
+apiVersion: jdai.upss/v1
+kind: Operations
+id: operations.jdai-gateway
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-operations-runbook-agent
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical operational specification for the JD.AI gateway service.
+service: jdai-gateway
+runbooks:
+  - name: Gateway Health Degradation
+    description: Steps to diagnose and restore gateway health when latency exceeds thresholds.
+    triggerCondition: P95 latency exceeds 500ms for 5 consecutive minutes.
+    steps:
+      - Check gateway pod status and recent restart events.
+      - Review upstream dependency health endpoints.
+      - Inspect recent deployment changes for regressions.
+      - Scale gateway replicas if load-related.
+      - Escalate to on-call engineer if unresolved within 15 minutes.
+incidentLevels:
+  - level: sev1
+    description: Complete service outage affecting all users.
+    responseTime: 5 minutes
+  - level: sev2
+    description: Partial degradation affecting a significant subset of users.
+    responseTime: 15 minutes
+responseSlos:
+  - level: sev1
+    acknowledgeWithin: 5 minutes
+    resolveWithin: 1 hour
+escalationPaths:
+  - level: sev1
+    contacts:
+      - on-call-primary
+      - engineering-lead
+trace:
+  upstream:
+    - specs/vision/examples/vision.example.yaml
+  downstream:
+    governance:
+      - tests/JD.AI.Tests/Specifications/OperationsSpecificationRepositoryTests.cs
+    audits:
+      - src/JD.AI.Core/Specifications/OperationsSpecification.cs

--- a/specs/operations/index.yaml
+++ b/specs/operations/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: OperationsIndex
+entries:
+  - id: operations.jdai-gateway
+    title: JD.AI Gateway Operations
+    path: specs/operations/examples/operations.example.yaml
+    status: draft

--- a/specs/operations/schema/operations.schema.json
+++ b/specs/operations/schema/operations.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Operational Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "service",
+    "runbooks",
+    "incidentLevels",
+    "responseSlos",
+    "escalationPaths",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Operations" },
+    "id": {
+      "type": "string",
+      "pattern": "^operations\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "service": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runbooks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "triggerCondition", "steps"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string" },
+          "triggerCondition": { "type": "string", "minLength": 1 },
+          "steps": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "incidentLevels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["level", "description", "responseTime"],
+        "properties": {
+          "level": { "type": "string", "enum": ["sev1", "sev2", "sev3", "sev4"] },
+          "description": { "type": "string", "minLength": 1 },
+          "responseTime": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "responseSlos": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["level", "acknowledgeWithin", "resolveWithin"],
+        "properties": {
+          "level": { "type": "string", "minLength": 1 },
+          "acknowledgeWithin": { "type": "string", "minLength": 1 },
+          "resolveWithin": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "escalationPaths": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["level", "contacts"],
+        "properties": {
+          "level": { "type": "string", "minLength": 1 },
+          "contacts": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["governance", "audits"],
+          "properties": {
+            "governance": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+            "audits": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/OperationsSpecification.cs
+++ b/src/JD.AI.Core/Specifications/OperationsSpecification.cs
@@ -1,0 +1,290 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class OperationsSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public BehaviorMetadata Metadata { get; set; } = new();
+    public string Service { get; set; } = string.Empty;
+    public IList<OperationsRunbook> Runbooks { get; init; } = [];
+    public IList<OperationsIncidentLevel> IncidentLevels { get; init; } = [];
+    public IList<OperationsResponseSlo> ResponseSlos { get; init; } = [];
+    public IList<OperationsEscalationPath> EscalationPaths { get; init; } = [];
+    public OperationsTraceability Trace { get; set; } = new();
+}
+
+public sealed class OperationsRunbook
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string TriggerCondition { get; set; } = string.Empty;
+    public IList<string> Steps { get; init; } = [];
+}
+
+public sealed class OperationsIncidentLevel
+{
+    public string Level { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string ResponseTime { get; set; } = string.Empty;
+}
+
+public sealed class OperationsResponseSlo
+{
+    public string Level { get; set; } = string.Empty;
+    public string AcknowledgeWithin { get; set; } = string.Empty;
+    public string ResolveWithin { get; set; } = string.Empty;
+}
+
+public sealed class OperationsEscalationPath
+{
+    public string Level { get; set; } = string.Empty;
+    public IList<string> Contacts { get; init; } = [];
+}
+
+public sealed class OperationsTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public OperationsDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class OperationsDownstreamTrace
+{
+    public IList<string> Governance { get; init; } = [];
+    public IList<string> Audits { get; init; } = [];
+}
+
+public sealed class OperationsSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<BehaviorSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public static class OperationsSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static OperationsSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<OperationsSpecification>(yaml);
+    }
+
+    public static OperationsSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static OperationsSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<OperationsSpecificationIndex>(yaml);
+    }
+
+    public static OperationsSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class OperationsSpecificationValidator
+{
+    private static readonly Regex OperationsIdPattern = new(
+        "^operations\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedIncidentLevels =
+    [
+        "sev1",
+        "sev2",
+        "sev3",
+        "sev4",
+    ];
+
+    public static IReadOnlyList<string> Validate(OperationsSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new BehaviorMetadata();
+        var trace = document.Trace ?? new OperationsTraceability();
+        var downstream = trace.Downstream ?? new OperationsDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Operations", StringComparison.Ordinal), "kind must be 'Operations'.", errors);
+        Require(OperationsIdPattern.IsMatch(document.Id), "id must match operations.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+        Require(!string.IsNullOrWhiteSpace(document.Service), "service is required.", errors);
+        Require(document.Runbooks.Count > 0, "runbooks must contain at least one runbook.", errors);
+        Require(document.IncidentLevels.Count > 0, "incidentLevels must contain at least one incident level.", errors);
+        Require(document.EscalationPaths.Count > 0, "escalationPaths must contain at least one escalation path.", errors);
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.Governance.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.governance entries must not be blank.", errors);
+        Require(downstream.Audits.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.audits entries must not be blank.", errors);
+
+        ValidateRunbooks(document.Runbooks, errors);
+        ValidateIncidentLevels(document.IncidentLevels, errors);
+        ValidateEscalationPaths(document.EscalationPaths, errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "operations", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "operations", "schema", "operations.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/operations/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/operations/schema/operations.schema.json.");
+
+        OperationsSpecificationIndex index;
+        try
+        {
+            index = OperationsSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/operations/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Operations index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "OperationsIndex", StringComparison.Ordinal), "Operations index kind must be 'OperationsIndex'.", errors);
+        Require(index.Entries.Count > 0, "Operations index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Operations spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            OperationsSpecification spec;
+            try
+            {
+                spec = OperationsSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse operations spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Governance ?? [], entry.Path, "trace.downstream.governance", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.Audits ?? [], entry.Path, "trace.downstream.audits", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateRunbooks(IList<OperationsRunbook> runbooks, List<string> errors)
+    {
+        for (var i = 0; i < runbooks.Count; i++)
+        {
+            var runbook = runbooks[i] ?? new OperationsRunbook();
+            var prefix = $"runbooks[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(runbook.Name), $"{prefix}.name is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(runbook.TriggerCondition), $"{prefix}.triggerCondition is required.", errors);
+            RequireHasValues(runbook.Steps, $"{prefix}.steps must contain at least one step.", errors);
+        }
+    }
+
+    private static void ValidateIncidentLevels(IList<OperationsIncidentLevel> incidentLevels, List<string> errors)
+    {
+        for (var i = 0; i < incidentLevels.Count; i++)
+        {
+            var level = incidentLevels[i] ?? new OperationsIncidentLevel();
+            var prefix = $"incidentLevels[{i}]";
+
+            Require(AllowedIncidentLevels.Contains(level.Level), $"{prefix}.level must be one of: sev1, sev2, sev3, sev4.", errors);
+            Require(!string.IsNullOrWhiteSpace(level.Description), $"{prefix}.description is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(level.ResponseTime), $"{prefix}.responseTime is required.", errors);
+        }
+    }
+
+    private static void ValidateEscalationPaths(IList<OperationsEscalationPath> escalationPaths, List<string> errors)
+    {
+        for (var i = 0; i < escalationPaths.Count; i++)
+        {
+            var path = escalationPaths[i] ?? new OperationsEscalationPath();
+            var prefix = $"escalationPaths[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(path.Level), $"{prefix}.level is required.", errors);
+            RequireHasValues(path.Contacts, $"{prefix}.contacts must contain at least one contact.", errors);
+        }
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/OperationsSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/OperationsSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class OperationsSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryOperationsArtifacts_ValidateSuccessfully()
+    {
+        var errors = OperationsSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OperationsSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "operations", "schema", "operations.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Operational Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "service", "runbooks", "incidentLevels", "responseSlos", "escalationPaths", "trace"]);
+    }
+
+    [Fact]
+    public void OperationsExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "operations", "examples", "operations.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "operations", "schema", "operations.schema.json");
+
+        var spec = OperationsSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/OperationsSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/OperationsSpecificationValidatorTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class OperationsSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidOperationsSpecification_RoundTripsFields()
+    {
+        var spec = OperationsSpecificationParser.Parse(ValidOperationsYaml());
+
+        spec.Id.Should().Be("operations.jdai-gateway");
+        spec.Service.Should().Be("jdai-gateway");
+        spec.Runbooks.Should().ContainSingle(runbook => runbook.Name == "Gateway Health Degradation");
+        spec.IncidentLevels.Should().Contain(level => level.Level == "sev1");
+        spec.EscalationPaths.Should().ContainSingle(path => path.Level == "sev1");
+    }
+
+    [Fact]
+    public void Validate_ValidOperationsSpecification_ReturnsNoErrors()
+    {
+        var spec = OperationsSpecificationParser.Parse(ValidOperationsYaml());
+
+        var errors = OperationsSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidOperationsSpecification_ReturnsErrors()
+    {
+        var spec = OperationsSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Operations
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            service: ""
+            runbooks:
+              - name: ""
+                triggerCondition: ""
+                steps: []
+            incidentLevels:
+              - level: sev5
+                description: ""
+                responseTime: ""
+            responseSlos: []
+            escalationPaths:
+              - level: ""
+                contacts: []
+            trace:
+              upstream: []
+              downstream:
+                governance: []
+                audits: []
+            """);
+
+        var errors = OperationsSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match operations.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("service is required", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("runbooks[0].name", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("runbooks[0].triggerCondition", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("runbooks[0].steps", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("incidentLevels[0].level must be one of", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("incidentLevels[0].description", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("escalationPaths[0].level", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("escalationPaths[0].contacts", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("trace.upstream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = OperationsSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingGovernanceReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/operations/examples/operations.example.yaml",
+            ValidOperationsYaml(governanceRefs: ["tests/missing.cs"]));
+
+        var errors = OperationsSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("tests/missing.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingAuditReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/operations/examples/operations.example.yaml",
+            ValidOperationsYaml(auditRefs: ["src/missing.cs"]));
+
+        var errors = OperationsSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", "vision");
+        _fixture.CreateFile("specs/operations/schema/operations.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/operations/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: OperationsIndex
+            entries:
+              - id: operations.jdai-gateway
+                title: JD.AI Gateway Operations
+                path: specs/operations/examples/operations.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/operations/examples/operations.example.yaml", ValidOperationsYaml());
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/OperationsSpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/OperationsSpecification.cs", "code");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidOperationsYaml(
+        IReadOnlyList<string>? governanceRefs = null,
+        IReadOnlyList<string>? auditRefs = null)
+    {
+        var governanceLines = string.Join(Environment.NewLine, (governanceRefs ?? ["tests/JD.AI.Tests/Specifications/OperationsSpecificationRepositoryTests.cs"]).Select(item => $"      - {item}"));
+        var auditLines = string.Join(Environment.NewLine, (auditRefs ?? ["src/JD.AI.Core/Specifications/OperationsSpecification.cs"]).Select(item => $"      - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Operations
+            id: operations.jdai-gateway
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-operations-runbook-agent
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical operations specifications for JD.AI.
+            service: jdai-gateway
+            runbooks:
+              - name: Gateway Health Degradation
+                description: Steps to diagnose and restore gateway health.
+                triggerCondition: P95 latency exceeds 500ms for 5 consecutive minutes.
+                steps:
+                  - Check gateway pod status and recent restart events.
+                  - Review upstream dependency health endpoints.
+            incidentLevels:
+              - level: sev1
+                description: Complete service outage affecting all users.
+                responseTime: 5 minutes
+              - level: sev2
+                description: Partial degradation affecting a subset of users.
+                responseTime: 15 minutes
+            responseSlos:
+              - level: sev1
+                acknowledgeWithin: 5 minutes
+                resolveWithin: 1 hour
+            escalationPaths:
+              - level: sev1
+                contacts:
+                  - on-call-primary
+                  - engineering-lead
+            trace:
+              upstream:
+                - specs/vision/examples/vision.example.yaml
+              downstream:
+                governance:
+            {{governanceLines}}
+                audits:
+            {{auditLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the UPSS Operational Specification System for runbooks, incident response, escalation policies, and response SLOs
- Implements `OperationsSpecification.cs` with model classes, parser, and validator following the existing `BehaviorSpecification` pattern
- Includes JSON schema, example YAML, index file, README, and full test coverage (9 tests)

## Test plan
- [x] All 9 new operations specification tests pass
- [x] Solution builds with zero warnings and zero errors
- [x] `ValidateRepository` test validates checked-in artifacts against the live repo
- [x] Schema contract test verifies required fields in `operations.schema.json`
- [x] Example YAML conforms to JSON schema shape via `OutputSchemaValidator`
- [x] Invalid spec test covers: bad ID, blank service, empty runbooks/steps, invalid incident levels, missing escalation contacts, empty trace

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)