### PR TITLE
fix: CI build failure — CA1003 events must use EventHandler<T>

### DIFF
--- a/src/JD.AI.Gateway.Client/GatewaySignalRClient.cs
+++ b/src/JD.AI.Gateway.Client/GatewaySignalRClient.cs
@@ -9,14 +9,31 @@ namespace JD.AI.Gateway.Client;
 /// SignalR client for JD.AI Gateway real-time communication.
 /// Provides agent chat streaming and event subscriptions.
 /// </summary>
+public sealed class ActivityEventArgs(ActivityEvent activityEvent) : EventArgs
+{
+    public ActivityEvent ActivityEvent { get; } = activityEvent;
+}
+
+public sealed class ChannelStatusEventArgs(string channel, bool connected) : EventArgs
+{
+    public string Channel { get; } = channel;
+    public bool Connected { get; } = connected;
+}
+
+public sealed class AgentMessageEventArgs(string agentId, string message) : EventArgs
+{
+    public string AgentId { get; } = agentId;
+    public string Message { get; } = message;
+}
+
 public sealed class GatewaySignalRClient : IAsyncDisposable
 {
     private readonly HubConnection _agentHub;
     private readonly HubConnection _eventHub;
 
-    public event Action<ActivityEvent>? OnActivityEvent;
-    public event Action<string, bool>? OnChannelStatusChanged;
-    public event Action<string, string>? OnAgentMessage;
+    public event EventHandler<ActivityEventArgs>? OnActivityEvent;
+    public event EventHandler<ChannelStatusEventArgs>? OnChannelStatusChanged;
+    public event EventHandler<AgentMessageEventArgs>? OnAgentMessage;
     public event EventHandler? OnConnected;
     public event EventHandler? OnDisconnected;
 
@@ -39,12 +56,13 @@ public sealed class GatewaySignalRClient : IAsyncDisposable
             .AddJsonProtocol()
             .Build();
 
-        _eventHub.On<ActivityEvent>("ActivityEvent", evt => OnActivityEvent?.Invoke(evt));
+        _eventHub.On<ActivityEvent>("ActivityEvent", evt =>
+            OnActivityEvent?.Invoke(this, new ActivityEventArgs(evt)));
         _eventHub.On<string, bool>("ChannelStatusChanged", (ch, connected) =>
-            OnChannelStatusChanged?.Invoke(ch, connected));
+            OnChannelStatusChanged?.Invoke(this, new ChannelStatusEventArgs(ch, connected)));
 
         _agentHub.On<string, string>("AgentMessage", (agentId, msg) =>
-            OnAgentMessage?.Invoke(agentId, msg));
+            OnAgentMessage?.Invoke(this, new AgentMessageEventArgs(agentId, msg)));
 
         _eventHub.Reconnected += _ => { OnConnected?.Invoke(this, EventArgs.Empty); return Task.CompletedTask; };
         _eventHub.Closed += _ => { OnDisconnected?.Invoke(this, EventArgs.Empty); return Task.CompletedTask; };


### PR DESCRIPTION
## Summary
Fix all 3 CI failures (CodeQL, Integration Tests, E2E Smoke) caused by CA1003 analyzer rule.

Events in `GatewaySignalRClient` used `Action<>` instead of `EventHandler<EventArgs>`. CI treats warnings as errors in Release builds.

**Fix:** Added proper EventArgs classes and replaced all `Action<>` events with `EventHandler<T>`.

## Test plan
- [x] Build: 0 warnings, 0 errors (Release mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)