### PR TITLE
feat: daemon version + NuGet update check in agent identity

### DIFF
--- a/src/JD.AI.Core/Tools/SystemInfoTools.cs
+++ b/src/JD.AI.Core/Tools/SystemInfoTools.cs
@@ -18,6 +18,9 @@ public sealed class SystemInfoTools
     private ProviderModelInfo? _model;
     private string? _agentId;
     private DateTimeOffset _startedAt = DateTimeOffset.UtcNow;
+    private string? _daemonVersion;
+    private string? _latestDaemonVersion;
+    private DateTimeOffset? _versionCheckedAt;
 
     /// <summary>Sets the active model info (called during registration).</summary>
     public void SetModel(ProviderModelInfo model) => _model = model;
@@ -27,6 +30,14 @@ public sealed class SystemInfoTools
 
     /// <summary>Sets the agent start time.</summary>
     public void SetStartedAt(DateTimeOffset startedAt) => _startedAt = startedAt;
+
+    /// <summary>Sets the daemon version info for identity reporting.</summary>
+    public void SetDaemonVersion(string currentVersion, string? latestVersion = null)
+    {
+        _daemonVersion = currentVersion;
+        _latestDaemonVersion = latestVersion;
+        _versionCheckedAt = DateTimeOffset.UtcNow;
+    }
 
     [KernelFunction("get_identity")]
     [ToolSafetyTier(SafetyTier.AutoApprove)]
@@ -66,6 +77,21 @@ public sealed class SystemInfoTools
             sb.AppendLine($"Agent ID: {_agentId}");
 
         sb.AppendLine($"Platform: JD.AI");
+
+        if (!string.IsNullOrEmpty(_daemonVersion))
+        {
+            sb.AppendLine($"Daemon Version: {_daemonVersion}");
+            if (!string.IsNullOrEmpty(_latestDaemonVersion))
+            {
+                var isLatest = string.Equals(_daemonVersion, _latestDaemonVersion, StringComparison.Ordinal);
+                sb.AppendLine(isLatest
+                    ? $"Latest Version: {_latestDaemonVersion} (up-to-date ✓)"
+                    : $"Latest Version: {_latestDaemonVersion} (UPDATE AVAILABLE)");
+            }
+            if (_versionCheckedAt.HasValue)
+                sb.AppendLine($"Version Checked: {_versionCheckedAt.Value:u}");
+        }
+
         sb.AppendLine($"Runtime: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
 
         return sb.ToString();
@@ -93,6 +119,17 @@ public sealed class SystemInfoTools
         {
             sb.AppendLine($"Model: {_model.ProviderName}/{_model.Id}");
             sb.AppendLine($"Capabilities: {_model.Capabilities.ToLabel()}");
+        }
+
+        if (!string.IsNullOrEmpty(_daemonVersion))
+        {
+            sb.AppendLine($"Daemon Version: {_daemonVersion}");
+            if (!string.IsNullOrEmpty(_latestDaemonVersion))
+            {
+                var isLatest = string.Equals(_daemonVersion, _latestDaemonVersion, StringComparison.Ordinal);
+                sb.Append(isLatest ? "Update: Up-to-date ✓" : $"Update: {_latestDaemonVersion} available!");
+                sb.AppendLine();
+            }
         }
 
         sb.AppendLine($"OS: {System.Runtime.InteropServices.RuntimeInformation.OSDescription}");

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -419,6 +419,21 @@ static void RunDaemon(string[] args)
     // --- Initialize stores ---
     app.Services.GetRequiredService<SessionStore>().InitializeAsync().GetAwaiter().GetResult();
 
+    // --- Set daemon version metadata on agent pool for identity enrichment ---
+    var agentPool = app.Services.GetRequiredService<AgentPoolService>();
+    var updateChecker = app.Services.GetRequiredService<UpdateChecker>();
+    agentPool.DaemonVersion = updateChecker.CurrentVersion.ToString();
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            var update = await updateChecker.CheckForUpdateAsync();
+            agentPool.LatestDaemonVersion = update?.LatestVersion.ToString()
+                ?? updateChecker.CurrentVersion.ToString();
+        }
+        catch { agentPool.LatestDaemonVersion = "check failed"; }
+    });
+
     // --- Middleware pipeline ---
     // API version rewrite must precede routing so /api/* → /api/v1/* happens first
     app.UseMiddleware<ApiVersionRewriteMiddleware>();

--- a/src/JD.AI.Gateway/Services/AgentPoolService.cs
+++ b/src/JD.AI.Gateway/Services/AgentPoolService.cs
@@ -28,6 +28,12 @@ public sealed class AgentPoolService : IHostedService
     private readonly ConcurrentDictionary<string, AgentInstance> _agents = new();
     private readonly ConcurrentDictionary<string, ChannelReactionTools> _reactionTools = new();
 
+    /// <summary>Daemon version info — set by Daemon host for agent identity enrichment.</summary>
+    public string? DaemonVersion { get; set; }
+
+    /// <summary>Latest available daemon version from NuGet — set by Daemon host.</summary>
+    public string? LatestDaemonVersion { get; set; }
+
     /// <summary>Maximum retry attempts for transient Ollama errors.</summary>
     internal const int MaxRetries = 3;
 
@@ -104,8 +110,10 @@ public sealed class AgentPoolService : IHostedService
         kernel.Plugins.AddFromObject(reactionTools, "reactions");
         _reactionTools[id] = reactionTools;
 
-        // Wire agent ID into SystemInfoTools
+        // Wire agent ID + daemon version into SystemInfoTools
         coreReg?.SystemInfoTools.SetAgentId(id);
+        if (DaemonVersion is not null)
+            coreReg?.SystemInfoTools.SetDaemonVersion(DaemonVersion, LatestDaemonVersion);
         var instance = new AgentInstance(id, provider, model, kernel, history, parameters, fallbackProviders);
         _agents[id] = instance;
 


### PR DESCRIPTION
## Summary
Agents now report daemon version and whether an update is available on NuGet.

**Changes:**
- `SystemInfoTools.SetDaemonVersion(current, latest)` — injectable version info
- `GetIdentity()` and `GetSystemStatus()` include daemon version + update status
- `AgentPoolService` has `DaemonVersion`/`LatestDaemonVersion` properties
- Daemon startup sets current version + background NuGet check

**Example output:**
```
Daemon Version: 1.1.383
Latest Version: 1.1.385 (UPDATE AVAILABLE)
Version Checked: 2026-03-27 05:00:00Z
```

## Test plan
- [x] Build: 0 warnings, 0 errors (Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)