### PR TITLE
fix: orchestrator test — unique Kernel per agent spawn

### DIFF
--- a/tests/JD.AI.Gateway.Tests/GatewayOrchestratorTests.cs
+++ b/tests/JD.AI.Gateway.Tests/GatewayOrchestratorTests.cs
@@ -29,19 +29,22 @@ public sealed class GatewayOrchestratorTests
         _providerRegistry = Substitute.For<IProviderRegistry>();
         _providerDetector = Substitute.For<IProviderDetector>();
         _providerDetector.ProviderName.Returns("fake");
-        _providerDetector.BuildKernel(Arg.Any<ProviderModelInfo>()).Returns(CreateKernel());
+        _providerDetector.BuildKernel(Arg.Any<ProviderModelInfo>()).Returns(_ => CreateKernel());
 
+        var fakeProviders = Task.FromResult<IReadOnlyList<ProviderInfo>>(
+            [
+                new ProviderInfo(
+                    "fake",
+                    true,
+                    "ready",
+                    [
+                        new ProviderModelInfo("model-a", "Model A", "fake"),
+                    ])
+            ]);
         _providerRegistry.DetectProvidersAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<ProviderInfo>>(
-                [
-                    new ProviderInfo(
-                        "fake",
-                        true,
-                        "ready",
-                        [
-                            new ProviderModelInfo("model-a", "Model A", "fake"),
-                        ])
-                ]));
+            .Returns(fakeProviders);
+        _providerRegistry.DetectProvidersAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(fakeProviders);
         _providerRegistry.GetDetector(Arg.Any<string>()).Returns((IProviderDetector?)null);
         _providerRegistry.GetDetector("fake").Returns(_providerDetector);
 


### PR DESCRIPTION
## Summary
Fix CI test failure in `GatewayOrchestratorTests.StartAsync_WithMultipleSameTypeChannels_UsesChannelNameForDedicatedRouting`.

**Root cause:** `BuildKernel` mock returned the same `Kernel` instance for both agent spawns. Registering plugins (core tools + reaction tools) on the same kernel twice caused a silent conflict, failing the second spawn.

**Fix:** `Returns(_ => CreateKernel())` — creates a new Kernel per invocation.

## Test plan
- [x] 256/256 Gateway tests pass (Release mode)
- [x] Specific failing test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)