### PR TITLE
feat(cli): add 'jdai gateway' and 'jdai dashboard' commands (#411, #412)

### DIFF
--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -169,6 +169,38 @@ bridgeCommand.SetAction(async parseResult =>
 });
 rootCommand.Subcommands.Add(bridgeCommand);
 
+var dashboardCommand = new Command("dashboard", "Open the dashboard in the default browser");
+dashboardCommand.SetAction(async _ =>
+{
+    var baseUrl = $"http://{GatewayRuntimeDefaults.DefaultHost}:{GatewayRuntimeDefaults.DefaultPort}";
+    try
+    {
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        var response = await client.GetAsync(new Uri($"{baseUrl}{GatewayRuntimeDefaults.HealthPath}"));
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.Error.WriteLine($"Daemon not running. Start with: {DaemonServiceIdentity.ToolCommand} run");
+            return 1;
+        }
+    }
+    catch
+    {
+        Console.Error.WriteLine($"Daemon not running. Start with: {DaemonServiceIdentity.ToolCommand} run");
+        return 1;
+    }
+
+    Console.WriteLine($"Opening dashboard at {baseUrl}/ ...");
+    if (OperatingSystem.IsWindows())
+        Process.Start(new ProcessStartInfo("cmd", $"/c start {baseUrl}/") { CreateNoWindow = true });
+    else if (OperatingSystem.IsLinux())
+        Process.Start("xdg-open", $"{baseUrl}/");
+    else if (OperatingSystem.IsMacOS())
+        Process.Start("open", $"{baseUrl}/");
+
+    return 0;
+});
+rootCommand.Subcommands.Add(dashboardCommand);
+
 return rootCommand.Parse(args).Invoke();
 
 // ════════════════════════════════════════════════════════════════════

--- a/src/JD.AI/Commands/DashboardCliHandler.cs
+++ b/src/JD.AI/Commands/DashboardCliHandler.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using JD.AI.Core.Infrastructure;
+using JD.AI.Utilities;
+
+namespace JD.AI.Commands;
+
+/// <summary>
+/// Handles <c>jdai dashboard</c> — ensures the gateway is running, then opens the dashboard in a browser.
+/// </summary>
+internal static class DashboardCliHandler
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var baseUrl = GatewayHealthChecker.DefaultBaseUrl;
+
+        // Check if gateway is already running
+        if (await GatewayHealthChecker.IsRunningAsync(baseUrl).ConfigureAwait(false))
+        {
+            Console.WriteLine($"Gateway is running at {baseUrl}");
+            BrowserLauncher.Open($"{baseUrl}/");
+            return 0;
+        }
+
+        // Start gateway in background
+        Console.WriteLine("Gateway not running. Starting in background...");
+        var daemonExe = DaemonServiceIdentity.ToolCommand;
+        Process process;
+        try
+        {
+            process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = daemonExe,
+                    Arguments = "run",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                },
+            };
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"Failed to start daemon: {ex.Message}");
+            Console.Error.WriteLine(
+                $"Ensure '{daemonExe}' is installed (dotnet tool install -g JD.AI.Daemon).");
+            return 1;
+        }
+
+        // Wait for health check
+        Console.WriteLine("Waiting for gateway to become healthy...");
+        if (!await GatewayHealthChecker.WaitForHealthyAsync(baseUrl, maxWaitMs: 15000).ConfigureAwait(false))
+        {
+            Console.Error.WriteLine("Gateway did not become healthy within 15 seconds.");
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.Dispose();
+            }
+
+            return 1;
+        }
+
+        Console.WriteLine($"Gateway running at {baseUrl}");
+        BrowserLauncher.Open($"{baseUrl}/");
+
+        // Detach — the daemon continues running in the background
+        process.Dispose();
+        return 0;
+    }
+}

--- a/src/JD.AI/Commands/GatewayCliHandler.cs
+++ b/src/JD.AI/Commands/GatewayCliHandler.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using JD.AI.Core.Infrastructure;
+using JD.AI.Utilities;
+
+namespace JD.AI.Commands;
+
+/// <summary>
+/// Handles <c>jdai gateway</c> — starts the full gateway persistently.
+/// Spawns <c>jdai-daemon run</c> as a subprocess to avoid duplicating the gateway host setup.
+/// </summary>
+internal static class GatewayCliHandler
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        var baseUrl = GatewayHealthChecker.DefaultBaseUrl;
+
+        // Check if gateway is already running
+        if (await GatewayHealthChecker.IsRunningAsync(baseUrl).ConfigureAwait(false))
+        {
+            Console.WriteLine($"Gateway is already running at {baseUrl}");
+            return 0;
+        }
+
+        Console.WriteLine($"Starting gateway on {baseUrl} ...");
+
+        // Spawn jdai-daemon run as a child process
+        var daemonExe = DaemonServiceIdentity.ToolCommand;
+        Process process;
+        try
+        {
+            process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = daemonExe,
+                    Arguments = "run",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                },
+            };
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"Failed to start daemon: {ex.Message}");
+            Console.Error.WriteLine(
+                $"Ensure '{daemonExe}' is installed (dotnet tool install -g JD.AI.Daemon).");
+            return 1;
+        }
+
+        // Wait for the health check to pass
+        if (!await GatewayHealthChecker.WaitForHealthyAsync(baseUrl, maxWaitMs: 15000).ConfigureAwait(false))
+        {
+            Console.Error.WriteLine("Gateway did not become healthy within 15 seconds.");
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                process.Dispose();
+            }
+
+            return 1;
+        }
+
+        Console.WriteLine($"Gateway running at {baseUrl}");
+        Console.WriteLine("Press Ctrl+C to stop.");
+
+        // Block until Ctrl+C
+        using var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            cts.Cancel();
+        };
+
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on Ctrl+C
+        }
+
+        Console.WriteLine("Stopping gateway...");
+        if (!process.HasExited)
+        {
+            process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync().ConfigureAwait(false);
+        }
+
+        process.Dispose();
+        Console.WriteLine("Gateway stopped.");
+        return 0;
+    }
+}

--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -59,6 +59,8 @@ if (opts.Subcommand != null)
         "onboard" or "wizard" => await OnboardingCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "setup" => await SetupCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         "update" or "install" => await UpdateCliHandler.RunAsync(opts.Subcommand, opts.SubcommandArgs).ConfigureAwait(false),
+        "gateway" => await GatewayCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
+        "dashboard" => await DashboardCliHandler.RunAsync(opts.SubcommandArgs).ConfigureAwait(false),
         _ => 1,
     };
 }

--- a/src/JD.AI/Startup/CliOptions.cs
+++ b/src/JD.AI/Startup/CliOptions.cs
@@ -86,7 +86,9 @@ internal static class CliArgumentParser
                 string.Equals(candidate, "wizard", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(candidate, "setup", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(candidate, "update", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(candidate, "install", StringComparison.OrdinalIgnoreCase))
+                string.Equals(candidate, "install", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate, "gateway", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidate, "dashboard", StringComparison.OrdinalIgnoreCase))
             {
                 subcommand = candidate.ToLowerInvariant();
                 subcommandArgs = args.Skip(firstNonOptionIndex + 1).ToArray();

--- a/src/JD.AI/Utilities/BrowserLauncher.cs
+++ b/src/JD.AI/Utilities/BrowserLauncher.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace JD.AI.Utilities;
+
+/// <summary>
+/// Cross-platform utility to open a URL in the default browser.
+/// </summary>
+internal static class BrowserLauncher
+{
+    public static void Open(string url)
+    {
+        if (OperatingSystem.IsWindows())
+            Process.Start(new ProcessStartInfo("cmd", $"/c start {url}") { CreateNoWindow = true });
+        else if (OperatingSystem.IsLinux())
+            Process.Start("xdg-open", url);
+        else if (OperatingSystem.IsMacOS())
+            Process.Start("open", url);
+    }
+}

--- a/src/JD.AI/Utilities/GatewayHealthChecker.cs
+++ b/src/JD.AI/Utilities/GatewayHealthChecker.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+using JD.AI.Core.Infrastructure;
+
+namespace JD.AI.Utilities;
+
+/// <summary>
+/// Checks whether the gateway daemon is running by probing its health endpoint.
+/// </summary>
+internal static class GatewayHealthChecker
+{
+    public static string DefaultBaseUrl =>
+        $"http://{GatewayRuntimeDefaults.DefaultHost}:{GatewayRuntimeDefaults.DefaultPort}";
+
+    public static async Task<bool> IsRunningAsync(string? baseUrl = null, int timeoutMs = 2000)
+    {
+        baseUrl ??= DefaultBaseUrl;
+        try
+        {
+            using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(timeoutMs) };
+            var response = await client.GetAsync(new Uri($"{baseUrl}{GatewayRuntimeDefaults.HealthPath}"))
+                .ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+#pragma warning disable CA1031
+        catch
+        {
+            return false;
+        }
+#pragma warning restore CA1031
+    }
+
+    public static async Task<bool> WaitForHealthyAsync(string? baseUrl = null, int maxWaitMs = 10000)
+    {
+        baseUrl ??= DefaultBaseUrl;
+        var sw = Stopwatch.StartNew();
+        while (sw.ElapsedMilliseconds < maxWaitMs)
+        {
+            if (await IsRunningAsync(baseUrl, 1000).ConfigureAwait(false))
+                return true;
+            await Task.Delay(500).ConfigureAwait(false);
+        }
+
+        return false;
+    }
+}

--- a/tests/JD.AI.Tests/Commands/GatewayCliTests.cs
+++ b/tests/JD.AI.Tests/Commands/GatewayCliTests.cs
@@ -1,0 +1,42 @@
+using JD.AI.Core.Infrastructure;
+using JD.AI.Utilities;
+
+namespace JD.AI.Tests.Commands;
+
+/// <summary>
+/// Tests for the gateway/dashboard CLI utilities.
+/// </summary>
+public sealed class GatewayCliTests
+{
+    [Fact]
+    public async Task GatewayHealthChecker_ReturnsFalse_WhenNothingIsRunning()
+    {
+        // Use a port that is almost certainly not in use
+        var result = await GatewayHealthChecker.IsRunningAsync("http://localhost:19999", timeoutMs: 500);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GatewayHealthChecker_WaitForHealthy_ReturnsFalse_WhenNothingIsRunning()
+    {
+        var result = await GatewayHealthChecker.WaitForHealthyAsync("http://localhost:19999", maxWaitMs: 1000);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GatewayHealthChecker_DefaultBaseUrl_UsesRuntimeDefaults()
+    {
+        var expected = $"http://{GatewayRuntimeDefaults.DefaultHost}:{GatewayRuntimeDefaults.DefaultPort}";
+        Assert.Equal(expected, GatewayHealthChecker.DefaultBaseUrl);
+    }
+
+    [Fact]
+    public void BrowserLauncher_Open_DoesNotThrow()
+    {
+        // Verify that calling Open with a dummy URL does not throw.
+        // The actual browser launch is a fire-and-forget side effect;
+        // we just verify no exception is raised on the current platform.
+        var ex = Record.Exception(() => BrowserLauncher.Open("http://localhost:0/test"));
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
## Summary
Adds gateway and dashboard CLI commands to both `jdai` and `jdai-daemon`, ensuring the gateway is always running when JD.AI is in use.

### New commands
| Command | Behavior |
|---------|----------|
| `jdai gateway` | Starts full gateway persistently (spawns `jdai-daemon run`), blocks until Ctrl+C |
| `jdai dashboard` | Ensures gateway running, opens browser to `http://localhost:15790/` |
| `jdai-daemon dashboard` | Opens browser to running daemon dashboard |

### Files
- `GatewayCliHandler.cs` — spawns daemon as subprocess, Ctrl+C to stop
- `DashboardCliHandler.cs` — starts gateway if needed, opens browser
- `BrowserLauncher.cs` — cross-platform (`cmd /c start`, `xdg-open`, `open`)
- `GatewayHealthChecker.cs` — health check polling with configurable timeout
- Daemon `Program.cs` — added `dashboard` System.CommandLine command
- TUI `Program.cs` + `CliOptions.cs` — routed `gateway`/`dashboard` subcommands
- 4 tests for health checker and browser launcher

### Design
`jdai gateway` delegates to `jdai-daemon run` rather than duplicating the full gateway host — keeps it simple and ensures feature parity.

Closes #411, closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)