### PR TITLE
feat(dashboard): add Plugins, Logs, and Agent Monitor pages (#416, #417, #418)

### DIFF
--- a/src/JD.AI.Dashboard.Wasm/Components/InstallPluginDialog.razor
+++ b/src/JD.AI.Dashboard.Wasm/Components/InstallPluginDialog.razor
@@ -1,0 +1,25 @@
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField @bind-Value="_pluginId" Label="Plugin ID or URL" Placeholder="e.g. my-plugin or https://..."
+                      Variant="Variant.Outlined" data-testid="plugin-id-input" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit"
+                   Disabled="@string.IsNullOrWhiteSpace(_pluginId)" data-testid="plugin-install-submit">
+            Install
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private string _pluginId = "";
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    private void Cancel() => MudDialog.Cancel();
+    private void Submit() => MudDialog.Close(DialogResult.Ok(_pluginId.Trim()));
+}

--- a/src/JD.AI.Dashboard.Wasm/Layout/NavMenu.razor
+++ b/src/JD.AI.Dashboard.Wasm/Layout/NavMenu.razor
@@ -20,6 +20,15 @@
     <MudNavLink Href="/routing" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.AltRoute" data-testid="nav-routing">
         Routing
     </MudNavLink>
+    <MudNavLink Href="/plugins" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Extension" data-testid="nav-plugins">
+        Plugins
+    </MudNavLink>
+    <MudNavLink Href="/logs" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.EventNote" data-testid="nav-logs">
+        Logs
+    </MudNavLink>
+    <MudNavLink Href="/monitor" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.MonitorHeart" data-testid="nav-monitor">
+        Monitor
+    </MudNavLink>
     <MudNavLink Href="/settings" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Settings" data-testid="nav-settings">
         Settings
     </MudNavLink>

--- a/src/JD.AI.Dashboard.Wasm/Models/AuditEvent.cs
+++ b/src/JD.AI.Dashboard.Wasm/Models/AuditEvent.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace JD.AI.Dashboard.Wasm.Models;
+
+public record AuditEvent
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = "";
+
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset Timestamp { get; init; }
+
+    [JsonPropertyName("level")]
+    public string Level { get; init; } = "info";
+
+    [JsonPropertyName("agentId")]
+    public string? AgentId { get; init; }
+
+    [JsonPropertyName("eventType")]
+    public string EventType { get; init; } = "";
+
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = "";
+
+    [JsonPropertyName("payload")]
+    public string? Payload { get; init; }
+}

--- a/src/JD.AI.Dashboard.Wasm/Models/PluginInfo.cs
+++ b/src/JD.AI.Dashboard.Wasm/Models/PluginInfo.cs
@@ -1,0 +1,10 @@
+namespace JD.AI.Dashboard.Wasm.Models;
+
+public record PluginInfo
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Version { get; init; } = "";
+    public string Author { get; init; } = "";
+    public bool Enabled { get; init; }
+}

--- a/src/JD.AI.Dashboard.Wasm/Pages/AgentMonitor.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/AgentMonitor.razor
@@ -1,0 +1,210 @@
+@page "/monitor"
+@inject GatewayApiClient Api
+@inject SignalRService SignalR
+@inject ISnackbar Snackbar
+@implements IDisposable
+
+<PageTitle>Agent Monitor — JD.AI</PageTitle>
+
+<div class="jd-page-header">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+        <MudText Typo="Typo.h4">Agent Monitor</MudText>
+        <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="LoadAsync" Size="Size.Small"
+                       data-testid="refresh-button" />
+    </MudStack>
+</div>
+
+@if (_loading)
+{
+    @* Skeleton summary cards *@
+    <MudGrid>
+        @for (var i = 0; i < 4; i++)
+        {
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Class="pa-4 jd-stat-card" Elevation="0" data-testid="skeleton-stat-card">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                        <MudSkeleton SkeletonType="SkeletonType.Circle" Width="40px" Height="40px" />
+                        <MudStack Spacing="1">
+                            <MudSkeleton Width="80px" Height="14px" />
+                            <MudSkeleton Width="48px" Height="28px" />
+                        </MudStack>
+                    </MudStack>
+                </MudPaper>
+            </MudItem>
+        }
+    </MudGrid>
+}
+else
+{
+    @* Fleet summary *@
+    <MudGrid>
+        <MudItem xs="12" sm="6" md="3">
+            <MudPaper Class="pa-4 jd-stat-card" Elevation="0" data-testid="stat-card" data-name="total-agents">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                    <MudAvatar Color="Color.Primary" Variant="Variant.Outlined" Size="Size.Medium">
+                        <MudIcon Icon="@Icons.Material.Filled.SmartToy" />
+                    </MudAvatar>
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600;">Total Agents</MudText>
+                        <MudText Typo="Typo.h4" Style="font-weight:700;" data-testid="stat-value">@_agents.Length</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudPaper Class="pa-4 jd-stat-card" Elevation="0" data-testid="stat-card" data-name="total-turns">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                    <MudAvatar Color="Color.Secondary" Variant="Variant.Outlined" Size="Size.Medium">
+                        <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" />
+                    </MudAvatar>
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600;">Total Turns</MudText>
+                        <MudText Typo="Typo.h4" Style="font-weight:700;" data-testid="stat-value">@_agents.Sum(a => a.TurnCount)</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudPaper Class="pa-4 jd-stat-card" Elevation="0" data-testid="stat-card" data-name="providers">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                    <MudAvatar Color="Color.Tertiary" Variant="Variant.Outlined" Size="Size.Medium">
+                        <MudIcon Icon="@Icons.Material.Filled.Hub" />
+                    </MudAvatar>
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600;">Providers</MudText>
+                        <MudText Typo="Typo.h4" Style="font-weight:700;" data-testid="stat-value">@_agents.Select(a => a.Provider).Distinct().Count()</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" sm="6" md="3">
+            <MudPaper Class="pa-4 jd-stat-card" Elevation="0" data-testid="stat-card" data-name="active-sessions">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                    <MudAvatar Color="Color.Success" Variant="Variant.Outlined" Size="Size.Medium">
+                        <MudIcon Icon="@Icons.Material.Filled.Forum" />
+                    </MudAvatar>
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary" Style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600;">Active Sessions</MudText>
+                        <MudText Typo="Typo.h4" Style="font-weight:700;" data-testid="stat-value">@_sessions.Count(s => s.IsActive)</MudText>
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    @* Agent cards *@
+    @if (_agents.Length == 0)
+    {
+        <MudPaper Class="pa-6 mt-4" Elevation="0" data-testid="monitor-empty">
+            <MudStack AlignItems="AlignItems.Center" Spacing="2">
+                <MudIcon Icon="@Icons.Material.Filled.MonitorHeart" Size="Size.Large" Color="Color.Default" Style="opacity:0.3" />
+                <MudText Color="Color.Secondary">No agents to monitor.</MudText>
+            </MudStack>
+        </MudPaper>
+    }
+    else
+    {
+        <MudGrid Class="mt-4">
+            @foreach (var agent in _agents)
+            {
+                var agentSessions = _sessions.Count(s => string.Equals(s.ModelId, agent.Model, StringComparison.OrdinalIgnoreCase));
+                var health = GetHealthColor(agent);
+
+                <MudItem xs="12" sm="6" md="4">
+                    <MudPaper Class="pa-4" Elevation="1" data-testid="agent-card">
+                        <MudStack Spacing="2">
+                            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                                <MudText Typo="Typo.h6" Style="font-weight:600;">@agent.Id</MudText>
+                                <MudChip T="string" Size="Size.Small" Color="@health" data-testid="agent-health">
+                                    @GetHealthLabel(health)
+                                </MudChip>
+                            </MudStack>
+                            <MudDivider />
+                            <MudSimpleTable Dense="true" Hover="false" Elevation="0">
+                                <tbody>
+                                    <tr>
+                                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Provider</MudText></td>
+                                        <td><MudText Typo="Typo.body2">@agent.Provider</MudText></td>
+                                    </tr>
+                                    <tr>
+                                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Model</MudText></td>
+                                        <td><MudText Typo="Typo.body2">@agent.Model</MudText></td>
+                                    </tr>
+                                    <tr>
+                                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Turns</MudText></td>
+                                        <td><MudText Typo="Typo.body2">@agent.TurnCount</MudText></td>
+                                    </tr>
+                                    <tr>
+                                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Sessions</MudText></td>
+                                        <td><MudText Typo="Typo.body2">@agentSessions</MudText></td>
+                                    </tr>
+                                    <tr>
+                                        <td><MudText Typo="Typo.body2" Color="Color.Secondary">Created</MudText></td>
+                                        <td><MudText Typo="Typo.body2">@agent.CreatedAt.LocalDateTime.ToString("g")</MudText></td>
+                                    </tr>
+                                </tbody>
+                            </MudSimpleTable>
+                        </MudStack>
+                    </MudPaper>
+                </MudItem>
+            }
+        </MudGrid>
+    }
+}
+
+@code {
+    private AgentInfo[] _agents = [];
+    private SessionInfo[] _sessions = [];
+    private bool _loading = true;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _activityHandler = (_, _) => InvokeAsync(async () =>
+        {
+            await LoadAsync();
+            StateHasChanged();
+        });
+        SignalR.OnActivityEvent += _activityHandler;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try
+        {
+            _agents = await Api.GetAgentsAsync();
+            _sessions = await Api.GetSessionsAsync();
+        }
+        catch
+        {
+            _agents = [];
+            _sessions = [];
+            Snackbar.Add("Failed to load agent data", Severity.Error);
+        }
+        _loading = false;
+    }
+
+    private static Color GetHealthColor(AgentInfo agent)
+    {
+        // Simple heuristic: high turn count with recent creation = healthy
+        // No error rate data available yet, so use turn activity as proxy
+        if (agent.TurnCount == 0) return Color.Warning;
+        return Color.Success;
+    }
+
+    private static string GetHealthLabel(Color color) => color switch
+    {
+        Color.Success => "Healthy",
+        Color.Warning => "Idle",
+        Color.Error => "Error",
+        _ => "Unknown"
+    };
+
+    public void Dispose()
+    {
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
+    }
+}

--- a/src/JD.AI.Dashboard.Wasm/Pages/Logs.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Logs.razor
@@ -1,0 +1,181 @@
+@page "/logs"
+@inject GatewayApiClient Api
+@inject ISnackbar Snackbar
+@implements IDisposable
+
+<PageTitle>Logs — JD.AI</PageTitle>
+
+<div class="jd-page-header">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+        <MudText Typo="Typo.h4">Logs</MudText>
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudSwitch T="bool" @bind-Value="_autoRefresh" Color="Color.Primary" Label="Auto-refresh"
+                       data-testid="auto-refresh-toggle" />
+            <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="LoadAsync" Size="Size.Small"
+                           data-testid="refresh-button" />
+        </MudStack>
+    </MudStack>
+</div>
+
+<MudPaper Class="pa-4 mb-4" Elevation="0" data-testid="log-filters">
+    <MudGrid>
+        <MudItem xs="12" sm="3">
+            <MudSelect T="string" @bind-Value="_severityFilter" Label="Severity" Variant="Variant.Outlined" Dense="true"
+                       Clearable="true" data-testid="severity-filter">
+                <MudSelectItem Value="@("info")">Info</MudSelectItem>
+                <MudSelectItem Value="@("warn")">Warning</MudSelectItem>
+                <MudSelectItem Value="@("error")">Error</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" sm="3">
+            <MudTextField T="string" @bind-Value="_agentFilter" Label="Agent" Variant="Variant.Outlined" Margin="Margin.Dense"
+                          Clearable="true" data-testid="agent-filter" />
+        </MudItem>
+        <MudItem xs="12" sm="3">
+            <MudTextField T="string" @bind-Value="_searchText" Label="Search" Variant="Variant.Outlined" Margin="Margin.Dense"
+                          Clearable="true" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                          data-testid="search-filter" />
+        </MudItem>
+        <MudItem xs="12" sm="3" Class="d-flex align-end">
+            <MudButton OnClick="LoadAsync" Variant="Variant.Outlined" Size="Size.Small"
+                       data-testid="apply-filters">Apply</MudButton>
+        </MudItem>
+    </MudGrid>
+</MudPaper>
+
+@if (_loading)
+{
+    <MudPaper Elevation="0">
+        @for (var i = 0; i < 5; i++)
+        {
+            <div class="jd-skeleton-row">
+                <MudSkeleton Width="120px" Height="14px" />
+                <MudSkeleton Width="72px" Height="24px" />
+                <MudSkeleton Width="100px" Height="14px" />
+                <MudSkeleton Width="100px" Height="14px" />
+                <MudSkeleton Width="300px" Height="14px" />
+            </div>
+        }
+    </MudPaper>
+}
+else if (_filteredEvents.Length == 0)
+{
+    <MudPaper Class="pa-6" Elevation="0" data-testid="logs-empty">
+        <MudStack AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.EventNote" Size="Size.Large" Color="Color.Default" Style="opacity:0.3" />
+            <MudText Color="Color.Secondary">No log events found.</MudText>
+        </MudStack>
+    </MudPaper>
+}
+else
+{
+    <MudPaper Elevation="0">
+        <MudDataGrid Items="@_filteredEvents" Dense="true" Hover="true" SortMode="SortMode.Multiple"
+                     data-testid="logs-grid">
+            <Columns>
+                <PropertyColumn Property="x => x.Timestamp" Title="Timestamp" Format="g" />
+                <TemplateColumn Title="Level">
+                    <CellTemplate>
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+                                 Color="@GetLevelColor(context.Item.Level)"
+                                 data-testid="log-level">
+                            @context.Item.Level
+                        </MudChip>
+                    </CellTemplate>
+                </TemplateColumn>
+                <PropertyColumn Property="x => x.AgentId" Title="Agent" />
+                <PropertyColumn Property="x => x.EventType" Title="Event" />
+                <PropertyColumn Property="x => x.Message" Title="Message" />
+                <TemplateColumn Title="" CellClass="d-flex justify-end">
+                    <CellTemplate>
+                        @if (!string.IsNullOrEmpty(context.Item.Payload))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" Size="Size.Small"
+                                           OnClick="@(() => ToggleDetail(context.Item.Id))"
+                                           data-testid="log-detail-button" />
+                        }
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
+    </MudPaper>
+}
+
+@if (_selectedEventId is not null && _allEvents.FirstOrDefault(e => e.Id == _selectedEventId) is { } selected)
+{
+    <MudPaper Class="pa-4 mt-4" Elevation="2" data-testid="log-detail">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="mb-3">
+            <MudText Typo="Typo.h6">Event Detail</MudText>
+            <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="@(() => _selectedEventId = null)" />
+        </MudStack>
+        <MudText Style="white-space: pre-wrap; font-family: monospace; font-size: 0.85rem;">@selected.Payload</MudText>
+    </MudPaper>
+}
+
+@code {
+    private AuditEvent[] _allEvents = [];
+    private AuditEvent[] _filteredEvents = [];
+    private bool _loading = true;
+    private string? _severityFilter;
+    private string? _agentFilter;
+    private string? _searchText;
+    private string? _selectedEventId;
+    private bool _autoRefresh;
+    private Timer? _timer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+        _timer = new Timer(async _ =>
+        {
+            if (_autoRefresh)
+            {
+                await InvokeAsync(async () =>
+                {
+                    await LoadAsync();
+                    StateHasChanged();
+                });
+            }
+        }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try { _allEvents = await Api.GetAuditEventsAsync(); }
+        catch { _allEvents = []; Snackbar.Add("Failed to load audit events", Severity.Error); }
+        ApplyFilters();
+        _loading = false;
+    }
+
+    private void ApplyFilters()
+    {
+        var events = _allEvents.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(_severityFilter))
+            events = events.Where(e => string.Equals(e.Level, _severityFilter, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(_agentFilter))
+            events = events.Where(e => e.AgentId is not null &&
+                e.AgentId.Contains(_agentFilter, StringComparison.OrdinalIgnoreCase));
+
+        if (!string.IsNullOrWhiteSpace(_searchText))
+            events = events.Where(e => e.Message.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+                e.EventType.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+
+        _filteredEvents = events.ToArray();
+    }
+
+    private void ToggleDetail(string id) =>
+        _selectedEventId = _selectedEventId == id ? null : id;
+
+    private static Color GetLevelColor(string level) => level.ToLowerInvariant() switch
+    {
+        "error" => Color.Error,
+        "warn" or "warning" => Color.Warning,
+        "info" => Color.Info,
+        _ => Color.Default
+    };
+
+    public void Dispose() => _timer?.Dispose();
+}

--- a/src/JD.AI.Dashboard.Wasm/Pages/Plugins.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Plugins.razor
@@ -1,0 +1,140 @@
+@page "/plugins"
+@inject GatewayApiClient Api
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<PageTitle>Plugins — JD.AI</PageTitle>
+
+<div class="jd-page-header">
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+        <MudText Typo="Typo.h4">Plugins</MudText>
+        <MudStack Row="true" Spacing="2">
+            <MudButton OnClick="OpenInstallDialogAsync" Variant="Variant.Filled" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Add" data-testid="install-plugin-button">
+                Install Plugin
+            </MudButton>
+            <MudIconButton Icon="@Icons.Material.Filled.Refresh" OnClick="LoadAsync" Size="Size.Small"
+                           data-testid="refresh-button" />
+        </MudStack>
+    </MudStack>
+</div>
+
+@if (_loading)
+{
+    <MudPaper Elevation="0">
+        @for (var i = 0; i < 5; i++)
+        {
+            <div class="jd-skeleton-row">
+                <MudSkeleton Width="160px" Height="14px" />
+                <MudSkeleton Width="80px" Height="14px" />
+                <MudSkeleton Width="100px" Height="14px" />
+                <MudSkeleton Width="72px" Height="24px" />
+                <MudSpacer />
+                <MudSkeleton Width="80px" Height="28px" />
+                <MudSkeleton SkeletonType="SkeletonType.Circle" Width="28px" Height="28px" />
+            </div>
+        }
+    </MudPaper>
+}
+else if (_plugins is null || _plugins.Length == 0)
+{
+    <MudPaper Class="pa-6" Elevation="0" data-testid="plugins-empty">
+        <MudStack AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.Extension" Size="Size.Large" Color="Color.Default" Style="opacity:0.3" />
+            <MudText Color="Color.Secondary">No plugins installed.</MudText>
+        </MudStack>
+    </MudPaper>
+}
+else
+{
+    <MudPaper Elevation="0">
+        <MudDataGrid Items="@_plugins" Dense="true" Hover="true" data-testid="plugins-grid">
+            <Columns>
+                <PropertyColumn Property="x => x.Name" Title="Name" />
+                <PropertyColumn Property="x => x.Version" Title="Version" />
+                <PropertyColumn Property="x => x.Author" Title="Author" />
+                <TemplateColumn Title="Status">
+                    <CellTemplate>
+                        <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+                                 Color="@(context.Item.Enabled ? Color.Success : Color.Default)"
+                                 data-testid="plugin-status">
+                            @(context.Item.Enabled ? "Enabled" : "Disabled")
+                        </MudChip>
+                    </CellTemplate>
+                </TemplateColumn>
+                <TemplateColumn Title="" CellClass="d-flex justify-end">
+                    <CellTemplate>
+                        <MudStack Row="true" Spacing="1">
+                            <MudSwitch T="bool" Value="@context.Item.Enabled"
+                                       ValueChanged="@(v => TogglePluginAsync(context.Item))"
+                                       Color="Color.Success" Size="Size.Small"
+                                       data-testid="plugin-toggle" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                           OnClick="@(() => UninstallPluginAsync(context.Item))"
+                                           data-testid="plugin-uninstall" />
+                        </MudStack>
+                    </CellTemplate>
+                </TemplateColumn>
+            </Columns>
+        </MudDataGrid>
+    </MudPaper>
+}
+
+@code {
+    private PluginInfo[]? _plugins;
+    private bool _loading = true;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        try { _plugins = await Api.GetPluginsAsync(); }
+        catch { _plugins = null; Snackbar.Add("Failed to load plugins", Severity.Error); }
+        _loading = false;
+    }
+
+    private async Task TogglePluginAsync(PluginInfo plugin)
+    {
+        try
+        {
+            if (plugin.Enabled)
+                await Api.DisablePluginAsync(plugin.Id);
+            else
+                await Api.EnablePluginAsync(plugin.Id);
+
+            Snackbar.Add($"Plugin {plugin.Name} {(plugin.Enabled ? "disabled" : "enabled")}", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex) { Snackbar.Add($"Failed: {ex.Message}", Severity.Error); }
+    }
+
+    private async Task UninstallPluginAsync(PluginInfo plugin)
+    {
+        try
+        {
+            await Api.UninstallPluginAsync(plugin.Id);
+            Snackbar.Add($"Plugin {plugin.Name} uninstalled", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex) { Snackbar.Add($"Failed: {ex.Message}", Severity.Error); }
+    }
+
+    private async Task OpenInstallDialogAsync()
+    {
+        var parameters = new DialogParameters<InstallPluginDialog>();
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<InstallPluginDialog>("Install Plugin", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled && result.Data is string pluginId && !string.IsNullOrWhiteSpace(pluginId))
+        {
+            try
+            {
+                await Api.InstallPluginAsync(pluginId);
+                Snackbar.Add("Plugin installed", Severity.Success);
+                await LoadAsync();
+            }
+            catch (Exception ex) { Snackbar.Add($"Install failed: {ex.Message}", Severity.Error); }
+        }
+    }
+}

--- a/src/JD.AI.Dashboard.Wasm/Services/GatewayApiClient.cs
+++ b/src/JD.AI.Dashboard.Wasm/Services/GatewayApiClient.cs
@@ -130,4 +130,33 @@ public sealed class GatewayApiClient(HttpClient http)
 
     public Task SyncOpenClawAsync() =>
         http.PostAsync(new Uri("api/gateway/openclaw/agents/sync", UriKind.Relative), null);
+
+    // Plugins
+    public async Task<PluginInfo[]> GetPluginsAsync()
+        => await http.GetFromJsonAsync<PluginInfo[]>("api/plugins") ?? [];
+
+    public async Task InstallPluginAsync(string pluginId)
+    {
+        var response = await http.PostAsJsonAsync("api/plugins/install", new { pluginId });
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task EnablePluginAsync(string id)
+    {
+        var response = await http.PostAsync(new Uri($"api/plugins/{Uri.EscapeDataString(id)}/enable", UriKind.Relative), null);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DisablePluginAsync(string id)
+    {
+        var response = await http.PostAsync(new Uri($"api/plugins/{Uri.EscapeDataString(id)}/disable", UriKind.Relative), null);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public Task UninstallPluginAsync(string id) =>
+        http.DeleteAsync(new Uri($"api/plugins/{Uri.EscapeDataString(id)}", UriKind.Relative));
+
+    // Audit / Logs
+    public async Task<AuditEvent[]> GetAuditEventsAsync(int limit = 100)
+        => await http.GetFromJsonAsync<AuditEvent[]>($"api/audit?limit={limit}") ?? [];
 }


### PR DESCRIPTION
## Summary
Three new dashboard pages filling the biggest UI gaps — all leveraging existing backend endpoints.

### Plugins page (`/plugins`) — #418
- MudDataGrid: name, version, enabled/disabled toggle, uninstall
- Install dialog for adding plugins by ID/URL
- Empty state handling

### Logs page (`/logs`) — #417
- Audit event viewer with severity filtering (info/warn/error chips)
- Agent filter dropdown, text search
- Detail panel for full event payload
- Auto-refresh toggle (5s polling)

### Agent Monitor page (`/monitor`) — #416
- Fleet summary cards (total agents, turns, providers, active sessions)
- Per-agent health cards with turn count and provider info
- Real-time updates via SignalR `OnActivityEvent`

### Also includes
- `InstallPluginDialog.razor` component
- `PluginInfo.cs` and `AuditEvent.cs` DTOs
- 6 new `GatewayApiClient` methods (plugins + audit)
- NavMenu updated with Plugins, Logs, Monitor entries

Build clean, 0 errors.

Closes #416, closes #417, closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)