### PR TITLE
fix(daemon): health check tries 127.0.0.1 before localhost

### DIFF
--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -172,30 +172,46 @@ rootCommand.Subcommands.Add(bridgeCommand);
 var dashboardCommand = new Command("dashboard", "Open the dashboard in the default browser");
 dashboardCommand.SetAction(async _ =>
 {
-    var baseUrl = $"http://{GatewayRuntimeDefaults.DefaultHost}:{GatewayRuntimeDefaults.DefaultPort}";
-    try
+    var port = GatewayRuntimeDefaults.DefaultPort;
+
+    // Try multiple addresses — some Windows configs resolve 'localhost' to IPv6
+    // which may not be bound when Kestrel listens on 0.0.0.0
+    string[] candidates = [$"http://127.0.0.1:{port}", $"http://localhost:{port}"];
+    string? reachableUrl = null;
+
+    using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+    foreach (var candidate in candidates)
     {
-        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
-        var response = await client.GetAsync(new Uri($"{baseUrl}{GatewayRuntimeDefaults.HealthPath}"));
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            Console.Error.WriteLine($"Daemon not running. Start with: {DaemonServiceIdentity.ToolCommand} run");
-            return 1;
+            var response = await client.GetAsync(new Uri($"{candidate}{GatewayRuntimeDefaults.HealthPath}"));
+            if (response.IsSuccessStatusCode)
+            {
+                reachableUrl = candidate;
+                break;
+            }
+        }
+        catch
+        {
+            // Try next candidate
         }
     }
-    catch
+
+    if (reachableUrl == null)
     {
-        Console.Error.WriteLine($"Daemon not running. Start with: {DaemonServiceIdentity.ToolCommand} run");
+        Console.Error.WriteLine($"Cannot reach gateway on port {port}.");
+        Console.Error.WriteLine($"Is the daemon running? Check with: {DaemonServiceIdentity.ToolCommand} status");
+        Console.Error.WriteLine($"Start with: {DaemonServiceIdentity.ToolCommand} run");
         return 1;
     }
 
-    Console.WriteLine($"Opening dashboard at {baseUrl}/ ...");
+    Console.WriteLine($"Opening dashboard at {reachableUrl}/ ...");
     if (OperatingSystem.IsWindows())
-        Process.Start(new ProcessStartInfo("cmd", $"/c start {baseUrl}/") { CreateNoWindow = true });
+        Process.Start(new ProcessStartInfo("cmd", $"/c start {reachableUrl}/") { CreateNoWindow = true });
     else if (OperatingSystem.IsLinux())
-        Process.Start("xdg-open", $"{baseUrl}/");
+        Process.Start("xdg-open", $"{reachableUrl}/");
     else if (OperatingSystem.IsMacOS())
-        Process.Start("open", $"{baseUrl}/");
+        Process.Start("open", $"{reachableUrl}/");
 
     return 0;
 });

--- a/src/JD.AI/Utilities/GatewayHealthChecker.cs
+++ b/src/JD.AI/Utilities/GatewayHealthChecker.cs
@@ -5,33 +5,48 @@ namespace JD.AI.Utilities;
 
 /// <summary>
 /// Checks whether the gateway daemon is running by probing its health endpoint.
+/// Tries 127.0.0.1 first (avoids IPv6 resolution issues on Windows), then localhost.
 /// </summary>
 internal static class GatewayHealthChecker
 {
+    private static readonly string[] DefaultCandidates =
+    [
+        $"http://127.0.0.1:{GatewayRuntimeDefaults.DefaultPort}",
+        $"http://localhost:{GatewayRuntimeDefaults.DefaultPort}"
+    ];
+
     public static string DefaultBaseUrl =>
-        $"http://{GatewayRuntimeDefaults.DefaultHost}:{GatewayRuntimeDefaults.DefaultPort}";
+        $"http://127.0.0.1:{GatewayRuntimeDefaults.DefaultPort}";
 
     public static async Task<bool> IsRunningAsync(string? baseUrl = null, int timeoutMs = 2000)
     {
-        baseUrl ??= DefaultBaseUrl;
-        try
+        using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(timeoutMs) };
+
+        var candidates = baseUrl != null ? [baseUrl] : DefaultCandidates;
+
+        foreach (var candidate in candidates)
         {
-            using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(timeoutMs) };
-            var response = await client.GetAsync(new Uri($"{baseUrl}{GatewayRuntimeDefaults.HealthPath}"))
-                .ConfigureAwait(false);
-            return response.IsSuccessStatusCode;
-        }
+            try
+            {
+                var response = await client
+                    .GetAsync(new Uri($"{candidate}{GatewayRuntimeDefaults.HealthPath}"))
+                    .ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                    return true;
+            }
 #pragma warning disable CA1031
-        catch
-        {
-            return false;
-        }
+            catch
+            {
+                // Try next candidate
+            }
 #pragma warning restore CA1031
+        }
+
+        return false;
     }
 
     public static async Task<bool> WaitForHealthyAsync(string? baseUrl = null, int maxWaitMs = 10000)
     {
-        baseUrl ??= DefaultBaseUrl;
         var sw = Stopwatch.StartNew();
         while (sw.ElapsedMilliseconds < maxWaitMs)
         {


### PR DESCRIPTION
## Problem
`jdai-daemon dashboard` reports "Daemon not running" even when the service is verifiably running and responding to curl.

## Root cause
On some Windows configurations, `localhost` resolves to IPv6 `[::1]` while Kestrel binds to `0.0.0.0` (IPv4 only). The `HttpClient` connects via IPv6 and gets a connection refused.

## Fix
- Try `127.0.0.1` first (reliable IPv4 loopback), fall back to `localhost`
- Same fix applied to both `jdai-daemon dashboard` and TUI `GatewayHealthChecker`
- Better error messaging: suggests checking `status` before `run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)