### PR TITLE
feat: add multiline thinking tree rendering in progress UI

### DIFF
--- a/src/JD.AI/Rendering/SpectreAgentOutput.cs
+++ b/src/JD.AI/Rendering/SpectreAgentOutput.cs
@@ -16,7 +16,9 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
     private TurnProgress? _progress;
     private readonly StringBuilder _thinkingBuffer = new();
     private readonly List<string> _thinkingSteps = [];
+    private readonly Queue<string> _thinkingDetails = new();
     private string? _lastThinkingDetail;
+    private int _thinkingTokenCount;
 
     public SpectreAgentOutput(SpinnerStyle style = SpinnerStyle.Normal, string? modelName = null)
     {
@@ -92,7 +94,9 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
     {
         _thinkingBuffer.Clear();
         _thinkingSteps.Clear();
+        _thinkingDetails.Clear();
         _lastThinkingDetail = null;
+        _thinkingTokenCount = 0;
         _progress = new TurnProgress(Style, ModelName);
     }
 
@@ -123,8 +127,10 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
         }
 
         _thinkingBuffer.Append(text);
+        _thinkingTokenCount += JD.SemanticKernel.Extensions.Compaction.TokenEstimator.EstimateTokens(text);
         UpdateThinkingSignals(text);
         _progress?.SetThinkingPreview(GetLiveThinkingPreview());
+        _progress?.SetThinkingTokenCount(_thinkingTokenCount);
     }
 
     public void EndThinking()
@@ -186,6 +192,7 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
                     !string.Equals(_thinkingSteps[^1], step, StringComparison.OrdinalIgnoreCase))
                 {
                     _thinkingSteps.Add(step);
+                    _thinkingDetails.Clear();
                 }
 
                 _lastThinkingDetail = step;
@@ -193,6 +200,13 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
             else
             {
                 _lastThinkingDetail = compact;
+                if (_thinkingDetails.Count == 0 ||
+                    !string.Equals(_thinkingDetails.Last(), compact, StringComparison.OrdinalIgnoreCase))
+                {
+                    _thinkingDetails.Enqueue(compact);
+                    if (_thinkingDetails.Count > 2)
+                        _thinkingDetails.Dequeue();
+                }
             }
         }
     }
@@ -205,24 +219,39 @@ internal sealed class SpectreAgentOutput : IAgentOutput, IDisposable
         if (Style == SpinnerStyle.Normal)
             return _lastThinkingDetail;
 
-        if (_thinkingSteps.Count == 0)
-            return _lastThinkingDetail;
+        var lines = new List<string>(6);
 
-        var step = _thinkingSteps[^1];
-        if (string.IsNullOrWhiteSpace(_lastThinkingDetail) ||
-            string.Equals(step, _lastThinkingDetail, StringComparison.OrdinalIgnoreCase))
+        var completedCount = Math.Max(0, _thinkingSteps.Count - 1);
+        var completedStart = Math.Max(0, completedCount - 3);
+        for (var i = completedStart; i < completedCount; i++)
         {
-            return $"▶ {step}";
+            lines.Add($"✔ {_thinkingSteps[i]}");
         }
 
-        return $"▶ {step} | {_lastThinkingDetail}";
+        if (_thinkingSteps.Count > 0)
+        {
+            lines.Add($"▶ {_thinkingSteps[^1]}");
+        }
+
+        var details = _thinkingDetails.ToArray();
+        var detailStart = Math.Max(0, details.Length - 2);
+        for (var i = detailStart; i < details.Length; i++)
+        {
+            var detail = TrimForSummary(details[i], 96);
+            lines.Add($"│ {detail}");
+        }
+
+        if (lines.Count == 0 && !string.IsNullOrWhiteSpace(_lastThinkingDetail))
+            lines.Add($"│ {TrimForSummary(_lastThinkingDetail, 96)}");
+
+        return lines.Count == 0 ? null : string.Join('\n', lines);
     }
 
     private string? BuildThinkingSummary()
     {
         if (_thinkingSteps.Count > 0)
         {
-            var joined = string.Join(" -> ", _thinkingSteps.Take(4));
+            var joined = string.Join(" → ", _thinkingSteps.Take(4));
             return TrimForSummary(joined, 140);
         }
 

--- a/src/JD.AI/Rendering/TurnProgress.cs
+++ b/src/JD.AI/Rendering/TurnProgress.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using JD.AI.Core.Config;
 
 namespace JD.AI.Rendering;
@@ -17,10 +18,13 @@ internal sealed class TurnProgress : IDisposable
     private readonly string? _modelName;
     private readonly Stopwatch _sw = Stopwatch.StartNew();
     private readonly Timer _timer;
+    private readonly System.Threading.Lock _renderLock = new();
     private int _frame;
+    private int _renderedLineCount;
     private volatile bool _stopped;
     private volatile bool _paused;
     private volatile string? _thinkingPreview;
+    private volatile int _thinkingTokenCount;
 
     /// <summary>Elapsed milliseconds when the spinner was stopped (first content arrived).</summary>
     public long TimeToFirstTokenMs { get; private set; } = -1;
@@ -57,8 +61,12 @@ internal sealed class TurnProgress : IDisposable
 
         try
         {
-            // Clear the line and write new content
-            Console.Write($"\x1b[2K\r{line}");
+            lock (_renderLock)
+            {
+                ClearRenderedBlockNoLock();
+                Console.Write(line);
+                _renderedLineCount = CountRenderedLines(line);
+            }
         }
         catch (ObjectDisposedException)
         {
@@ -77,7 +85,10 @@ internal sealed class TurnProgress : IDisposable
 
         try
         {
-            Console.Write("\x1b[2K\r");
+            lock (_renderLock)
+            {
+                ClearRenderedBlockNoLock();
+            }
         }
         catch (ObjectDisposedException)
         {
@@ -97,7 +108,10 @@ internal sealed class TurnProgress : IDisposable
 
         try
         {
-            Console.Write("\x1b[2K\r");
+            lock (_renderLock)
+            {
+                ClearRenderedBlockNoLock();
+            }
         }
         catch (ObjectDisposedException)
         {
@@ -124,7 +138,22 @@ internal sealed class TurnProgress : IDisposable
             return;
         }
 
-        _thinkingPreview = preview.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        var normalized = preview
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var lines = normalized
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+
+        _thinkingPreview = lines.Count == 0
+            ? null
+            : string.Join('\n', lines);
+    }
+
+    /// <summary>Updates thinking token count shown in Nerdy mode.</summary>
+    public void SetThinkingTokenCount(int tokens)
+    {
+        _thinkingTokenCount = Math.Max(0, tokens);
     }
 
     public void Dispose()
@@ -146,7 +175,8 @@ internal sealed class TurnProgress : IDisposable
     {
         var spinner = BrailleFrames[_frame++ % BrailleFrames.Length];
         var core = $"  \x1b[36m{spinner}\x1b[0m Thinking... \x1b[2m{FormatElapsed(elapsed)}\x1b[0m";
-        return AppendPreview(core, _thinkingPreview, 96);
+        var preview = GetLastPreviewLine();
+        return AppendPreview(core, preview, 96, multiline: false);
     }
 
     internal string FormatRich(TimeSpan elapsed)
@@ -155,7 +185,7 @@ internal sealed class TurnProgress : IDisposable
         var bar = BuildProgressBar(elapsed);
         var core = $"  \x1b[36m{spinner}\x1b[0m Thinking \x1b[2m{bar}\x1b[0m " +
                    $"\x1b[2m{FormatElapsed(elapsed)}\x1b[0m";
-        return AppendPreview(core, _thinkingPreview, 120);
+        return AppendPreview(core, _thinkingPreview, 120, multiline: true);
     }
 
     internal string FormatNerdy(TimeSpan elapsed)
@@ -165,9 +195,10 @@ internal sealed class TurnProgress : IDisposable
         var model = !string.IsNullOrEmpty(_modelName)
             ? $" │ \x1b[33m{_modelName}\x1b[0m"
             : "";
+        var thinkTokens = _thinkingTokenCount >= 0 ? _thinkingTokenCount : 0;
         var core = $"  \x1b[36m{spinner}\x1b[0m Thinking \x1b[2m{bar}\x1b[0m " +
-                   $"\x1b[2m{FormatElapsed(elapsed)}{model} │ awaiting first token\x1b[0m";
-        return AppendPreview(core, _thinkingPreview, 140);
+                   $"\x1b[2m{FormatElapsed(elapsed)}{model} │ {thinkTokens} think-tok\x1b[0m";
+        return AppendPreview(core, _thinkingPreview, 140, multiline: true);
     }
 
     internal static string BuildProgressBar(TimeSpan elapsed)
@@ -189,15 +220,82 @@ internal sealed class TurnProgress : IDisposable
             ? $"{ts.Minutes}m {ts.Seconds:D2}s"
             : $"{ts.TotalSeconds:F1}s";
 
-    private static string AppendPreview(string core, string? preview, int maxChars)
+    private void ClearRenderedBlockNoLock()
+    {
+        if (_renderedLineCount <= 0)
+            return;
+
+        for (var i = 0; i < _renderedLineCount - 1; i++)
+        {
+            Console.Write("\x1b[2K\r\x1b[1A");
+        }
+
+        Console.Write("\x1b[2K\r");
+        _renderedLineCount = 0;
+    }
+
+    private static int CountRenderedLines(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return 0;
+
+        var lines = 1;
+        foreach (var c in text)
+        {
+            if (c == '\n')
+                lines++;
+        }
+
+        return lines;
+    }
+
+    private string? GetLastPreviewLine()
+    {
+        if (string.IsNullOrWhiteSpace(_thinkingPreview))
+            return null;
+
+        var normalized = _thinkingPreview
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var lines = normalized
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return lines.Length == 0 ? null : lines[^1];
+    }
+
+    private static string AppendPreview(string core, string? preview, int maxChars, bool multiline)
     {
         if (string.IsNullOrWhiteSpace(preview))
             return core;
 
-        var compact = preview.Trim();
-        if (compact.Length > maxChars)
-            compact = string.Concat(compact.AsSpan(0, maxChars - 3), "...");
+        var normalized = preview
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+        var lines = normalized
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
 
-        return $"{core} \x1b[2m│ {compact}\x1b[0m";
+        if (lines.Count == 0)
+            return core;
+
+        if (!multiline || lines.Count == 1)
+        {
+            var compact = lines[0];
+            if (compact.Length > maxChars)
+                compact = string.Concat(compact.AsSpan(0, maxChars - 3), "...");
+
+            return $"{core} \x1b[2m│ {compact}\x1b[0m";
+        }
+
+        var sb = new StringBuilder(core);
+        foreach (var line in lines.Take(4))
+        {
+            var compact = line;
+            if (compact.Length > maxChars)
+                compact = string.Concat(compact.AsSpan(0, maxChars - 3), "...");
+            sb.Append('\n').Append("  \x1b[2m").Append(compact).Append("\x1b[0m");
+        }
+
+        return sb.ToString();
     }
 }

--- a/tests/JD.AI.Tests/Rendering/TurnProgressTests.cs
+++ b/tests/JD.AI.Tests/Rendering/TurnProgressTests.cs
@@ -100,9 +100,10 @@ public sealed class TurnProgressTests : IDisposable
     public void FormatNerdy_ContainsModelName()
     {
         using var progress = new TurnProgress(SpinnerStyle.Nerdy, "gpt-4o");
+        progress.SetThinkingTokenCount(42);
         var result = progress.FormatNerdy(TimeSpan.FromSeconds(3));
         result.Should().Contain("gpt-4o");
-        result.Should().Contain("awaiting first token");
+        result.Should().Contain("42 think-tok");
     }
 
     [Fact]
@@ -122,6 +123,19 @@ public sealed class TurnProgressTests : IDisposable
         progress.SetThinkingPreview(longText);
         var result = progress.FormatRich(TimeSpan.FromSeconds(1));
         result.Should().Contain("...");
+    }
+
+    [Fact]
+    public void FormatRich_WithMultilinePreview_RendersMultipleLines()
+    {
+        using var progress = new TurnProgress(SpinnerStyle.Rich);
+        progress.SetThinkingPreview("✔ Step 1\n▶ Step 2\n│ detail");
+
+        var result = progress.FormatRich(TimeSpan.FromSeconds(1));
+
+        result.Should().Contain("\n");
+        result.Should().Contain("✔ Step 1");
+        result.Should().Contain("▶ Step 2");
     }
 
     // ── State transitions ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- implement multiline thinking-tree preview rendering for rich/nerdy spinner styles (completed + current step rows and detail lines)
- switch TurnProgress redraw behavior to clear/rewrite a full multiline block in place each tick
- add nerdy-mode thinking token counter (	hink-tok) and feed counts from streamed thinking chunks
- keep normal style on single-line preview while rich/nerdy use the structured tree format

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ""FullyQualifiedName~TurnProgressTests|FullyQualifiedName~TurnProgressBddTests|FullyQualifiedName~SpectreAgentOutputBddTests"" --nologo -m:1
- dotnet build JD.AI.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true

Closes #312