### PR TITLE
feat: provider detection consolidation — refresh endpoint + interface

### DIFF
--- a/src/JD.AI.Core/Providers/IProviderRegistry.cs
+++ b/src/JD.AI.Core/Providers/IProviderRegistry.cs
@@ -14,6 +14,13 @@ public interface IProviderRegistry
         CancellationToken ct = default);
 
     /// <summary>
+    /// Probes all known provider backends, optionally forcing a cache refresh.
+    /// </summary>
+    Task<IReadOnlyList<ProviderInfo>> DetectProvidersAsync(
+        bool forceRefresh,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Returns all models across all available providers.
     /// </summary>
     Task<IReadOnlyList<ProviderModelInfo>> GetModelsAsync(

--- a/src/JD.AI.Gateway/Endpoints/ProviderEndpoints.cs
+++ b/src/JD.AI.Gateway/Endpoints/ProviderEndpoints.cs
@@ -33,5 +33,19 @@ public static class ProviderEndpoints
         })
         .WithName("GetProviderModels")
         .WithDescription("Get models for a specific provider.");
+
+        group.MapPost("/refresh", async (IProviderRegistry registry, CancellationToken ct) =>
+        {
+            var providers = await registry.DetectProvidersAsync(forceRefresh: true, ct);
+            return Results.Ok(providers.Select(p => new
+            {
+                p.Name,
+                p.IsAvailable,
+                p.StatusMessage,
+                Models = p.Models.Select(m => new { m.Id, m.DisplayName, m.ProviderName })
+            }));
+        })
+        .WithName("RefreshProviders")
+        .WithDescription("Force re-detection of all providers, invalidating cache.");
     }
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/providers/refresh` endpoint for explicit provider cache invalidation
- Add `forceRefresh` overload to `IProviderRegistry` interface
- Enables TUI to query providers from Gateway instead of running local detection

Closes #372

## Test plan
- [x] Build: 0 errors, 0 warnings
- [x] Existing provider detection unchanged (cache still works)
- [x] New refresh endpoint forces re-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)