### PR TITLE
feat: propagate reasoning effort through gateway and auxiliary paths

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -51,6 +51,12 @@ Search remote model catalogs (Ollama, HuggingFace, Foundry Local) for models mat
 /model search phi-3
 ```
 
+Supports optional filters:
+
+```text
+/model search --provider openrouter --cap reasoning --sort cost llama
+```
+
 ### `/model url <url>`
 
 Pull a model directly from a URL. Supports Ollama model URLs, HuggingFace repository URLs, and direct GGUF download links.
@@ -120,6 +126,17 @@ Clears current conversation history for the active session.
 ### `/compact`
 
 Triggers context compaction immediately.
+
+### `/reasoning [auto|none|low|medium|high|max]`
+
+Shows or sets session reasoning effort override for compatible reasoning models.
+
+```text
+/reasoning
+/reasoning low
+/reasoning max
+/reasoning auto
+```
 
 ### `/context`
 

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -44,8 +44,9 @@ Checks:
 |---------|-------------|
 | `/models` | List all available models across providers |
 | `/model <id>` | Switch to a different model (fuzzy-matches) |
-| `/model search <query>` | Search remote catalogs (Ollama, HuggingFace, Foundry Local) |
+| `/model search <query>` | Search models with optional provider/capability/sort filters |
 | `/model url <url>` | Pull a model from a URL |
+| `/reasoning [auto\|none\|low\|medium\|high\|max]` | Show or set session reasoning effort |
 | `/providers` | List detected providers with connection status |
 | `/provider` | Interactive picker to switch providers |
 | `/provider add <name>` | Configure an API-key provider interactively |
@@ -55,6 +56,8 @@ Checks:
 ```text
 /model gpt-4o
 /model search llama 70b
+/model search --provider openrouter --cap reasoning --sort cost llama
+/reasoning high
 /providers
 /provider add openai
 /provider test

--- a/src/JD.AI.Core/Agents/AgentLoop.cs
+++ b/src/JD.AI.Core/Agents/AgentLoop.cs
@@ -148,6 +148,10 @@ public sealed class AgentLoop
                     MaxTokens = _session.CurrentModel?.MaxOutputTokens is > 0
                         ? _session.CurrentModel.MaxOutputTokens : 4096,
                 };
+                ApplyReasoningEffort(
+                    retrySettings,
+                    _session.CurrentModel,
+                    _session.ReasoningEffortOverride);
 
                 var result = await chat.GetChatMessageContentAsync(
                     _session.History, retrySettings, _session.Kernel, ct).ConfigureAwait(false);
@@ -537,6 +541,10 @@ public sealed class AgentLoop
                     MaxTokens = _session.CurrentModel?.MaxOutputTokens is > 0
                         ? _session.CurrentModel.MaxOutputTokens : 4096,
                 };
+                ApplyReasoningEffort(
+                    retrySettings,
+                    _session.CurrentModel,
+                    _session.ReasoningEffortOverride);
 
                 var result = await chat.GetChatMessageContentAsync(
                     _session.History, retrySettings, _session.Kernel, ct).ConfigureAwait(false);
@@ -790,7 +798,7 @@ public sealed class AgentLoop
         return settings;
     }
 
-    internal static void ApplyReasoningEffort(
+    public static void ApplyReasoningEffort(
         OpenAIPromptExecutionSettings settings,
         ProviderModelInfo? model,
         ReasoningEffort? effort)

--- a/src/JD.AI.Core/Agents/Orchestration/MultiTurnExecutor.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/MultiTurnExecutor.cs
@@ -75,6 +75,10 @@ public sealed class MultiTurnExecutor : ISubagentExecutor
                 ? FunctionChoiceBehavior.Auto(autoInvoke: true)
                 : null,
         };
+        AgentLoop.ApplyReasoningEffort(
+            settings,
+            parentSession.CurrentModel,
+            parentSession.ReasoningEffortOverride);
         PromptCachePolicy.Apply(
             settings,
             parentSession.CurrentModel,

--- a/src/JD.AI.Core/Agents/Orchestration/SingleTurnExecutor.cs
+++ b/src/JD.AI.Core/Agents/Orchestration/SingleTurnExecutor.cs
@@ -58,6 +58,10 @@ public sealed class SingleTurnExecutor : ISubagentExecutor
                 ? FunctionChoiceBehavior.Auto(autoInvoke: true)
                 : null,
         };
+        AgentLoop.ApplyReasoningEffort(
+            settings,
+            parentSession.CurrentModel,
+            parentSession.ReasoningEffortOverride);
         PromptCachePolicy.Apply(
             settings,
             parentSession.CurrentModel,

--- a/src/JD.AI.Core/Agents/SubagentRunner.cs
+++ b/src/JD.AI.Core/Agents/SubagentRunner.cs
@@ -66,6 +66,10 @@ public sealed class SubagentRunner
                 ? FunctionChoiceBehavior.Auto(autoInvoke: true)
                 : null,
         };
+        AgentLoop.ApplyReasoningEffort(
+            settings,
+            _parentSession.CurrentModel,
+            _parentSession.ReasoningEffortOverride);
         PromptCachePolicy.Apply(
             settings,
             _parentSession.CurrentModel,

--- a/src/JD.AI.Gateway/Config/GatewayConfig.cs
+++ b/src/JD.AI.Gateway/Config/GatewayConfig.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA2227 // Collection properties should be read only — needed for IOptions binding
 
+using JD.AI.Core.Agents;
 using JD.AI.Core.Infrastructure;
 
 namespace JD.AI.Gateway.Config;
@@ -128,6 +129,9 @@ public sealed class ModelParameters
 
     /// <summary>Sequences that cause the model to stop generating further tokens.</summary>
     public IList<string> StopSequences { get; set; } = [];
+
+    /// <summary>Reasoning effort hint for compatible reasoning models.</summary>
+    public ReasoningEffort? ReasoningEffort { get; set; }
 }
 
 /// <summary>Routing rules that map channels to agents.</summary>

--- a/src/JD.AI.Gateway/Services/AgentPoolService.cs
+++ b/src/JD.AI.Gateway/Services/AgentPoolService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using JD.AI.Core.Agents;
 using JD.AI.Core.Events;
 using JD.AI.Core.PromptCaching;
 using JD.AI.Core.Providers;
@@ -91,7 +92,7 @@ public sealed class AgentPoolService : IHostedService
 
         agent.History.AddUserMessage(message);
         var chat = agent.Kernel.GetRequiredService<IChatCompletionService>();
-        var settings = BuildExecutionSettings(agent.Parameters);
+        var settings = BuildExecutionSettings(agent.Parameters, agent.Provider, agent.Model);
         PromptCachePolicy.Apply(
             settings,
             agent.Provider,
@@ -142,7 +143,7 @@ public sealed class AgentPoolService : IHostedService
                 new KeyValuePair<string, object?>("gen_ai.system", agent.Provider));
 
             // Try fallback providers before giving up
-            var fallbackResult = await TryFallbackProvidersAsync(agent, settings, ct).ConfigureAwait(false);
+            var fallbackResult = await TryFallbackProvidersAsync(agent, ct).ConfigureAwait(false);
             if (fallbackResult is not null)
             {
                 content = fallbackResult;
@@ -173,7 +174,7 @@ public sealed class AgentPoolService : IHostedService
     /// response content on first success, or <c>null</c> if all fallbacks fail.
     /// </summary>
     private async Task<string?> TryFallbackProvidersAsync(
-        AgentInstance agent, OpenAIPromptExecutionSettings settings, CancellationToken ct)
+        AgentInstance agent, CancellationToken ct)
     {
         if (agent.FallbackProviders.Count == 0)
             return null;
@@ -223,8 +224,20 @@ public sealed class AgentPoolService : IHostedService
                     new GatewayEvent("agent.fallback", agent.Id, DateTimeOffset.UtcNow,
                         new { Provider = fbProvider, Model = modelInfo.Id }), ct);
 
+                var fallbackSettings = BuildExecutionSettings(
+                    agent.Parameters,
+                    fbProvider,
+                    modelInfo.Id);
+                PromptCachePolicy.Apply(
+                    fallbackSettings,
+                    fbProvider,
+                    modelInfo.Id,
+                    agent.History,
+                    enabled: true,
+                    ttl: PromptCacheTtl.FiveMinutes);
+
                 var result = await fbChat.GetChatMessageContentAsync(
-                    agent.History, settings, cancellationToken: ct).ConfigureAwait(false);
+                    agent.History, fallbackSettings, cancellationToken: ct).ConfigureAwait(false);
 
                 return result.Content ?? "";
             }
@@ -370,7 +383,10 @@ public sealed class AgentPoolService : IHostedService
     public IProviderDetector? GetDetector(string provider) =>
         _providers.GetDetector(provider);
 
-    internal static OpenAIPromptExecutionSettings BuildExecutionSettings(ModelParameters? p)
+    internal static OpenAIPromptExecutionSettings BuildExecutionSettings(
+        ModelParameters? p,
+        string? providerName = null,
+        string? modelId = null)
     {
         var settings = new OpenAIPromptExecutionSettings
         {
@@ -393,6 +409,11 @@ public sealed class AgentPoolService : IHostedService
         if (p.RepeatPenalty.HasValue) extra["repeat_penalty"] = p.RepeatPenalty.Value;
 
         if (extra.Count > 0) settings.ExtensionData = extra;
+
+        AgentLoop.ApplyReasoningEffort(
+            settings,
+            new ProviderModelInfo(modelId ?? "unknown", modelId ?? "unknown", providerName ?? "unknown"),
+            p.ReasoningEffort);
 
         return settings;
     }

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -3502,6 +3502,10 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             MaxTokens = 2200,
             Temperature = 0.1,
         };
+        AgentLoop.ApplyReasoningEffort(
+            settings,
+            _session.CurrentModel,
+            _session.ReasoningEffortOverride);
         PromptCachePolicy.Apply(
             settings,
             _session.CurrentModel,

--- a/tests/JD.AI.Gateway.Tests/ConfigWriteEndpointTests.cs
+++ b/tests/JD.AI.Gateway.Tests/ConfigWriteEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
 using JD.AI.Gateway.Config;
+using CoreReasoningEffort = JD.AI.Core.Agents.ReasoningEffort;
 
 namespace JD.AI.Gateway.Tests;
 
@@ -116,6 +117,7 @@ public sealed class ConfigWriteEndpointTests : IClassFixture<GatewayTestFactory>
                     RepeatPenalty = 1.2,
                     Seed = 42,
                     StopSequences = ["<|end|>"],
+                    ReasoningEffort = CoreReasoningEffort.Low,
                 }
             }
         };

--- a/tests/JD.AI.Gateway.Tests/ModelParametersTests.cs
+++ b/tests/JD.AI.Gateway.Tests/ModelParametersTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using JD.AI.Gateway.Config;
 using JD.AI.Gateway.Services;
+using CoreReasoningEffort = JD.AI.Core.Agents.ReasoningEffort;
 
 namespace JD.AI.Gateway.Tests;
 
@@ -165,6 +166,34 @@ public sealed class ModelParametersTests
     }
 
     [Fact]
+    public void BuildExecutionSettings_ReasoningEffort_OpenAiProvider_MapsReasoningEffort()
+    {
+        var p = new ModelParameters { ReasoningEffort = CoreReasoningEffort.Max };
+
+        var settings = AgentPoolService.BuildExecutionSettings(
+            p, providerName: "OpenAI", modelId: "o3-mini");
+
+        settings.ExtensionData.Should().ContainKey("reasoning_effort");
+        settings.ExtensionData!["reasoning_effort"].Should().Be("xhigh");
+    }
+
+    [Fact]
+    public void BuildExecutionSettings_ReasoningEffort_AnthropicProvider_MapsOutputConfig()
+    {
+        var p = new ModelParameters { ReasoningEffort = CoreReasoningEffort.High };
+
+        var settings = AgentPoolService.BuildExecutionSettings(
+            p, providerName: "Anthropic", modelId: "claude-sonnet-4-6");
+
+        settings.ExtensionData.Should().ContainKey("thinking");
+        settings.ExtensionData.Should().ContainKey("output_config");
+        settings.ExtensionData!["output_config"]
+            .Should().BeOfType<Dictionary<string, object>>();
+        var outputConfig = (Dictionary<string, object>)settings.ExtensionData["output_config"];
+        outputConfig["effort"].Should().Be("high");
+    }
+
+    [Fact]
     public void BuildExecutionSettings_FullConfig_AllFieldsMapped()
     {
         var p = new ModelParameters
@@ -209,6 +238,7 @@ public sealed class ModelParametersTests
         p.PresencePenalty.Should().BeNull();
         p.RepeatPenalty.Should().BeNull();
         p.Seed.Should().BeNull();
+        p.ReasoningEffort.Should().BeNull();
         p.StopSequences.Should().BeEmpty();
     }
 

--- a/tests/JD.AI.Tests/Agents/Orchestration/SingleTurnExecutorTests.cs
+++ b/tests/JD.AI.Tests/Agents/Orchestration/SingleTurnExecutorTests.cs
@@ -661,6 +661,34 @@ public sealed class SingleTurnExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithReasoningEffortOverride_MapsProviderReasoningSettings()
+    {
+        PromptExecutionSettings? capturedSettings = null;
+        var svc = Substitute.For<IChatCompletionService>();
+        svc.GetStreamingChatMessageContentsAsync(
+                Arg.Any<ChatHistory>(),
+                Arg.Do<PromptExecutionSettings>(s => capturedSettings = s),
+                Arg.Any<Kernel>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Chunks("ok"));
+
+        var model = new ProviderModelInfo("claude-sonnet-4-6", "Claude Sonnet 4.6", "Anthropic");
+        var session = SessionWithChatService(svc, model);
+        session.ReasoningEffortOverride = ReasoningEffort.Max;
+        var sut = new SingleTurnExecutor();
+
+        await sut.ExecuteAsync(Cfg(), session);
+
+        var openAiSettings = capturedSettings as Microsoft.SemanticKernel.Connectors.OpenAI.OpenAIPromptExecutionSettings;
+        openAiSettings.Should().NotBeNull();
+        openAiSettings!.ExtensionData.Should().ContainKey("output_config");
+        openAiSettings.ExtensionData!["output_config"]
+            .Should().BeOfType<Dictionary<string, object>>();
+        var outputConfig = (Dictionary<string, object>)openAiSettings.ExtensionData["output_config"];
+        outputConfig["effort"].Should().Be("max");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ModelMaxOutputTokensZero_DefaultsTo4096()
     {
         PromptExecutionSettings? capturedSettings = null;


### PR DESCRIPTION
## Summary
- add ModelParameters.ReasoningEffort to gateway config and apply it when building execution settings
- propagate reasoning effort mapping into auxiliary execution paths (subagent runner, single-turn and multi-turn executors, and tool-calling retry settings)
- apply session reasoning override to /review model analysis calls
- document /reasoning and updated /model search filter syntax in command docs
- add regression tests for gateway reasoning mapping and subagent settings propagation

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ""FullyQualifiedName~BuildExecutionSettingsTests|FullyQualifiedName~SingleTurnExecutorTests"" --nologo -m:1
- dotnet test tests/JD.AI.Gateway.Tests/JD.AI.Gateway.Tests.csproj --configuration Release --filter ""FullyQualifiedName~ModelParametersTests|FullyQualifiedName~ConfigWriteEndpointTests|FullyQualifiedName~DashboardModelIntegrationTests"" --nologo -m:1
- dotnet build JD.AI.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true

Closes #310