### PR TITLE
feat: agent-driven emoji reactions — agents choose their own emojis

### DIFF
--- a/src/JD.AI.Channels.Discord/DiscordChannel.cs
+++ b/src/JD.AI.Channels.Discord/DiscordChannel.cs
@@ -315,6 +315,19 @@ public sealed class DiscordChannel : Core.Channels.IChannel, ICommandAwareChanne
         }
     }
 
+    public async Task ReactAsync(string conversationId, string messageId, string emoji, CancellationToken ct = default)
+    {
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+
+        if (ulong.TryParse(conversationId, out var channelId)
+            && ulong.TryParse(messageId, out var msgId)
+            && await _client.GetChannelAsync(channelId) is IMessageChannel channel
+            && await channel.GetMessageAsync(msgId) is IUserMessage message)
+        {
+            await TryAddReactionAsync(message, emoji);
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_client is not null)

--- a/src/JD.AI.Core/Channels/IChannel.cs
+++ b/src/JD.AI.Core/Channels/IChannel.cs
@@ -48,6 +48,12 @@ public interface IChannel : IAsyncDisposable
     /// <summary>Sends a message to the specified conversation/thread.</summary>
     Task SendMessageAsync(string conversationId, string content, CancellationToken ct = default);
 
+    /// <summary>
+    /// Adds a reaction emoji to a message. Not all channels support this — default is no-op.
+    /// </summary>
+    Task ReactAsync(string conversationId, string messageId, string emoji, CancellationToken ct = default)
+        => Task.CompletedTask;
+
     /// <summary>Raised when a new inbound message arrives.</summary>
     /// <remarks>Uses <c>Func&lt;ChannelMessage, Task&gt;</c> instead of <c>EventHandler</c> to support async handlers.</remarks>
 #pragma warning disable CA1003 // Async event pattern requires Func<T, Task> delegate

--- a/src/JD.AI.Core/Tools/ChannelReactionTools.cs
+++ b/src/JD.AI.Core/Tools/ChannelReactionTools.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel;
+using JD.AI.Core.Channels;
+using Microsoft.SemanticKernel;
+
+namespace JD.AI.Core.Tools;
+
+/// <summary>
+/// Semantic Kernel tool plugin that lets agents add emoji reactions to messages.
+/// The agent chooses the emoji — useful for expressing acknowledgment, status, or emotion.
+/// </summary>
+public sealed class ChannelReactionTools(IChannelRegistry channelRegistry)
+{
+    /// <summary>
+    /// The channel ID of the conversation the agent is currently responding to.
+    /// Set by the message handler before each turn.
+    /// </summary>
+    public string? ActiveChannelType { get; set; }
+
+    /// <summary>
+    /// The conversation/channel ID of the current message context.
+    /// </summary>
+    public string? ActiveConversationId { get; set; }
+
+    /// <summary>
+    /// The message ID the agent is currently responding to.
+    /// </summary>
+    public string? ActiveMessageId { get; set; }
+
+    [KernelFunction("react")]
+    [Description("Add an emoji reaction to the current message. Use this to express acknowledgment, status, mood, or any contextual response. Choose an emoji that fits the situation — you have full creative freedom.")]
+    public async Task<string> ReactAsync(
+        [Description("The emoji to react with (e.g., 👍, 🎉, 🔥, 💡, ❤️, 🚀, etc.)")] string emoji,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(ActiveChannelType) ||
+            string.IsNullOrWhiteSpace(ActiveConversationId) ||
+            string.IsNullOrWhiteSpace(ActiveMessageId))
+        {
+            return "No active message context — cannot add reaction.";
+        }
+
+        var channel = channelRegistry.GetChannel(ActiveChannelType);
+        if (channel is null)
+            return $"Channel '{ActiveChannelType}' not found.";
+
+        await channel.ReactAsync(ActiveConversationId, ActiveMessageId, emoji, ct);
+        return $"Reacted with {emoji}";
+    }
+
+    [KernelFunction("react_to_message")]
+    [Description("Add an emoji reaction to a specific message by ID. Use when you want to react to a message other than the one you're currently responding to.")]
+    public async Task<string> ReactToMessageAsync(
+        [Description("The conversation/channel ID")] string conversationId,
+        [Description("The message ID to react to")] string messageId,
+        [Description("The emoji to react with")] string emoji,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(ActiveChannelType))
+            return "No active channel context.";
+
+        var channel = channelRegistry.GetChannel(ActiveChannelType);
+        if (channel is null)
+            return $"Channel '{ActiveChannelType}' not found.";
+
+        await channel.ReactAsync(conversationId, messageId, emoji, ct);
+        return $"Reacted with {emoji} on message {messageId}";
+    }
+}


### PR DESCRIPTION
## Summary
Let agents choose their own emoji reactions instead of hardcoded status emojis.

**New:**
- `IChannel.ReactAsync(conversationId, messageId, emoji)` — default interface method
- `ChannelReactionTools` Semantic Kernel plugin with `react(emoji)` and `react_to_message()` tools
- Discord `ReactAsync` implementation
- Agent has full creative freedom — can react with 👍🎉🔥💡❤️🚀 or any emoji

**Preserved:** Hardcoded status reactions (👀🧠✅❌) still work alongside agent-chosen ones.

## Test plan
- [x] Build: 0 warnings, 0 errors (Release mode)
- [x] IChannel default method doesn't break other channel implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)