### PR TITLE
feat: Gateway Client SDK — shared HTTP + SignalR client library

### DIFF
--- a/JD.AI.slnx
+++ b/JD.AI.slnx
@@ -5,6 +5,7 @@
     <Project Path="src/JD.AI.Core/JD.AI.Core.csproj" />
     <Project Path="src/JD.AI.Telemetry/JD.AI.Telemetry.csproj" />
     <Project Path="src/JD.AI.Dashboard.Wasm/JD.AI.Dashboard.Wasm.csproj" />
+    <Project Path="src/JD.AI.Gateway.Client/JD.AI.Gateway.Client.csproj" />
     <Project Path="src/JD.AI.Gateway/JD.AI.Gateway.csproj" />
     <Project Path="src/JD.AI.Credentials.Aws/JD.AI.Credentials.Aws.csproj" />
     <Project Path="src/JD.AI.Credentials.Azure/JD.AI.Credentials.Azure.csproj" />

--- a/src/JD.AI.Gateway.Client/GatewayHttpClient.cs
+++ b/src/JD.AI.Gateway.Client/GatewayHttpClient.cs
@@ -1,0 +1,130 @@
+using System.Net.Http.Json;
+using JD.AI.Gateway.Client.Models;
+
+namespace JD.AI.Gateway.Client;
+
+/// <summary>
+/// HTTP client for JD.AI Gateway REST API.
+/// Covers agents, sessions, providers, channels, routing, memory, plugins, and gateway status.
+/// </summary>
+public sealed class GatewayHttpClient(HttpClient http)
+{
+    // --- Agents ---
+
+    public async Task<AgentInfo[]> GetAgentsAsync(CancellationToken ct = default)
+        => await http.GetFromJsonAsync<AgentInfo[]>("api/v1/agents", ct) ?? [];
+
+    public async Task<AgentInfo?> SpawnAgentAsync(AgentDefinition definition, CancellationToken ct = default)
+    {
+        var response = await http.PostAsJsonAsync("api/v1/agents", definition, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<AgentInfo>(cancellationToken: ct);
+    }
+
+    public async Task<string?> SendMessageAsync(string agentId, string message, CancellationToken ct = default)
+    {
+        var response = await http.PostAsJsonAsync($"api/v1/agents/{agentId}/message", new { message }, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    public async Task DeleteAgentAsync(string agentId, CancellationToken ct = default)
+    {
+        var response = await http.DeleteAsync(new Uri($"api/v1/agents/{agentId}", UriKind.Relative), ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    // --- Sessions ---
+
+    public async Task<SessionInfo[]> GetSessionsAsync(int limit = 50, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<SessionInfo[]>($"api/v1/sessions?limit={limit}", ct) ?? [];
+
+    public async Task<SessionInfo?> GetSessionAsync(string id, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<SessionInfo>($"api/v1/sessions/{id}", ct);
+
+    public async Task CloseSessionAsync(string id, CancellationToken ct = default)
+    {
+        var response = await http.PostAsync(new Uri($"api/v1/sessions/{id}/close", UriKind.Relative), null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task ExportSessionAsync(string id, CancellationToken ct = default)
+    {
+        var response = await http.PostAsync(new Uri($"api/v1/sessions/{id}/export", UriKind.Relative), null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    // --- Providers ---
+
+    public async Task<ProviderInfo[]> GetProvidersAsync(CancellationToken ct = default)
+        => await http.GetFromJsonAsync<ProviderInfo[]>("api/v1/providers", ct) ?? [];
+
+    public async Task<ProviderModelInfo[]> GetProviderModelsAsync(string name, CancellationToken ct = default)
+        => await http.GetFromJsonAsync<ProviderModelInfo[]>($"api/v1/providers/{name}/models", ct) ?? [];
+
+    // --- Channels ---
+
+    public async Task<ChannelInfo[]> GetChannelsAsync(CancellationToken ct = default)
+        => await http.GetFromJsonAsync<ChannelInfo[]>("api/v1/channels", ct) ?? [];
+
+    public async Task ConnectChannelAsync(string type, CancellationToken ct = default)
+    {
+        var response = await http.PostAsync(new Uri($"api/v1/channels/{type}/connect", UriKind.Relative), null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DisconnectChannelAsync(string type, CancellationToken ct = default)
+    {
+        var response = await http.PostAsync(new Uri($"api/v1/channels/{type}/disconnect", UriKind.Relative), null, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    // --- Routing ---
+
+    public async Task<RoutingMapping[]> GetRoutingMappingsAsync(CancellationToken ct = default)
+    {
+        var dict = await http.GetFromJsonAsync<Dictionary<string, string>>("api/v1/routing/mappings", ct);
+        return dict?.Select(kv => new RoutingMapping(kv.Key, kv.Value)).ToArray() ?? [];
+    }
+
+    public async Task MapRoutingAsync(string channelId, string agentId, CancellationToken ct = default)
+    {
+        var response = await http.PostAsJsonAsync("api/v1/routing/map", new { channelId, agentId }, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    // --- Gateway Status ---
+
+    public async Task<GatewayStatus?> GetStatusAsync(CancellationToken ct = default)
+        => await http.GetFromJsonAsync<GatewayStatus>("api/v1/gateway/status", ct);
+
+    // --- Memory ---
+
+    public async Task IndexDocumentAsync(string content, string? source = null, CancellationToken ct = default)
+    {
+        var response = await http.PostAsJsonAsync("api/v1/memory/index", new { content, source }, ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<string[]> SearchMemoryAsync(string query, int limit = 5, CancellationToken ct = default)
+    {
+        var response = await http.PostAsJsonAsync("api/v1/memory/search", new { query, limit }, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<string[]>(cancellationToken: ct) ?? [];
+    }
+
+    // --- Health ---
+
+    public async Task<bool> IsHealthyAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await http.GetAsync(new Uri("api/v1/gateway/status", UriKind.Relative), ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/JD.AI.Gateway.Client/GatewaySignalRClient.cs
+++ b/src/JD.AI.Gateway.Client/GatewaySignalRClient.cs
@@ -1,0 +1,96 @@
+using System.Runtime.CompilerServices;
+using JD.AI.Gateway.Client.Models;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JD.AI.Gateway.Client;
+
+/// <summary>
+/// SignalR client for JD.AI Gateway real-time communication.
+/// Provides agent chat streaming and event subscriptions.
+/// </summary>
+public sealed class GatewaySignalRClient : IAsyncDisposable
+{
+    private readonly HubConnection _agentHub;
+    private readonly HubConnection _eventHub;
+
+    public event Action<ActivityEvent>? OnActivityEvent;
+    public event Action<string, bool>? OnChannelStatusChanged;
+    public event Action<string, string>? OnAgentMessage;
+    public event EventHandler? OnConnected;
+    public event EventHandler? OnDisconnected;
+
+    public bool IsConnected => _eventHub.State == HubConnectionState.Connected;
+    public string? ConnectionError { get; private set; }
+
+    public GatewaySignalRClient(string gatewayUrl)
+    {
+        var baseUrl = gatewayUrl.TrimEnd('/');
+
+        _eventHub = new HubConnectionBuilder()
+            .WithUrl($"{baseUrl}/hubs/events")
+            .WithAutomaticReconnect([TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30)])
+            .AddJsonProtocol()
+            .Build();
+
+        _agentHub = new HubConnectionBuilder()
+            .WithUrl($"{baseUrl}/hubs/agent")
+            .WithAutomaticReconnect([TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30)])
+            .AddJsonProtocol()
+            .Build();
+
+        _eventHub.On<ActivityEvent>("ActivityEvent", evt => OnActivityEvent?.Invoke(evt));
+        _eventHub.On<string, bool>("ChannelStatusChanged", (ch, connected) =>
+            OnChannelStatusChanged?.Invoke(ch, connected));
+
+        _agentHub.On<string, string>("AgentMessage", (agentId, msg) =>
+            OnAgentMessage?.Invoke(agentId, msg));
+
+        _eventHub.Reconnected += _ => { OnConnected?.Invoke(this, EventArgs.Empty); return Task.CompletedTask; };
+        _eventHub.Closed += _ => { OnDisconnected?.Invoke(this, EventArgs.Empty); return Task.CompletedTask; };
+    }
+
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await _eventHub.StartAsync(ct);
+            ConnectionError = null;
+        }
+        catch (Exception ex)
+        {
+            ConnectionError = $"Events hub: {ex.Message}";
+        }
+
+        try
+        {
+            await _agentHub.StartAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            ConnectionError = (ConnectionError is null ? "" : ConnectionError + "; ") + $"Agent hub: {ex.Message}";
+        }
+
+        if (ConnectionError is null)
+            OnConnected?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Stream chat responses from an agent. Yields chunks as they arrive.
+    /// </summary>
+    public async IAsyncEnumerable<AgentStreamChunk> StreamChatAsync(
+        string agentId, string message, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var stream = _agentHub.StreamAsync<AgentStreamChunk>("StreamChat", agentId, message, ct);
+        await foreach (var chunk in stream.WithCancellation(ct))
+        {
+            yield return chunk;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { await _eventHub.DisposeAsync(); } catch { /* ignore */ }
+        try { await _agentHub.DisposeAsync(); } catch { /* ignore */ }
+    }
+}

--- a/src/JD.AI.Gateway.Client/JD.AI.Gateway.Client.csproj
+++ b/src/JD.AI.Gateway.Client/JD.AI.Gateway.Client.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Shared Gateway client SDK for JD.AI — HTTP + SignalR client used by TUI, Dashboard, and external integrations.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+  </ItemGroup>
+
+</Project>

--- a/src/JD.AI.Gateway.Client/Models/AgentModels.cs
+++ b/src/JD.AI.Gateway.Client/Models/AgentModels.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Serialization;
+
+namespace JD.AI.Gateway.Client.Models;
+
+public sealed record AgentInfo(
+    string Id,
+    string Provider,
+    string Model,
+    int TurnCount,
+    DateTimeOffset CreatedAt
+);
+
+public sealed class AgentDefinition
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = string.Empty;
+
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = string.Empty;
+
+    [JsonPropertyName("systemPrompt")]
+    public string SystemPrompt { get; set; } = string.Empty;
+
+    [JsonPropertyName("autoSpawn")]
+    public bool AutoSpawn { get; set; }
+
+    [JsonPropertyName("maxTurns")]
+    public int MaxTurns { get; set; }
+
+    [JsonPropertyName("tools")]
+    public string[] Tools { get; set; } = [];
+
+    [JsonPropertyName("parameters")]
+    public ModelParameters? Parameters { get; set; }
+}
+
+public sealed class ModelParameters
+{
+    [JsonPropertyName("temperature")]
+    public double? Temperature { get; set; }
+
+    [JsonPropertyName("topP")]
+    public double? TopP { get; set; }
+
+    [JsonPropertyName("topK")]
+    public int? TopK { get; set; }
+
+    [JsonPropertyName("maxTokens")]
+    public int? MaxTokens { get; set; }
+
+    [JsonPropertyName("contextWindowSize")]
+    public int? ContextWindowSize { get; set; }
+
+    [JsonPropertyName("seed")]
+    public int? Seed { get; set; }
+
+    [JsonPropertyName("stopSequences")]
+    public string[] StopSequences { get; set; } = [];
+}
+
+public sealed record AgentStreamChunk(
+    string Type,
+    string AgentId,
+    string? Content
+);

--- a/src/JD.AI.Gateway.Client/Models/ChannelModels.cs
+++ b/src/JD.AI.Gateway.Client/Models/ChannelModels.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace JD.AI.Gateway.Client.Models;
+
+public sealed class ChannelInfo
+{
+    [JsonPropertyName("channelType")]
+    public string ChannelType { get; init; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; } = string.Empty;
+
+    [JsonPropertyName("isConnected")]
+    public bool IsConnected { get; init; }
+}

--- a/src/JD.AI.Gateway.Client/Models/GatewayModels.cs
+++ b/src/JD.AI.Gateway.Client/Models/GatewayModels.cs
@@ -1,0 +1,71 @@
+using System.Text.Json.Serialization;
+
+namespace JD.AI.Gateway.Client.Models;
+
+public sealed class GatewayStatus
+{
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    [JsonPropertyName("uptime")]
+    public DateTimeOffset Uptime { get; init; }
+
+    [JsonPropertyName("channels")]
+    public GatewayChannelStatus[] Channels { get; init; } = [];
+
+    [JsonPropertyName("agents")]
+    public GatewayAgentStatus[] Agents { get; init; } = [];
+
+    [JsonPropertyName("routes")]
+    public IDictionary<string, string> Routes { get; init; } = new Dictionary<string, string>();
+
+    [JsonIgnore]
+    public bool IsRunning => string.Equals(Status, "running", StringComparison.Ordinal);
+
+    [JsonIgnore]
+    public int ActiveAgents => Agents.Length;
+
+    [JsonIgnore]
+    public int ActiveChannels => Channels.Count(c => c.IsConnected);
+}
+
+public sealed record GatewayChannelStatus
+{
+    [JsonPropertyName("channelType")]
+    public string ChannelType { get; init; } = string.Empty;
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; init; } = string.Empty;
+
+    [JsonPropertyName("isConnected")]
+    public bool IsConnected { get; init; }
+}
+
+public sealed record GatewayAgentStatus
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; init; } = string.Empty;
+
+    [JsonPropertyName("model")]
+    public string Model { get; init; } = string.Empty;
+}
+
+public sealed record RoutingMapping(string ChannelId, string AgentId);
+
+public sealed record ActivityEvent
+{
+    [JsonPropertyName("eventType")]
+    public string EventType { get; init; } = string.Empty;
+
+    [JsonPropertyName("sourceId")]
+    public string SourceId { get; init; } = string.Empty;
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+}

--- a/src/JD.AI.Gateway.Client/Models/ProviderModels.cs
+++ b/src/JD.AI.Gateway.Client/Models/ProviderModels.cs
@@ -1,0 +1,14 @@
+namespace JD.AI.Gateway.Client.Models;
+
+public sealed record ProviderInfo(
+    string Name,
+    bool IsAvailable,
+    string? StatusMessage,
+    ProviderModelInfo[] Models
+);
+
+public sealed record ProviderModelInfo(
+    string Id,
+    string DisplayName,
+    string ProviderName
+);

--- a/src/JD.AI.Gateway.Client/Models/SessionModels.cs
+++ b/src/JD.AI.Gateway.Client/Models/SessionModels.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+
+namespace JD.AI.Gateway.Client.Models;
+
+public sealed class SessionInfo
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("modelId")]
+    public string? ModelId { get; init; }
+
+    [JsonPropertyName("providerName")]
+    public string? ProviderName { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public DateTimeOffset UpdatedAt { get; init; }
+
+    [JsonPropertyName("totalTokens")]
+    public int TotalTokens { get; init; }
+
+    [JsonPropertyName("messageCount")]
+    public int MessageCount { get; init; }
+
+    [JsonPropertyName("isActive")]
+    public bool IsActive { get; init; }
+
+    [JsonPropertyName("turns")]
+    public IList<TurnRecord> Turns { get; init; } = [];
+}
+
+public sealed class TurnRecord
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("turnIndex")]
+    public int TurnIndex { get; init; }
+
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; init; } = string.Empty;
+
+    [JsonPropertyName("modelId")]
+    public string? ModelId { get; init; }
+
+    [JsonPropertyName("tokensIn")]
+    public int TokensIn { get; init; }
+
+    [JsonPropertyName("tokensOut")]
+    public int TokensOut { get; init; }
+
+    [JsonPropertyName("durationMs")]
+    public int DurationMs { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/JD.AI.Gateway.Client/ServiceCollectionExtensions.cs
+++ b/src/JD.AI.Gateway.Client/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JD.AI.Gateway.Client;
+
+/// <summary>
+/// Extension methods for registering JD.AI Gateway client services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the Gateway HTTP client and SignalR client to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="gatewayUrl">Base URL of the Gateway (e.g., "http://localhost:5100").</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGatewayClient(this IServiceCollection services, string gatewayUrl)
+    {
+        var baseUrl = gatewayUrl.TrimEnd('/');
+
+        services.AddHttpClient<GatewayHttpClient>(client =>
+        {
+            client.BaseAddress = new Uri(baseUrl + "/");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+
+        services.AddSingleton(new GatewaySignalRClient(baseUrl));
+
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
New `JD.AI.Gateway.Client` project providing a shared client library for Gateway communication.

**Components:**
- `GatewayHttpClient` — typed HTTP client covering all REST endpoints (agents, sessions, providers, channels, routing, memory, status)
- `GatewaySignalRClient` — dual-hub real-time client (events + agent streaming) with auto-reconnect
- `ServiceCollectionExtensions.AddGatewayClient(url)` — DI registration for both clients
- Shared DTOs in `Models/` — AgentInfo, SessionInfo, ProviderInfo, ChannelInfo, GatewayStatus, etc.

**Purpose:** Both TUI and Dashboard will reference this instead of duplicating client code. Foundation for #369 (TUI → Gateway refactor).

Closes #371

## Test plan
- [x] Build: 0 warnings, 0 errors
- [x] All analyzer rules pass (CA1003, CA2234 addressed)
- [x] Solution builds with new project added

🤖 Generated with [Claude Code](https://claude.com/claude-code)