### PR TITLE
fix: update Gateway tests for AgentPoolService constructor change

### DIFF
--- a/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
@@ -44,7 +44,7 @@ public class GatewayCommandTests
         _providers.GetDetector(Arg.Any<string>()).Returns(detector);
 
         var eventBus = Substitute.For<IEventBus>();
-        _pool = new AgentPoolService(_providers, eventBus, NullLogger<AgentPoolService>.Instance);
+        _pool = new AgentPoolService(_providers, new ChannelRegistry(), eventBus, NullLogger<AgentPoolService>.Instance);
         _channels = new ChannelRegistry();
         _router = new AgentRouter(_pool, _channels, eventBus, NullLogger<AgentRouter>.Instance);
         _config = new GatewayConfig

--- a/tests/JD.AI.Gateway.Tests/GatewayOrchestratorTests.cs
+++ b/tests/JD.AI.Gateway.Tests/GatewayOrchestratorTests.cs
@@ -47,6 +47,7 @@ public sealed class GatewayOrchestratorTests
 
         _pool = new AgentPoolService(
             _providerRegistry,
+            _channels,
             _events,
             NullLogger<AgentPoolService>.Instance);
         _router = new AgentRouter(

--- a/tests/JD.AI.Gateway.Tests/Services/GatewayHealthCheckTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Services/GatewayHealthCheckTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using JD.AI.Core.Channels;
 using JD.AI.Core.Events;
 using JD.AI.Core.Providers;
 using JD.AI.Gateway.Services;
@@ -15,7 +16,7 @@ public sealed class GatewayHealthCheckTests
         var providers = Substitute.For<IProviderRegistry>();
         var events = Substitute.For<IEventBus>();
         var logger = NullLogger<AgentPoolService>.Instance;
-        return new AgentPoolService(providers, events, logger);
+        return new AgentPoolService(providers, new ChannelRegistry(), events, logger);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fix CI build failure from PR #383 — `AgentPoolService` constructor now requires `IChannelRegistry` parameter for reaction tools. Updated 3 test files to pass `new ChannelRegistry()`.

## Test plan
- [x] Build: 0 warnings, 0 errors (Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)