### PR TITLE
feat(discord): file attachment support for outbound messages

### DIFF
--- a/src/JD.AI.Channels.Discord/DiscordChannel.cs
+++ b/src/JD.AI.Channels.Discord/DiscordChannel.cs
@@ -315,6 +315,45 @@ public sealed class DiscordChannel : Core.Channels.IChannel, ICommandAwareChanne
         }
     }
 
+    public async Task SendMessageWithAttachmentsAsync(
+        string conversationId,
+        string? content,
+        IReadOnlyList<OutboundAttachment> attachments,
+        CancellationToken ct = default)
+    {
+        if (_client is null) throw new InvalidOperationException("Not connected.");
+
+        if (ulong.TryParse(conversationId, out var channelId)
+            && await _client.GetChannelAsync(channelId) is IMessageChannel channel)
+        {
+            try
+            {
+                if (_enableReactions && _pendingInboundByChannelId.TryGetValue(conversationId, out var inboundMsgId))
+                {
+                    if (await channel.GetMessageAsync(inboundMsgId) is IUserMessage inbound)
+                        await SetStatusReactionAsync(inbound, "✍️");
+                }
+
+                var fileAttachments = attachments.Select(a =>
+                    new FileAttachment(a.Content, a.FileName, a.Description)).ToArray();
+
+                await channel.SendFilesAsync(
+                    fileAttachments,
+                    text: string.IsNullOrWhiteSpace(content) ? null : content);
+
+                if (_enableReactions && _pendingInboundByChannelId.TryGetValue(conversationId, out var sentInboundMsgId))
+                {
+                    if (await channel.GetMessageAsync(sentInboundMsgId) is IUserMessage inbound)
+                        await SetStatusReactionAsync(inbound, "✅");
+                }
+            }
+            finally
+            {
+                _pendingInboundByChannelId.Remove(conversationId);
+            }
+        }
+    }
+
     public async Task ReactAsync(string conversationId, string messageId, string emoji, CancellationToken ct = default)
     {
         if (_client is null) throw new InvalidOperationException("Not connected.");

--- a/src/JD.AI.Core/Channels/IChannel.cs
+++ b/src/JD.AI.Core/Channels/IChannel.cs
@@ -18,12 +18,18 @@ public record ChannelMessage
         new Dictionary<string, string>();
 }
 
-/// <summary>File or image attachment on a channel message.</summary>
+/// <summary>File or image attachment on an inbound channel message.</summary>
 public record ChannelAttachment(
     string FileName,
     string ContentType,
     long SizeBytes,
     Func<CancellationToken, Task<Stream>> OpenReadAsync);
+
+/// <summary>File attachment for outbound messages.</summary>
+public record OutboundAttachment(
+    string FileName,
+    Stream Content,
+    string? Description = null);
 
 /// <summary>
 /// Unified abstraction for a messaging channel (Discord, Slack, Signal, Web, etc.).
@@ -47,6 +53,17 @@ public interface IChannel : IAsyncDisposable
 
     /// <summary>Sends a message to the specified conversation/thread.</summary>
     Task SendMessageAsync(string conversationId, string content, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends a message with file attachments. Channels that don't support attachments
+    /// fall back to sending the text content only.
+    /// </summary>
+    Task SendMessageWithAttachmentsAsync(
+        string conversationId,
+        string? content,
+        IReadOnlyList<OutboundAttachment> attachments,
+        CancellationToken ct = default)
+        => SendMessageAsync(conversationId, content ?? string.Empty, ct);
 
     /// <summary>
     /// Adds a reaction emoji to a message. Not all channels support this — default is no-op.


### PR DESCRIPTION
## Summary
Add bidirectional file attachment support to the Discord channel.

**New:**
- `OutboundAttachment` record: FileName, Content stream, Description
- `IChannel.SendMessageWithAttachmentsAsync()` — default interface method with text-only fallback
- Discord `SendMessageWithAttachmentsAsync` — uses `SendFilesAsync` for multi-file uploads
- Supports optional text content alongside attachments
- Reaction flow preserved (✍️ → ✅)

**Already existed:** Inbound attachment handling (ChannelAttachment with metadata + download)

## Test plan
- [x] Build: 0 warnings, 0 errors (Release, full solution)
- [x] Default interface method doesn't break other channel implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)