### PR TITLE
feat: improve model picker filtering and catalog-backed search

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -55,6 +55,7 @@ Supports optional filters:
 
 ```text
 /model search --provider openrouter --cap reasoning --sort cost llama
+/model search --sort popularity gpt
 ```
 
 ### `/model url <url>`

--- a/docs/user-guide/commands.md
+++ b/docs/user-guide/commands.md
@@ -57,6 +57,7 @@ Checks:
 /model gpt-4o
 /model search llama 70b
 /model search --provider openrouter --cap reasoning --sort cost llama
+/model search --sort popularity gpt
 /reasoning high
 /providers
 /provider add openai

--- a/src/JD.AI.Core/Providers/Metadata/ModelMetadataProvider.cs
+++ b/src/JD.AI.Core/Providers/Metadata/ModelMetadataProvider.cs
@@ -86,6 +86,18 @@ public sealed class ModelMetadataProvider
     }
 
     /// <summary>
+    /// Returns a copy of the currently loaded metadata entries keyed by LiteLLM model key.
+    /// Returns an empty dictionary when metadata has not been loaded.
+    /// </summary>
+    public IReadOnlyDictionary<string, ModelMetadataEntry> GetEntriesSnapshot()
+    {
+        if (_entries is null || _entries.Count == 0)
+            return new Dictionary<string, ModelMetadataEntry>(StringComparer.Ordinal);
+
+        return new Dictionary<string, ModelMetadataEntry>(_entries, StringComparer.Ordinal);
+    }
+
+    /// <summary>
     /// Enriches a list of models with metadata from the loaded catalog.
     /// Unmatched models are returned unchanged.
     /// </summary>

--- a/src/JD.AI/Commands/SlashCommandRouter.cs
+++ b/src/JD.AI/Commands/SlashCommandRouter.cs
@@ -355,6 +355,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             m => $"{m.ProviderName}|{m.Id}",
             m => m,
             StringComparer.OrdinalIgnoreCase);
+        var modelInfoMap = new Dictionary<string, ProviderModelInfo>(installedMap, StringComparer.OrdinalIgnoreCase);
 
         var results = installedMatches
             .Select(m => new RemoteModelResult(
@@ -366,6 +367,23 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                 null,
                 m.Capabilities))
             .ToList();
+        var resultKeys = new HashSet<string>(
+            results.Select(r => $"{r.ProviderName}|{r.Id}"),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var catalog in await SearchMetadataCatalogAsync(options, ct).ConfigureAwait(false))
+        {
+            var key = $"{catalog.Result.ProviderName}|{catalog.Result.Id}";
+            if (resultKeys.Add(key))
+            {
+                results.Add(catalog.Result);
+            }
+
+            if (!modelInfoMap.ContainsKey(key))
+            {
+                modelInfoMap[key] = catalog.ModelInfo;
+            }
+        }
 
         if (_modelSearchAggregator is not null && !string.IsNullOrWhiteSpace(options.Query))
         {
@@ -378,8 +396,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                         continue;
 
                     var key = $"{remote.ProviderName}|{remote.Id}";
-                    if (!installedMap.ContainsKey(key) &&
-                        results.All(r => !string.Equals($"{r.ProviderName}|{r.Id}", key, StringComparison.OrdinalIgnoreCase)))
+                    if (resultKeys.Add(key))
                     {
                         results.Add(remote);
                     }
@@ -395,7 +412,7 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         if (results.Count == 0)
             return $"No models found for '{options.Query}'.";
 
-        results = SortModelSearchResults(results, installedMap, options.Sort);
+        results = SortModelSearchResults(results, modelInfoMap, options.Sort);
 
         // Display results table
         var table = new Table()
@@ -417,12 +434,13 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
 
         foreach (var r in results)
         {
-            installedMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var installed);
+            modelInfoMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var modelInfo);
             var statusMarkup = r.Status switch
             {
                 "Installed" => "[green]Installed[/]",
                 "Available" or "Pull" => $"[yellow]{Markup.Escape(r.Status)}[/]",
                 "Download" => "[blue]Download[/]",
+                "Catalog" => "[grey]Catalog[/]",
                 _ => Markup.Escape(r.Status),
             };
 
@@ -430,9 +448,9 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
                 Markup.Escape(r.ProviderName),
                 Markup.Escape(r.DisplayName),
                 r.Capabilities.ToBadge(),
-                installed is null ? "-" : installed.ContextWindowTokens.ToString("N0"),
-                installed is { HasMetadata: true }
-                    ? $"${installed.InputCostPerToken}/{installed.OutputCostPerToken}"
+                modelInfo is null ? "-" : modelInfo.ContextWindowTokens.ToString("N0"),
+                modelInfo is { HasMetadata: true }
+                    ? $"${modelInfo.InputCostPerToken}/{modelInfo.OutputCostPerToken}"
                     : "-",
                 statusMarkup);
         }
@@ -459,6 +477,10 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
             return "Model search cancelled.";
         }
         catch (InvalidOperationException)
+        {
+            return "Model search cancelled.";
+        }
+        catch (NotSupportedException)
         {
             return "Model search cancelled.";
         }
@@ -494,13 +516,17 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         string? Capability,
         string Sort);
 
+    private sealed record CatalogSearchResult(
+        RemoteModelResult Result,
+        ProviderModelInfo ModelInfo);
+
     private static bool TryParseModelSearchOptions(
         string raw,
         out ModelSearchOptions options,
         out string error)
     {
         options = new ModelSearchOptions(string.Empty, null, null, "name");
-        error = "Usage: /model search [--provider <name>] [--cap <chat|tools|vision|embeddings|reasoning>] [--sort <name|context|cost>] <query>";
+        error = "Usage: /model search [--provider <name>] [--cap <chat|tools|vision|embeddings|reasoning>] [--sort <name|context|cost|popularity>] <query>";
 
         if (string.IsNullOrWhiteSpace(raw))
             return false;
@@ -542,9 +568,9 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         if (string.IsNullOrWhiteSpace(query))
             return false;
 
-        if (sort is not ("name" or "context" or "cost"))
+        if (sort is not ("name" or "context" or "cost" or "popularity"))
         {
-            error = "Sort must be one of: name, context, cost.";
+            error = "Sort must be one of: name, context, cost, popularity.";
             return false;
         }
 
@@ -616,25 +642,130 @@ public sealed class SlashCommandRouter : ISlashCommandRouter
         };
     }
 
+    private async Task<IReadOnlyList<CatalogSearchResult>> SearchMetadataCatalogAsync(
+        ModelSearchOptions options,
+        CancellationToken ct)
+    {
+        if (_metadataProvider is null || string.IsNullOrWhiteSpace(options.Query))
+            return [];
+
+        if (!_metadataProvider.IsLoaded)
+        {
+            await _metadataProvider.LoadAsync(ct: ct).ConfigureAwait(false);
+        }
+
+        var entries = _metadataProvider.GetEntriesSnapshot();
+        if (entries.Count == 0)
+            return [];
+
+        var results = new List<CatalogSearchResult>();
+        foreach (var (key, entry) in entries)
+        {
+            var providerToken = ResolveCatalogProviderToken(entry, key);
+            var providerName = ToDisplayProviderName(providerToken);
+            var modelId = StripProviderPrefix(key, providerToken);
+            var capabilities = ToCapabilities(entry);
+
+            var candidate = new RemoteModelResult(
+                modelId,
+                modelId,
+                providerName,
+                null,
+                "Catalog",
+                null,
+                capabilities);
+
+            if (MatchesRemoteSearch(candidate, options))
+            {
+                results.Add(new CatalogSearchResult(
+                    candidate,
+                    new ProviderModelInfo(
+                        modelId,
+                        modelId,
+                        providerName,
+                        ContextWindowTokens: entry.MaxInputTokens ?? 128_000,
+                        MaxOutputTokens: entry.MaxOutputTokens ?? 16_384,
+                        InputCostPerToken: entry.InputCostPerToken ?? 0m,
+                        OutputCostPerToken: entry.OutputCostPerToken ?? 0m,
+                        HasMetadata: true,
+                        Capabilities: capabilities)));
+            }
+        }
+
+        return results;
+    }
+
+    private static string ResolveCatalogProviderToken(ModelMetadataEntry entry, string key)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.LitellmProvider))
+            return entry.LitellmProvider!;
+
+        var slash = key.IndexOf('/', StringComparison.Ordinal);
+        return slash > 0 ? key[..slash] : "unknown";
+    }
+
+    private static string StripProviderPrefix(string key, string providerToken)
+    {
+        if (!string.IsNullOrWhiteSpace(providerToken) &&
+            key.StartsWith(providerToken + "/", StringComparison.OrdinalIgnoreCase))
+        {
+            return key[(providerToken.Length + 1)..];
+        }
+
+        return key;
+    }
+
+    private static string ToDisplayProviderName(string providerToken) => providerToken.ToLowerInvariant() switch
+    {
+        "openai" => "OpenAI",
+        "openrouter" => "OpenRouter",
+        "azure" or "azure_ai" => "Azure OpenAI",
+        "anthropic" => "Anthropic",
+        "gemini" or "google" or "vertex_ai" => "Google Gemini",
+        "bedrock" or "bedrock_converse" => "Amazon Bedrock",
+        "huggingface" => "HuggingFace",
+        "mistral" => "Mistral",
+        "ollama" => "Ollama",
+        "foundrylocal" or "foundry_local" => "Foundry Local",
+        _ => providerToken,
+    };
+
+    private static ModelCapabilities ToCapabilities(ModelMetadataEntry entry)
+    {
+        var caps = ModelCapabilities.Chat;
+
+        if (entry.SupportsFunctionCalling is true)
+            caps |= ModelCapabilities.ToolCalling;
+        if (entry.SupportsVision is true)
+            caps |= ModelCapabilities.Vision;
+
+        return caps;
+    }
+
     private static List<RemoteModelResult> SortModelSearchResults(
         IEnumerable<RemoteModelResult> results,
-        Dictionary<string, ProviderModelInfo> installedMap,
+        Dictionary<string, ProviderModelInfo> modelInfoMap,
         string sort)
     {
         return sort switch
         {
             "context" => results
-                .OrderByDescending(r => installedMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var m)
+                .OrderByDescending(r => modelInfoMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var m)
                     ? m.ContextWindowTokens : 0)
                 .ThenBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
                 .ToList(),
             "cost" => results
                 .OrderBy(r =>
                 {
-                    if (!installedMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var model) || !model.HasMetadata)
+                    if (!modelInfoMap.TryGetValue($"{r.ProviderName}|{r.Id}", out var model) || !model.HasMetadata)
                         return decimal.MaxValue;
                     return model.InputCostPerToken + model.OutputCostPerToken;
                 })
+                .ThenBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            "popularity" => results
+                .OrderByDescending(r => r.Status.Equals("Installed", StringComparison.OrdinalIgnoreCase))
+                .ThenBy(r => r.DisplayName.Length)
                 .ThenBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
                 .ToList(),
             _ => results

--- a/src/JD.AI/Rendering/ModelPicker.cs
+++ b/src/JD.AI/Rendering/ModelPicker.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using JD.AI.Core.Providers;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace JD.AI.Rendering;
 
@@ -10,6 +11,9 @@ namespace JD.AI.Rendering;
 [ExcludeFromCodeCoverage]
 internal static class ModelPicker
 {
+    private const int FilterActivationThreshold = 20;
+    private const int PageSize = 20;
+
     /// <summary>
     /// Displays an interactive scrollable model list and returns the selected model,
     /// or null if the user cancels or no models are available.
@@ -24,6 +28,22 @@ internal static class ModelPicker
             return null;
         }
 
+        var ordered = OrderModels(models, currentModel);
+
+        if (ordered.Count > FilterActivationThreshold &&
+            !Console.IsInputRedirected &&
+            !Console.IsOutputRedirected)
+        {
+            return PickWithFilter(ordered, currentModel);
+        }
+
+        return PickWithSelectionPrompt(ordered, currentModel);
+    }
+
+    private static ProviderModelInfo? PickWithSelectionPrompt(
+        List<ProviderModelInfo> models,
+        ProviderModelInfo? currentModel)
+    {
         // Group models by provider for readability
         var grouped = models
             .GroupBy(m => m.ProviderName)
@@ -76,4 +96,204 @@ internal static class ModelPicker
             return null;
         }
     }
+
+    private static ProviderModelInfo? PickWithFilter(
+        List<ProviderModelInfo> models,
+        ProviderModelInfo? currentModel)
+    {
+        var filter = string.Empty;
+        var selectedIndex = 0;
+        ProviderModelInfo? selected = null;
+        var done = false;
+
+        try
+        {
+            AnsiConsole.Live(RenderFilterView(models, filter, selectedIndex, currentModel))
+                .Overflow(VerticalOverflow.Crop)
+                .Start(ctx =>
+                {
+                    while (!done)
+                    {
+                        var filtered = ApplyFilter(models, filter);
+                        if (filtered.Count == 0)
+                        {
+                            selectedIndex = 0;
+                        }
+                        else
+                        {
+                            selectedIndex = Math.Clamp(selectedIndex, 0, filtered.Count - 1);
+                        }
+
+                        var key = Console.ReadKey(intercept: true);
+                        switch (key.Key)
+                        {
+                            case ConsoleKey.UpArrow:
+                                if (filtered.Count > 0)
+                                    selectedIndex = (selectedIndex - 1 + filtered.Count) % filtered.Count;
+                                break;
+                            case ConsoleKey.DownArrow:
+                                if (filtered.Count > 0)
+                                    selectedIndex = (selectedIndex + 1) % filtered.Count;
+                                break;
+                            case ConsoleKey.PageUp:
+                                selectedIndex = Math.Max(0, selectedIndex - PageSize);
+                                break;
+                            case ConsoleKey.PageDown:
+                                if (filtered.Count > 0)
+                                    selectedIndex = Math.Min(filtered.Count - 1, selectedIndex + PageSize);
+                                break;
+                            case ConsoleKey.Backspace:
+                                if (filter.Length > 0)
+                                {
+                                    filter = filter[..^1];
+                                    selectedIndex = 0;
+                                }
+                                break;
+                            case ConsoleKey.Escape:
+                                if (filter.Length > 0)
+                                {
+                                    filter = string.Empty;
+                                    selectedIndex = 0;
+                                }
+                                else
+                                {
+                                    done = true;
+                                }
+                                break;
+                            case ConsoleKey.Enter:
+                                if (filtered.Count > 0)
+                                {
+                                    selected = filtered[selectedIndex];
+                                    done = true;
+                                }
+                                break;
+                            default:
+                                if (!char.IsControl(key.KeyChar))
+                                {
+                                    filter += key.KeyChar;
+                                    selectedIndex = 0;
+                                }
+                                break;
+                        }
+
+                        if (!done)
+                        {
+                            var clamped = ApplyFilter(models, filter).Count == 0 ? 0 : selectedIndex;
+                            ctx.UpdateTarget(RenderFilterView(models, filter, clamped, currentModel));
+                            ctx.Refresh();
+                        }
+                    }
+                });
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+
+        return selected;
+    }
+
+    private static IReadOnlyList<ProviderModelInfo> ApplyFilter(
+        IReadOnlyList<ProviderModelInfo> models,
+        string filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+            return models;
+
+        return models
+            .Where(m =>
+                m.Id.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                m.DisplayName.Contains(filter, StringComparison.OrdinalIgnoreCase) ||
+                m.ProviderName.Contains(filter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static Panel RenderFilterView(
+        IReadOnlyList<ProviderModelInfo> allModels,
+        string filter,
+        int selectedIndex,
+        ProviderModelInfo? currentModel)
+    {
+        var filtered = ApplyFilter(allModels, filter);
+        if (filtered.Count > 0)
+            selectedIndex = Math.Clamp(selectedIndex, 0, filtered.Count - 1);
+        else
+            selectedIndex = 0;
+
+        var start = filtered.Count <= PageSize
+            ? 0
+            : Math.Clamp(selectedIndex - (PageSize / 2), 0, filtered.Count - PageSize);
+
+        var visible = filtered.Skip(start).Take(PageSize).ToList();
+        var previousCount = start;
+        var moreCount = Math.Max(0, filtered.Count - (start + visible.Count));
+
+        var rows = new List<IRenderable>
+        {
+            new Markup("[bold]Select a model[/] [dim](type to filter, ↑/↓ move, Enter select, Esc clear/cancel)[/]"),
+            new Markup($"[grey]Filter:[/] [yellow]{Markup.Escape(filter)}[/]"),
+            new Markup($"[dim]({filtered.Count} models matching)[/]"),
+        };
+
+        if (filtered.Count == 0)
+        {
+            rows.Add(new Markup("[yellow]No models found — try a different search term.[/]"));
+            return new Panel(new Rows(rows)).Border(BoxBorder.Rounded);
+        }
+
+        if (previousCount > 0)
+            rows.Add(new Markup($"[dim]({previousCount} previous {Pluralize("model", previousCount)})[/]"));
+
+        for (var i = 0; i < visible.Count; i++)
+        {
+            var model = visible[i];
+            var absoluteIndex = start + i;
+            var isSelected = absoluteIndex == selectedIndex;
+            var isActive = currentModel is not null &&
+                           string.Equals(model.Id, currentModel.Id, StringComparison.Ordinal);
+            var prefix = isSelected ? "[aqua]>[/]" : " ";
+            var badge = model.Capabilities.ToBadge();
+            var active = isActive ? " [green](active)[/]" : string.Empty;
+            var line = $"{prefix} {badge} [dim][[{Markup.Escape(model.ProviderName)}]][/] {Markup.Escape(model.DisplayName)}{active}";
+            rows.Add(new Markup(line));
+        }
+
+        if (moreCount > 0)
+            rows.Add(new Markup($"[dim]({moreCount} more {Pluralize("model", moreCount)})[/]"));
+
+        return new Panel(new Rows(rows)).Border(BoxBorder.Rounded);
+    }
+
+    private static List<ProviderModelInfo> OrderModels(
+        IReadOnlyList<ProviderModelInfo> models,
+        ProviderModelInfo? currentModel)
+    {
+        var grouped = models
+            .GroupBy(m => m.ProviderName)
+            .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (currentModel != null)
+        {
+            var currentGroup = grouped.FirstOrDefault(g =>
+                string.Equals(g.Key, currentModel.ProviderName, StringComparison.Ordinal));
+
+            if (currentGroup != null)
+            {
+                grouped.Remove(currentGroup);
+                grouped.Insert(0, currentGroup);
+            }
+        }
+
+        return grouped
+            .SelectMany(g => g.OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+    }
+
+    private static string Pluralize(string noun, int count) =>
+        count == 1 ? noun : noun + "s";
 }

--- a/tests/JD.AI.Tests/Commands/SlashCommandRouterBddTests.cs
+++ b/tests/JD.AI.Tests/Commands/SlashCommandRouterBddTests.cs
@@ -4,6 +4,7 @@ using JD.AI.Core.Agents;
 using JD.AI.Core.Agents.Checkpointing;
 using JD.AI.Core.Config;
 using JD.AI.Core.Providers;
+using JD.AI.Core.Providers.Metadata;
 using JD.AI.Workflows;
 using JD.AI.Workflows.Store;
 using Microsoft.Extensions.DependencyInjection;
@@ -1350,4 +1351,64 @@ public sealed class SlashCommandRouterBddTests : TinyBddXunitBase
 
         result.Should().Contain("No models found");
     }
+
+    // ── 59. /model search accepts popularity sort ───────────
+
+    [Scenario("Model search with popularity sort is accepted"), Fact]
+    public async Task ModelSearchPopularitySortIsAccepted()
+    {
+        _registry.GetModelsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ProviderModelInfo>>(
+            [
+                new ProviderModelInfo("gpt-4.1", "GPT-4.1", "OpenAI"),
+            ]));
+
+        var router = CreateRouter();
+
+        var result = await router.ExecuteAsync("/model search --sort popularity gpt");
+
+        result.Should().NotContain("Sort must be one of");
+    }
+
+    // ── 60. /model search includes LiteLLM catalog matches ──
+
+    [Scenario("Model search falls back to LiteLLM metadata catalog"), Fact]
+    public async Task ModelSearchUsesLiteLlmCatalog()
+    {
+        _registry.GetModelsAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ProviderModelInfo>>([]));
+
+        const string metadataJson = """
+            {
+              "openrouter/meta-llama/llama-3.1-8b-instruct": {
+                "litellm_provider": "openrouter",
+                "mode": "chat",
+                "max_input_tokens": 131072,
+                "max_output_tokens": 8192,
+                "input_cost_per_token": 0.0000001,
+                "output_cost_per_token": 0.0000002,
+                "supports_function_calling": true,
+                "supports_vision": false
+              }
+            }
+            """;
+
+        var source = Substitute.For<IModelMetadataSource>();
+        source.FetchAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(metadataJson));
+        var metadataProvider = new ModelMetadataProvider(source);
+
+        var kernel = Kernel.CreateBuilder().Build();
+        var model = new ProviderModelInfo("test-model", "Test Model", "TestProvider");
+        var session = new AgentSession(_registry, kernel, model);
+        var router = new SlashCommandRouter(
+            session,
+            _registry,
+            metadataProvider: metadataProvider);
+
+        var result = await router.ExecuteAsync("/model search --provider openrouter llama");
+
+        result.Should().NotContain("No models found");
+    }
+
 }


### PR DESCRIPTION
## Summary
- add type-to-filter /models picker flow for large catalogs (>20 models) with live filtering, up/down navigation, and top/bottom overflow indicators (N previous models / N more models)
- support Esc behavior in model picker (Esc clears filter first, second Esc cancels)
- extend /model search to merge LiteLLM metadata-catalog matches (independent of detector-installed model lists)
- enrich catalog search rows with metadata-backed context/cost and add --sort popularity
- harden non-interactive model-search prompt handling by treating NotSupportedException as cancellation
- add regression tests for popularity sort parsing and metadata-catalog fallback search

## Validation
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ""FullyQualifiedName~SlashCommandRouterBddTests"" --nologo -m:1
- dotnet test tests/JD.AI.Tests/JD.AI.Tests.csproj --configuration Release --filter ""FullyQualifiedName~ModelSearch"" --nologo -m:1
- dotnet build JD.AI.slnx --configuration Release --no-restore /p:ContinuousIntegrationBuild=true

Closes #311