### PR TITLE
feat(upss): add governance specification system

### DIFF
--- a/specs/governance/README.md
+++ b/specs/governance/README.md
@@ -1,0 +1,74 @@
+# Governance Specification System
+
+The Governance Specification captures contribution workflows, release policies, approval gates, and change management rules that agents and human reviewers enforce across the product lifecycle.
+
+## Purpose
+
+Use `governance.v1` to describe:
+
+- ownership models for repository areas
+- change processes with approval requirements
+- approval gates (automated, manual, or hybrid) with criteria
+- release policies including cadence, branch strategy, and hotfix processes
+- audit requirements that must be met before changes ship
+
+## Repository Layout
+
+`/specs/governance/README.md`
+`/specs/governance/schema/governance.schema.json`
+`/specs/governance/examples/governance.example.yaml`
+`/specs/governance/index.yaml`
+
+## Authoring Contract
+
+Governance specs use YAML with these required concepts:
+
+- `apiVersion`: `jdai.upss/v1`
+- `kind`: `Governance`
+- `id`: `governance.<name>` identifier
+- `ownershipModel`
+- `changeProcess[]`
+- `approvalGates[]`
+- `releasePolicy`
+- `auditRequirements[]`
+- `trace.upstream[]`
+- `trace.downstream.allSpecTypes[]`
+
+Each change process entry must include:
+
+- `name`
+- `description`
+- `requiredApprovals`
+
+Each approval gate must include:
+
+- `name`
+- `type`
+- `criteria[]`
+
+## Validation
+
+Validation is enforced by:
+
+1. `specs/governance/schema/governance.schema.json` for machine-readable contract shape.
+2. `JD.AI.Core.Specifications.GovernanceSpecificationValidator` for repo-native enforcement, including:
+   - required governance fields and status values
+   - ownership model value validation
+   - change process completeness
+   - approval gate type and criteria validation
+   - release policy cadence and branch strategy validation
+   - audit requirements presence
+   - repository file validation for upstream and downstream links
+
+Invalid governance specs fail the existing repository test gate.
+
+## Agent Workflow
+
+Assigned agent: `upss-governance-agent`
+
+1. Read the upstream vision and capability context.
+2. Define the ownership model appropriate for the repository area.
+3. Express change processes with clear approval thresholds.
+4. Configure approval gates with concrete, verifiable criteria.
+5. Set release policy to match the project delivery cadence.
+6. Run repository validation before opening a PR.

--- a/specs/governance/examples/governance.example.yaml
+++ b/specs/governance/examples/governance.example.yaml
@@ -1,0 +1,35 @@
+apiVersion: jdai.upss/v1
+kind: Governance
+id: governance.specification-lifecycle
+version: 1
+status: draft
+metadata:
+  owners:
+    - JerrettDavis
+  reviewers:
+    - upss-governance-agent
+  lastReviewed: 2026-03-07
+  changeReason: Establish the first canonical governance specification for specification lifecycle management.
+ownershipModel: codeowners
+changeProcess:
+  - name: Specification change proposal
+    description: All specification changes must be submitted as pull requests with upstream traceability links.
+    requiredApprovals: 1
+approvalGates:
+  - name: CI validation gate
+    type: automated
+    criteria:
+      - All repository specification validators pass without errors.
+releasePolicy:
+  cadence: continuous
+  branchStrategy: trunk-based
+  hotfixProcess: Fast-track PR with owner approval bypassing scheduled review.
+auditRequirements:
+  - Every specification change must include trace links to upstream and downstream artifacts.
+trace:
+  upstream:
+    - specs/vision/examples/vision.example.yaml
+  downstream:
+    allSpecTypes:
+      - tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs
+      - src/JD.AI.Core/Specifications/GovernanceSpecification.cs

--- a/specs/governance/index.yaml
+++ b/specs/governance/index.yaml
@@ -1,0 +1,7 @@
+apiVersion: jdai.upss/v1
+kind: GovernanceIndex
+entries:
+  - id: governance.specification-lifecycle
+    title: Specification Lifecycle Governance
+    path: specs/governance/examples/governance.example.yaml
+    status: draft

--- a/specs/governance/schema/governance.schema.json
+++ b/specs/governance/schema/governance.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JD.AI Governance Specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "id",
+    "version",
+    "status",
+    "metadata",
+    "ownershipModel",
+    "changeProcess",
+    "approvalGates",
+    "releasePolicy",
+    "auditRequirements",
+    "trace"
+  ],
+  "properties": {
+    "apiVersion": { "const": "jdai.upss/v1" },
+    "kind": { "const": "Governance" },
+    "id": {
+      "type": "string",
+      "pattern": "^governance\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "active", "deprecated", "retired"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owners", "reviewers", "lastReviewed", "changeReason"],
+      "properties": {
+        "owners": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "reviewers": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "lastReviewed": { "type": "string", "format": "date" },
+        "changeReason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "ownershipModel": {
+      "type": "string",
+      "enum": ["codeowners", "team-based", "individual", "shared"]
+    },
+    "changeProcess": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "description", "requiredApprovals"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "requiredApprovals": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "approvalGates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "type", "criteria"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "enum": ["automated", "manual", "hybrid"] },
+          "criteria": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "releasePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cadence", "branchStrategy"],
+      "properties": {
+        "cadence": { "type": "string", "enum": ["continuous", "scheduled", "manual"] },
+        "branchStrategy": { "type": "string", "minLength": 1 },
+        "hotfixProcess": { "type": "string" }
+      }
+    },
+    "auditRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["upstream", "downstream"],
+      "properties": {
+        "upstream": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "downstream": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["allSpecTypes"],
+          "properties": {
+            "allSpecTypes": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/JD.AI.Core/Specifications/GovernanceSpecification.cs
+++ b/src/JD.AI.Core/Specifications/GovernanceSpecification.cs
@@ -1,0 +1,304 @@
+using System.Text.RegularExpressions;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace JD.AI.Core.Specifications;
+
+public sealed class GovernanceSpecification
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public GovernanceMetadata Metadata { get; set; } = new();
+    public string OwnershipModel { get; set; } = string.Empty;
+    public IList<GovernanceChangeProcess> ChangeProcess { get; init; } = [];
+    public IList<GovernanceApprovalGate> ApprovalGates { get; init; } = [];
+    public GovernanceReleasePolicy ReleasePolicy { get; set; } = new();
+    public IList<string> AuditRequirements { get; init; } = [];
+    public GovernanceTraceability Trace { get; set; } = new();
+}
+
+public sealed class GovernanceMetadata
+{
+    public IList<string> Owners { get; init; } = [];
+    public IList<string> Reviewers { get; init; } = [];
+    public string LastReviewed { get; set; } = string.Empty;
+    public string ChangeReason { get; set; } = string.Empty;
+}
+
+public sealed class GovernanceChangeProcess
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int RequiredApprovals { get; set; }
+}
+
+public sealed class GovernanceApprovalGate
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public IList<string> Criteria { get; init; } = [];
+}
+
+public sealed class GovernanceReleasePolicy
+{
+    public string Cadence { get; set; } = string.Empty;
+    public string BranchStrategy { get; set; } = string.Empty;
+    public string HotfixProcess { get; set; } = string.Empty;
+}
+
+public sealed class GovernanceTraceability
+{
+    public IList<string> Upstream { get; init; } = [];
+    public GovernanceDownstreamTrace Downstream { get; set; } = new();
+}
+
+public sealed class GovernanceDownstreamTrace
+{
+    public IList<string> AllSpecTypes { get; init; } = [];
+}
+
+public sealed class GovernanceSpecificationIndex
+{
+    public string ApiVersion { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public IList<GovernanceSpecificationIndexEntry> Entries { get; init; } = [];
+}
+
+public sealed class GovernanceSpecificationIndexEntry
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}
+
+public static class GovernanceSpecificationParser
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static GovernanceSpecification Parse(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<GovernanceSpecification>(yaml);
+    }
+
+    public static GovernanceSpecification ParseFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return Parse(File.ReadAllText(path));
+    }
+
+    public static GovernanceSpecificationIndex ParseIndex(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        return Deserializer.Deserialize<GovernanceSpecificationIndex>(yaml);
+    }
+
+    public static GovernanceSpecificationIndex ParseIndexFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return ParseIndex(File.ReadAllText(path));
+    }
+}
+
+public static class GovernanceSpecificationValidator
+{
+    private static readonly Regex GovernanceIdPattern = new(
+        "^governance\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly HashSet<string> AllowedStatuses =
+    [
+        "draft",
+        "active",
+        "deprecated",
+        "retired",
+    ];
+
+    private static readonly HashSet<string> AllowedOwnershipModels =
+    [
+        "codeowners",
+        "team-based",
+        "individual",
+        "shared",
+    ];
+
+    private static readonly HashSet<string> AllowedGateTypes =
+    [
+        "automated",
+        "manual",
+        "hybrid",
+    ];
+
+    private static readonly HashSet<string> AllowedCadences =
+    [
+        "continuous",
+        "scheduled",
+        "manual",
+    ];
+
+    public static IReadOnlyList<string> Validate(GovernanceSpecification document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var metadata = document.Metadata ?? new GovernanceMetadata();
+        var releasePolicy = document.ReleasePolicy ?? new GovernanceReleasePolicy();
+        var trace = document.Trace ?? new GovernanceTraceability();
+        var downstream = trace.Downstream ?? new GovernanceDownstreamTrace();
+        var errors = new List<string>();
+
+        Require(string.Equals(document.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(document.Kind, "Governance", StringComparison.Ordinal), "kind must be 'Governance'.", errors);
+        Require(GovernanceIdPattern.IsMatch(document.Id), "id must match governance.<name> convention.", errors);
+        Require(document.Version >= 1, "version must be greater than or equal to 1.", errors);
+        Require(AllowedStatuses.Contains(document.Status), "status must be one of: draft, active, deprecated, retired.", errors);
+        RequireHasValues(metadata.Owners, "metadata.owners must contain at least one owner.", errors);
+        RequireHasValues(metadata.Reviewers, "metadata.reviewers must contain at least one reviewer.", errors);
+        Require(DateOnly.TryParse(metadata.LastReviewed, out _), "metadata.lastReviewed must be a valid ISO-8601 date.", errors);
+        Require(!string.IsNullOrWhiteSpace(metadata.ChangeReason), "metadata.changeReason is required.", errors);
+
+        Require(AllowedOwnershipModels.Contains(document.OwnershipModel), "ownershipModel must be one of: codeowners, team-based, individual, shared.", errors);
+
+        Require(document.ChangeProcess.Count > 0, "changeProcess must contain at least one entry.", errors);
+        ValidateChangeProcesses(document.ChangeProcess, errors);
+
+        Require(document.ApprovalGates.Count > 0, "approvalGates must contain at least one entry.", errors);
+        ValidateApprovalGates(document.ApprovalGates, errors);
+
+        Require(AllowedCadences.Contains(releasePolicy.Cadence), "releasePolicy.cadence must be one of: continuous, scheduled, manual.", errors);
+        Require(!string.IsNullOrWhiteSpace(releasePolicy.BranchStrategy), "releasePolicy.branchStrategy is required.", errors);
+
+        RequireHasValues(document.AuditRequirements, "auditRequirements must contain at least one entry.", errors);
+
+        RequireHasValues(trace.Upstream, "trace.upstream must contain at least one upstream artifact.", errors);
+        Require(downstream.AllSpecTypes.All(value => !string.IsNullOrWhiteSpace(value)), "trace.downstream.allSpecTypes entries must not be blank.", errors);
+
+        return errors;
+    }
+
+    public static IReadOnlyList<string> ValidateRepository(string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(repoRoot);
+
+        var errors = new List<string>();
+        var indexPath = Path.Combine(repoRoot, "specs", "governance", "index.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "governance", "schema", "governance.schema.json");
+
+        if (!File.Exists(indexPath))
+        {
+            errors.Add("Missing specs/governance/index.yaml.");
+            return errors;
+        }
+
+        if (!File.Exists(schemaPath))
+            errors.Add("Missing specs/governance/schema/governance.schema.json.");
+
+        GovernanceSpecificationIndex index;
+        try
+        {
+            index = GovernanceSpecificationParser.ParseIndexFile(indexPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            errors.Add($"Unable to parse specs/governance/index.yaml: {ex.Message}");
+            return errors;
+        }
+
+        Require(string.Equals(index.ApiVersion, "jdai.upss/v1", StringComparison.Ordinal), "Governance index apiVersion must be 'jdai.upss/v1'.", errors);
+        Require(string.Equals(index.Kind, "GovernanceIndex", StringComparison.Ordinal), "Governance index kind must be 'GovernanceIndex'.", errors);
+        Require(index.Entries.Count > 0, "Governance index must contain at least one entry.", errors);
+
+        foreach (var entry in index.Entries)
+        {
+            var specPath = Path.Combine(repoRoot, entry.Path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(specPath))
+            {
+                errors.Add($"Governance spec file not found for '{entry.Id}': {entry.Path}");
+                continue;
+            }
+
+            GovernanceSpecification spec;
+            try
+            {
+                spec = GovernanceSpecificationParser.ParseFile(specPath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                errors.Add($"Unable to parse governance spec '{entry.Path}': {ex.Message}");
+                continue;
+            }
+
+            foreach (var validationError in Validate(spec))
+                errors.Add($"{entry.Path}: {validationError}");
+
+            if (!string.Equals(spec.Id, entry.Id, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec id '{spec.Id}' does not match index id '{entry.Id}'.");
+
+            if (!string.Equals(spec.Status, entry.Status, StringComparison.Ordinal))
+                errors.Add($"{entry.Path}: spec status '{spec.Status}' does not match index status '{entry.Status}'.");
+
+            ValidateFileReferences(repoRoot, spec.Trace?.Upstream ?? [], entry.Path, "trace.upstream", errors);
+            ValidateFileReferences(repoRoot, spec.Trace?.Downstream?.AllSpecTypes ?? [], entry.Path, "trace.downstream.allSpecTypes", errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateChangeProcesses(IList<GovernanceChangeProcess> processes, List<string> errors)
+    {
+        for (var i = 0; i < processes.Count; i++)
+        {
+            var process = processes[i] ?? new GovernanceChangeProcess();
+            var prefix = $"changeProcess[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(process.Name), $"{prefix}.name is required.", errors);
+            Require(!string.IsNullOrWhiteSpace(process.Description), $"{prefix}.description is required.", errors);
+        }
+    }
+
+    private static void ValidateApprovalGates(IList<GovernanceApprovalGate> gates, List<string> errors)
+    {
+        for (var i = 0; i < gates.Count; i++)
+        {
+            var gate = gates[i] ?? new GovernanceApprovalGate();
+            var prefix = $"approvalGates[{i}]";
+
+            Require(!string.IsNullOrWhiteSpace(gate.Name), $"{prefix}.name is required.", errors);
+            Require(AllowedGateTypes.Contains(gate.Type), $"{prefix}.type must be one of: automated, manual, hybrid.", errors);
+            RequireHasValues(gate.Criteria, $"{prefix}.criteria must contain at least one entry.", errors);
+        }
+    }
+
+    private static void ValidateFileReferences(string repoRoot, IList<string> paths, string specPath, string fieldName, List<string> errors)
+    {
+        foreach (var path in paths)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                errors.Add($"{specPath}: {fieldName} entries must not be blank.");
+                continue;
+            }
+
+            var fullPath = Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                errors.Add($"{specPath}: {fieldName} reference '{path}' does not resolve to a repository file.");
+        }
+    }
+
+    private static void Require(bool condition, string message, List<string> errors)
+    {
+        if (!condition)
+            errors.Add(message);
+    }
+
+    private static void RequireHasValues(IList<string>? values, string message, List<string> errors)
+    {
+        if (values is null || values.Count == 0 || values.Any(string.IsNullOrWhiteSpace))
+            errors.Add(message);
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs
+++ b/tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using JD.AI.Core.Specifications;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class GovernanceSpecificationRepositoryTests
+{
+    private static readonly JsonSerializerOptions CamelCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void RepositoryGovernanceArtifacts_ValidateSuccessfully()
+    {
+        var errors = GovernanceSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GovernanceSchema_ContainsRequiredContract()
+    {
+        var schemaPath = Path.Combine(GetRepoRoot(), "specs", "governance", "schema", "governance.schema.json");
+        var schema = JsonNode.Parse(File.ReadAllText(schemaPath))!.AsObject();
+
+        schema["title"]!.GetValue<string>().Should().Be("JD.AI Governance Specification");
+
+        var required = schema["required"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        required.Should().Contain(["apiVersion", "kind", "id", "ownershipModel", "changeProcess", "approvalGates", "releasePolicy", "auditRequirements", "trace"]);
+    }
+
+    [Fact]
+    public void GovernanceExample_ConformsToJsonSchemaShape()
+    {
+        var repoRoot = GetRepoRoot();
+        var examplePath = Path.Combine(repoRoot, "specs", "governance", "examples", "governance.example.yaml");
+        var schemaPath = Path.Combine(repoRoot, "specs", "governance", "schema", "governance.schema.json");
+
+        var spec = GovernanceSpecificationParser.ParseFile(examplePath);
+        var json = JsonSerializer.Serialize(spec, CamelCaseJson);
+        var schema = OutputSchemaValidator.LoadSchema(schemaPath);
+
+        var errors = OutputSchemaValidator.Validate(json, schema);
+
+        errors.Should().BeEmpty();
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+}

--- a/tests/JD.AI.Tests/Specifications/GovernanceSpecificationValidatorTests.cs
+++ b/tests/JD.AI.Tests/Specifications/GovernanceSpecificationValidatorTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using JD.AI.Core.Specifications;
+using JD.AI.Tests.Fixtures;
+
+namespace JD.AI.Tests.Specifications;
+
+public sealed class GovernanceSpecificationValidatorTests : IDisposable
+{
+    private readonly TempDirectoryFixture _fixture = new();
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void Parse_ValidGovernanceSpecification_RoundTripsFields()
+    {
+        var spec = GovernanceSpecificationParser.Parse(ValidGovernanceYaml());
+
+        spec.Id.Should().Be("governance.specification-lifecycle");
+        spec.OwnershipModel.Should().Be("codeowners");
+        spec.ChangeProcess.Should().ContainSingle(process => process.Name == "Specification change proposal");
+        spec.ApprovalGates.Should().ContainSingle(gate => gate.Type == "automated");
+        spec.ReleasePolicy.Cadence.Should().Be("continuous");
+    }
+
+    [Fact]
+    public void Validate_ValidGovernanceSpecification_ReturnsNoErrors()
+    {
+        var spec = GovernanceSpecificationParser.Parse(ValidGovernanceYaml());
+
+        var errors = GovernanceSpecificationValidator.Validate(spec);
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_InvalidGovernanceSpecification_ReturnsErrors()
+    {
+        var spec = GovernanceSpecificationParser.Parse("""
+            apiVersion: jdai.upss/v1
+            kind: Governance
+            id: bad
+            version: 0
+            status: pending
+            metadata:
+              owners: []
+              reviewers: []
+              lastReviewed: no
+              changeReason: ""
+            ownershipModel: dictator
+            changeProcess: []
+            approvalGates:
+              - name: ""
+                type: unknown
+                criteria: []
+            releasePolicy:
+              cadence: biweekly
+              branchStrategy: ""
+            auditRequirements: []
+            trace:
+              upstream: []
+              downstream:
+                allSpecTypes: []
+            """);
+
+        var errors = GovernanceSpecificationValidator.Validate(spec);
+
+        errors.Should().Contain(error => error.Contains("id must match governance.", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("ownershipModel", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("changeProcess must contain", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("approvalGates[0].type", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("releasePolicy.cadence", StringComparison.Ordinal));
+        errors.Should().Contain(error => error.Contains("auditRequirements", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_CheckedInArtifacts_ReturnNoErrors()
+    {
+        var errors = GovernanceSpecificationValidator.ValidateRepository(GetRepoRoot());
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingUpstreamReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/governance/examples/governance.example.yaml",
+            ValidGovernanceYaml(upstreamRefs: ["specs/vision/missing.yaml"]));
+
+        var errors = GovernanceSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("specs/vision/missing.yaml", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidateRepository_MissingDownstreamReference_Fails()
+    {
+        SeedRepository();
+        _fixture.CreateFile(
+            "specs/governance/examples/governance.example.yaml",
+            ValidGovernanceYaml(allSpecTypeRefs: ["src/missing.cs"]));
+
+        var errors = GovernanceSpecificationValidator.ValidateRepository(_fixture.DirectoryPath);
+
+        errors.Should().ContainSingle(error => error.Contains("src/missing.cs", StringComparison.Ordinal));
+    }
+
+    private void SeedRepository()
+    {
+        _fixture.CreateFile("JD.AI.slnx", "<Solution />");
+        _fixture.CreateFile("specs/governance/schema/governance.schema.json", """{"type":"object"}""");
+        _fixture.CreateFile("specs/governance/index.yaml", """
+            apiVersion: jdai.upss/v1
+            kind: GovernanceIndex
+            entries:
+              - id: governance.specification-lifecycle
+                title: Specification Lifecycle Governance
+                path: specs/governance/examples/governance.example.yaml
+                status: draft
+            """);
+        _fixture.CreateFile("specs/governance/examples/governance.example.yaml", ValidGovernanceYaml());
+        _fixture.CreateFile("specs/vision/examples/vision.example.yaml", "vision");
+        _fixture.CreateFile("tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs", "test");
+        _fixture.CreateFile("src/JD.AI.Core/Specifications/GovernanceSpecification.cs", "code");
+    }
+
+    private static string GetRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "JD.AI.slnx")))
+            current = current.Parent;
+
+        Assert.NotNull(current);
+        return current!.FullName;
+    }
+
+    private static string ValidGovernanceYaml(
+        IReadOnlyList<string>? upstreamRefs = null,
+        IReadOnlyList<string>? allSpecTypeRefs = null)
+    {
+        var upstreamLines = string.Join(Environment.NewLine, (upstreamRefs ?? ["specs/vision/examples/vision.example.yaml"]).Select(item => $"      - {item}"));
+        var allSpecTypeLines = string.Join(Environment.NewLine, (allSpecTypeRefs ?? ["tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs", "src/JD.AI.Core/Specifications/GovernanceSpecification.cs"]).Select(item => $"        - {item}"));
+
+        return $$"""
+            apiVersion: jdai.upss/v1
+            kind: Governance
+            id: governance.specification-lifecycle
+            version: 1
+            status: draft
+            metadata:
+              owners:
+                - JerrettDavis
+              reviewers:
+                - upss-governance-agent
+              lastReviewed: 2026-03-07
+              changeReason: Establish canonical governance specifications for JD.AI.
+            ownershipModel: codeowners
+            changeProcess:
+              - name: Specification change proposal
+                description: All specification changes must be submitted as pull requests.
+                requiredApprovals: 1
+            approvalGates:
+              - name: CI validation gate
+                type: automated
+                criteria:
+                  - All repository specification validators pass without errors.
+            releasePolicy:
+              cadence: continuous
+              branchStrategy: trunk-based
+              hotfixProcess: Fast-track PR with owner approval.
+            auditRequirements:
+              - Every specification change must include trace links.
+            trace:
+              upstream:
+            {{upstreamLines}}
+              downstream:
+                allSpecTypes:
+            {{allSpecTypeLines}}
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- Add UPSS Governance Specification System with full schema, example, index, model classes, parser, validator, and tests
- Follows the exact pattern established by the `behavior` spec type (BehaviorSpecification.cs)
- Governance specs define ownership models, change processes, approval gates, release policies, and audit requirements

## Files Added
- `specs/governance/README.md` -- documentation and agent workflow
- `specs/governance/schema/governance.schema.json` -- JSON schema with `additionalProperties: false` throughout
- `specs/governance/examples/governance.example.yaml` -- canonical example with upstream/downstream traceability
- `specs/governance/index.yaml` -- GovernanceIndex with single entry
- `src/JD.AI.Core/Specifications/GovernanceSpecification.cs` -- model, parser, and validator
- `tests/JD.AI.Tests/Specifications/GovernanceSpecificationValidatorTests.cs` -- 6 unit tests (parse, valid, invalid, repo, missing refs)
- `tests/JD.AI.Tests/Specifications/GovernanceSpecificationRepositoryTests.cs` -- 3 repository-level tests (artifacts, schema contract, JSON shape)

## Test plan
- [x] All 9 new governance specification tests pass
- [x] Build succeeds with zero warnings and zero errors
- [x] `ValidateRepository_CheckedInArtifacts_ReturnNoErrors` validates the real repo artifacts
- [x] Invalid spec test covers: bad ownershipModel, empty changeProcess, invalid gate type, bad cadence, empty auditRequirements

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)