### PR TITLE
feat(dashboard): real-time SignalR updates on all pages (#421)

### DIFF
--- a/src/JD.AI.Dashboard.Wasm/Pages/Agents.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Agents.razor
@@ -1,7 +1,9 @@
 @page "/agents"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@implements IDisposable
 
 <PageTitle>Agents — JD.AI</PageTitle>
 
@@ -66,8 +68,27 @@ else
 @code {
     private AgentInfo[]? _agents;
     private bool _loading = true;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        _activityHandler = (_, e) =>
+        {
+            var type = e.Activity.EventType;
+            if (type.Contains("agent", StringComparison.OrdinalIgnoreCase) ||
+                type.Contains("spawn", StringComparison.OrdinalIgnoreCase))
+            {
+                InvokeAsync(async () =>
+                {
+                    Snackbar.Add($"Agent update: {e.Activity.Message}", Severity.Info);
+                    await LoadAsync();
+                    StateHasChanged();
+                });
+            }
+        };
+        SignalR.OnActivityEvent += _activityHandler;
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -100,5 +121,11 @@ else
             }
             catch (Exception ex) { Snackbar.Add($"Failed: {ex.Message}", Severity.Error); }
         }
+    }
+
+    public void Dispose()
+    {
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
     }
 }

--- a/src/JD.AI.Dashboard.Wasm/Pages/Channels.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Channels.razor
@@ -1,7 +1,9 @@
 @page "/channels"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@implements IDisposable
 
 <PageTitle>Channels — JD.AI</PageTitle>
 
@@ -109,8 +111,23 @@ else
 @code {
     private ChannelInfo[]? _channels;
     private bool _loading = true;
+    private EventHandler<ChannelStatusEventArgs>? _channelHandler;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        _channelHandler = (_, e) =>
+        {
+            InvokeAsync(async () =>
+            {
+                Snackbar.Add($"{e.Channel} {(e.Connected ? "connected" : "disconnected")}",
+                    e.Connected ? Severity.Success : Severity.Warning);
+                await LoadAsync();
+                StateHasChanged();
+            });
+        };
+        SignalR.OnChannelStatusChanged += _channelHandler;
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -176,4 +193,10 @@ else
         "web" => Icons.Material.Filled.Language,
         _ => Icons.Material.Filled.Cable
     };
+
+    public void Dispose()
+    {
+        if (_channelHandler is not null)
+            SignalR.OnChannelStatusChanged -= _channelHandler;
+    }
 }

--- a/src/JD.AI.Dashboard.Wasm/Pages/Logs.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Logs.razor
@@ -1,5 +1,6 @@
 @page "/logs"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
 @inject ISnackbar Snackbar
 @implements IDisposable
 
@@ -122,9 +123,20 @@ else
     private string? _selectedEventId;
     private bool _autoRefresh;
     private Timer? _timer;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
 
     protected override async Task OnInitializedAsync()
     {
+        _activityHandler = (_, _) =>
+        {
+            InvokeAsync(async () =>
+            {
+                await LoadAsync();
+                StateHasChanged();
+            });
+        };
+        SignalR.OnActivityEvent += _activityHandler;
+
         await LoadAsync();
         _timer = new Timer(async _ =>
         {
@@ -177,5 +189,10 @@ else
         _ => Color.Default
     };
 
-    public void Dispose() => _timer?.Dispose();
+    public void Dispose()
+    {
+        _timer?.Dispose();
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
+    }
 }

--- a/src/JD.AI.Dashboard.Wasm/Pages/Plugins.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Plugins.razor
@@ -1,7 +1,9 @@
 @page "/plugins"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@implements IDisposable
 
 <PageTitle>Plugins — JD.AI</PageTitle>
 
@@ -83,8 +85,25 @@ else
 @code {
     private PluginInfo[]? _plugins;
     private bool _loading = true;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        _activityHandler = (_, e) =>
+        {
+            var type = e.Activity.EventType;
+            if (type.Contains("plugin", StringComparison.OrdinalIgnoreCase))
+            {
+                InvokeAsync(async () =>
+                {
+                    await LoadAsync();
+                    StateHasChanged();
+                });
+            }
+        };
+        SignalR.OnActivityEvent += _activityHandler;
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -136,5 +155,11 @@ else
             }
             catch (Exception ex) { Snackbar.Add($"Install failed: {ex.Message}", Severity.Error); }
         }
+    }
+
+    public void Dispose()
+    {
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
     }
 }

--- a/src/JD.AI.Dashboard.Wasm/Pages/Providers.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Providers.razor
@@ -1,5 +1,8 @@
 @page "/providers"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
+@inject ISnackbar Snackbar
+@implements IDisposable
 
 <PageTitle>Providers — JD.AI</PageTitle>
 
@@ -104,8 +107,26 @@ else
 @code {
     private ProviderInfo[]? _providers;
     private bool _loading = true;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        _activityHandler = (_, e) =>
+        {
+            var type = e.Activity.EventType;
+            if (type.Contains("provider", StringComparison.OrdinalIgnoreCase))
+            {
+                InvokeAsync(async () =>
+                {
+                    Snackbar.Add($"Provider update: {e.Activity.Message}", Severity.Info);
+                    await LoadAsync();
+                    StateHasChanged();
+                });
+            }
+        };
+        SignalR.OnActivityEvent += _activityHandler;
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -113,5 +134,11 @@ else
         try { _providers = await Api.GetProvidersAsync(); }
         catch { _providers = null; }
         _loading = false;
+    }
+
+    public void Dispose()
+    {
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
     }
 }

--- a/src/JD.AI.Dashboard.Wasm/Pages/Sessions.razor
+++ b/src/JD.AI.Dashboard.Wasm/Pages/Sessions.razor
@@ -1,6 +1,8 @@
 @page "/sessions"
 @inject GatewayApiClient Api
+@inject SignalRService SignalR
 @inject ISnackbar Snackbar
+@implements IDisposable
 
 <PageTitle>Sessions — JD.AI</PageTitle>
 
@@ -120,8 +122,26 @@ else
     private SessionInfo[]? _sessions;
     private SessionInfo? _selectedSession;
     private bool _loading = true;
+    private EventHandler<ActivityEventArgs>? _activityHandler;
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        _activityHandler = (_, e) =>
+        {
+            var type = e.Activity.EventType;
+            if (type.Contains("session", StringComparison.OrdinalIgnoreCase))
+            {
+                InvokeAsync(async () =>
+                {
+                    Snackbar.Add($"Session update: {e.Activity.Message}", Severity.Info);
+                    await LoadAsync();
+                    StateHasChanged();
+                });
+            }
+        };
+        SignalR.OnActivityEvent += _activityHandler;
+        await LoadAsync();
+    }
 
     private async Task LoadAsync()
     {
@@ -160,4 +180,10 @@ else
 
     private static string GetTurnBorderStyle(string role) =>
         $"border-left: 3px solid {(string.Equals(role, "user", StringComparison.Ordinal) ? "var(--mud-palette-primary)" : "var(--mud-palette-secondary)")}";
+
+    public void Dispose()
+    {
+        if (_activityHandler is not null)
+            SignalR.OnActivityEvent -= _activityHandler;
+    }
 }


### PR DESCRIPTION
## Summary
All dashboard pages now auto-update via SignalR — no more manual refresh needed.

### Pages updated
| Page | Event filter | Behavior |
|------|-------------|----------|
| **Agents** | agent/spawn events | Auto-refresh list + toast notification |
| **Sessions** | session events | Auto-add new sessions + update stats |
| **Channels** | channel status changes | Live connection indicators + toast |
| **Providers** | provider events | Real-time availability updates |
| **Plugins** | plugin events | Auto-refresh on install/uninstall |
| **Logs** | all events | Immediate refresh (complements 5s polling) |

### Pattern
Each page subscribes to `SignalR.OnActivityEvent`, filters for relevant events, calls `InvokeAsync` + `StateHasChanged()`, and disposes cleanly.

Build clean (0 errors). Closes #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)