### PR TITLE
fix(agents): robust text-based tool call detection for Foundry Local

### DIFF
--- a/src/JD.AI.Core/Agents/AgentLoop.cs
+++ b/src/JD.AI.Core/Agents/AgentLoop.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using JD.AI.Core.PromptCaching;
 using JD.AI.Core.Providers;
 using JD.AI.Core.Tools;
@@ -80,6 +81,7 @@ public sealed class AgentLoop
                 _session.History.AddAssistantMessage(response);
                 _session.History.AddUserMessage($"[Tool result for {toolResult.Value.FunctionName}]:\n{toolResult.Value.Result}");
 
+                AgentOutput.Current.RenderToolCall(toolResult.Value.FunctionName, null, toolResult.Value.Result);
                 turnEntry.Attributes["text_tool_call"] = toolResult.Value.FunctionName;
 
                 // Re-invoke the model with the tool result so it can produce a natural response
@@ -406,6 +408,8 @@ public sealed class AgentLoop
                 _session.History.AddAssistantMessage(response);
                 _session.History.AddUserMessage($"[Tool result for {toolResult.Value.FunctionName}]:\n{toolResult.Value.Result}");
 
+                output.RenderToolCall(toolResult.Value.FunctionName, null, toolResult.Value.Result);
+
                 DebugLogger.Log(DebugCategory.Agents,
                     "Text-based tool call detected: {0}, re-invoking model with result",
                     toolResult.Value.FunctionName);
@@ -481,6 +485,23 @@ public sealed class AgentLoop
                 sw.Stop();
 
                 var response = result.Content ?? "(no response)";
+
+                // Check for text-based tool calls before rendering or committing to history
+                var fallbackToolResult = await TryExecuteTextToolCallAsync(response, ct).ConfigureAwait(false);
+                if (fallbackToolResult is not null)
+                {
+                    output.RenderToolCall(fallbackToolResult.Value.FunctionName, null, fallbackToolResult.Value.Result);
+                    _session.History.AddAssistantMessage(response);
+                    _session.History.AddUserMessage(
+                        $"[Tool result for {fallbackToolResult.Value.FunctionName}]:\n{fallbackToolResult.Value.Result}");
+
+                    sw.Restart();
+                    var followUp = await chat.GetChatMessageContentAsync(
+                        _session.History, settings, _session.Kernel, ct).ConfigureAwait(false);
+                    sw.Stop();
+                    response = followUp.Content ?? fallbackToolResult.Value.Result;
+                }
+
                 _session.History.AddAssistantMessage(response);
 
                 var tokenEstimate = JD.SemanticKernel.Extensions.Compaction.TokenEstimator
@@ -544,6 +565,23 @@ public sealed class AgentLoop
                 sw.Stop();
 
                 var response = result.Content ?? "(no response)";
+
+                // Even without structured tool calling, the model may emit JSON tool calls as text
+                var retryToolResult = await TryExecuteTextToolCallAsync(response, ct).ConfigureAwait(false);
+                if (retryToolResult is not null)
+                {
+                    output.RenderToolCall(retryToolResult.Value.FunctionName, null, retryToolResult.Value.Result);
+                    _session.History.AddAssistantMessage(response);
+                    _session.History.AddUserMessage(
+                        $"[Tool result for {retryToolResult.Value.FunctionName}]:\n{retryToolResult.Value.Result}");
+
+                    sw.Restart();
+                    var followUp = await chat.GetChatMessageContentAsync(
+                        _session.History, retrySettings, _session.Kernel, ct).ConfigureAwait(false);
+                    sw.Stop();
+                    response = followUp.Content ?? retryToolResult.Value.Result;
+                }
+
                 _session.History.AddAssistantMessage(response);
 
                 var tokenEstimate = JD.SemanticKernel.Extensions.Compaction.TokenEstimator
@@ -992,6 +1030,7 @@ public sealed class AgentLoop
     /// Detects when a model emits a tool/function call as plain text JSON instead of
     /// using the structured tool calling protocol. Common with smaller models (1-8B).
     /// If detected, resolves and invokes the kernel function, returning the result.
+    /// Handles single bare JSON, code-fenced JSON, and responses with prose around the JSON.
     /// </summary>
     private async Task<TextToolCallResult?> TryExecuteTextToolCallAsync(
         string response, CancellationToken ct)
@@ -999,25 +1038,13 @@ public sealed class AgentLoop
         if (string.IsNullOrWhiteSpace(response))
             return null;
 
-        // Strip markdown code fences if present (```json ... ```)
-        var text = response.Trim();
-        if (text.StartsWith("```", StringComparison.Ordinal))
-        {
-            var firstNewline = text.IndexOf('\n');
-            if (firstNewline > 0)
-                text = text[(firstNewline + 1)..];
-            if (text.EndsWith("```", StringComparison.Ordinal))
-                text = text[..^3];
-            text = text.Trim();
-        }
-
-        // Must look like a JSON object with "name" and "arguments"
-        if (!text.StartsWith('{') || !text.EndsWith('}'))
+        var jsonText = ExtractFirstToolCallJson(response);
+        if (jsonText is null)
             return null;
 
         try
         {
-            using var doc = JsonDocument.Parse(text);
+            using var doc = JsonDocument.Parse(jsonText);
             var root = doc.RootElement;
 
             if (!root.TryGetProperty("name", out var nameEl) ||
@@ -1085,6 +1112,93 @@ public sealed class AgentLoop
             DebugLogger.Log(DebugCategory.Agents,
                 "Text-based tool call execution failed: {0}", ex.Message);
             return null;
+        }
+    }
+
+    // Compiled regex for fenced JSON blocks (e.g. ```json\n{...}\n```)
+    private static readonly Regex FencedJsonRegex = new(
+        @"```(?:json)?\s*\r?\n(?<json>\{[\s\S]*?\})\s*\r?\n```",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Extracts the first JSON object that looks like a tool call (has "name" + "arguments")
+    /// from a response that may contain prose, code fences, or multiple JSON blocks.
+    /// </summary>
+    internal static string? ExtractFirstToolCallJson(string response)
+    {
+        var text = response.Trim();
+
+        // Strategy 1: Whole response is bare JSON
+        if (text.StartsWith('{') && text.EndsWith('}'))
+        {
+            if (LooksLikeToolCall(text))
+                return text;
+        }
+
+        // Strategy 2: Fenced code blocks (```json ... ```)
+        foreach (Match m in FencedJsonRegex.Matches(text))
+        {
+            var candidate = m.Groups["json"].Value.Trim();
+            if (LooksLikeToolCall(candidate))
+                return candidate;
+        }
+
+        // Strategy 3: Scan for first { ... } block with balanced braces
+        var pos = 0;
+        while (pos < text.Length)
+        {
+            var start = text.IndexOf('{', pos);
+            if (start < 0) break;
+
+            var depth = 0;
+            var inString = false;
+            var escape = false;
+
+            for (var i = start; i < text.Length; i++)
+            {
+                var ch = text[i];
+                if (escape) { escape = false; continue; }
+                if (ch == '\\' && inString) { escape = true; continue; }
+                if (ch == '"') { inString = !inString; continue; }
+                if (inString) continue;
+
+                if (ch == '{') depth++;
+                else if (ch == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        var candidate = text[start..(i + 1)];
+                        if (LooksLikeToolCall(candidate))
+                            return candidate;
+                        break;
+                    }
+                }
+            }
+
+            pos = start + 1;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Quick heuristic: returns true if the JSON text contains both "name" and "arguments" keys
+    /// at the top level, suggesting it's a tool call rather than arbitrary data.
+    /// </summary>
+    private static bool LooksLikeToolCall(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            return root.TryGetProperty("name", out var n) &&
+                   n.ValueKind == JsonValueKind.String &&
+                   root.TryGetProperty("arguments", out _);
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 }

--- a/tests/JD.AI.Tests/Agents/AgentLoopTextToolCallTests.cs
+++ b/tests/JD.AI.Tests/Agents/AgentLoopTextToolCallTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using JD.AI.Core.Agents;
+using Xunit;
+
+namespace JD.AI.Tests.Agents;
+
+/// <summary>
+/// Unit tests for <see cref="AgentLoop.ExtractFirstToolCallJson"/>.
+/// Verifies that JSON tool calls are detected in various response formats
+/// produced by small models that emit tool calls as plain text.
+/// </summary>
+public sealed class AgentLoopTextToolCallTests
+{
+    // ── Bare JSON ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractFirstToolCallJson_BareJson_ReturnsJson()
+    {
+        const string response = """
+            {
+              "name": "shell-run_command",
+              "arguments": { "command": "pwd" }
+            }
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"name\"");
+        result.Should().Contain("\"shell-run_command\"");
+    }
+
+    // ── Fenced code blocks ───────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractFirstToolCallJson_FencedJsonBlock_ReturnsJson()
+    {
+        const string response = """
+            ```json
+            {
+              "name": "environment-get_environment",
+              "arguments": { "includeEnvVars": false }
+            }
+            ```
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"environment-get_environment\"");
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_FencedBlockNoLang_ReturnsJson()
+    {
+        const string response = """
+            ```
+            { "name": "shell-run_command", "arguments": { "command": "ls" } }
+            ```
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"shell-run_command\"");
+    }
+
+    // ── Duplicate / multiple blocks ──────────────────────────────────────
+
+    [Fact]
+    public void ExtractFirstToolCallJson_TwoIdenticalFencedBlocks_ReturnsFirst()
+    {
+        // Small models sometimes emit the same tool call twice in one response
+        const string response = """
+            ```json
+            { "name": "toolDiscovery-discover_tools", "arguments": { "page": 1 } }
+            ```
+            ```json
+            { "name": "toolDiscovery-discover_tools", "arguments": { "page": 1 } }
+            ```
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"toolDiscovery-discover_tools\"");
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_ProseAroundJson_ReturnsJson()
+    {
+        const string response = """
+            I'll use the shell tool to run that command.
+            ```json
+            { "name": "shell-run_command", "arguments": { "command": "pwd", "cwd": "" } }
+            ```
+            This will show the current working directory.
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"shell-run_command\"");
+    }
+
+    // ── Not a tool call ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractFirstToolCallJson_PlainText_ReturnsNull()
+    {
+        const string response = "The current directory is C:\\Users\\jd";
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_JsonWithoutName_ReturnsNull()
+    {
+        const string response = """{ "foo": "bar", "baz": 42 }""";
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_JsonWithNameButNoArguments_ReturnsNull()
+    {
+        const string response = """{ "name": "something", "params": {} }""";
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_NullOrEmpty_ReturnsNull()
+    {
+        AgentLoop.ExtractFirstToolCallJson(string.Empty).Should().BeNull();
+        AgentLoop.ExtractFirstToolCallJson("   ").Should().BeNull();
+    }
+
+    // ── Balanced brace scanning ──────────────────────────────────────────
+
+    [Fact]
+    public void ExtractFirstToolCallJson_EmbeddedJsonInBraces_ReturnsToolCall()
+    {
+        // Response contains a non-tool-call JSON object first, then a tool call
+        const string response = """
+            Here is some data: {"info": "hello"}.
+            Tool call: {"name": "shell-run_command", "arguments": {"command": "echo hi"}}
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"shell-run_command\"");
+    }
+
+    [Fact]
+    public void ExtractFirstToolCallJson_NestedArgumentsObject_ParsesCorrectly()
+    {
+        const string response = """
+            {
+              "name": "fs-read_file",
+              "arguments": {
+                "path": "src/foo.cs",
+                "options": { "encoding": "utf8" }
+              }
+            }
+            """;
+
+        var result = AgentLoop.ExtractFirstToolCallJson(response);
+
+        result.Should().NotBeNull();
+        result.Should().Contain("\"fs-read_file\"");
+    }
+}


### PR DESCRIPTION
Fixes double JSON rendering with no tool execution on small models (Foundry Local, Ollama). Three root causes addressed: missing TryExecuteTextToolCallAsync in fallback paths, brittle single-block JSON parser, and no RenderToolCall visual feedback.