### PR TITLE
feat(cli): auto-start gateway on TUI launch (#413)

### DIFF
--- a/src/JD.AI/Program.cs
+++ b/src/JD.AI/Program.cs
@@ -1,6 +1,7 @@
 using JD.AI;
 using JD.AI.Agent;
 using JD.AI.Commands;
+using JD.AI.Utilities;
 using JD.AI.Core.Agents;
 using JD.AI.Core.Agents.Checkpointing;
 using JD.AI.Core.Agents.Orchestration;
@@ -317,7 +318,28 @@ if (pendingUpdate is not null)
     AnsiConsole.WriteLine();
 }
 
-// 12. Interactive TUI loop
+// 12. Auto-start gateway if not already running (TUI interactive mode only)
+if (!opts.GatewayMode)
+{
+    if (!await GatewayHealthChecker.IsRunningAsync().ConfigureAwait(false))
+    {
+        var daemonProcess = GatewayAutoStart.StartBackground();
+        if (daemonProcess != null)
+        {
+            var healthy = await GatewayHealthChecker.WaitForHealthyAsync(maxWaitMs: 10000).ConfigureAwait(false);
+            if (healthy)
+                AnsiConsole.MarkupLine("[dim]Gateway started automatically[/]");
+            else
+                AnsiConsole.MarkupLine("[yellow]Warning: Gateway did not start in time[/]");
+        }
+    }
+    else
+    {
+        AnsiConsole.MarkupLine("[dim]Gateway already running[/]");
+    }
+}
+
+// 13. Interactive TUI loop
 var loop = new InteractiveLoop(
     session, opts, selectedModel, allModels, kernel, registry,
     providerConfig, configStore, metadataProvider, governance,
@@ -337,5 +359,7 @@ if (gatewayHost is not null)
     await gatewayHost.StopAsync().ConfigureAwait(false);
     (gatewayHost as IDisposable)?.Dispose();
 }
+
+GatewayAutoStart.StopBackground();
 
 return exitCode;

--- a/src/JD.AI/Utilities/GatewayAutoStart.cs
+++ b/src/JD.AI/Utilities/GatewayAutoStart.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+using JD.AI.Core.Infrastructure;
+
+namespace JD.AI.Utilities;
+
+/// <summary>
+/// Auto-starts the gateway daemon in the background when the TUI launches.
+/// The spawned process is non-persistent — it dies when the TUI exits.
+/// </summary>
+internal static class GatewayAutoStart
+{
+    private static Process? _daemonProcess;
+
+    /// <summary>
+    /// Starts jdai-daemon in background. Returns the process, or null if it couldn't start.
+    /// The process is killed when the TUI exits.
+    /// </summary>
+    public static Process? StartBackground()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(DaemonServiceIdentity.ToolCommand, "run")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+
+            _daemonProcess = Process.Start(psi);
+
+            // Register cleanup on process exit
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => StopBackground();
+            Console.CancelKeyPress += (_, _) => StopBackground();
+
+            return _daemonProcess;
+        }
+#pragma warning disable CA1031
+        catch
+        {
+            return null; // jdai-daemon not installed or not in PATH
+        }
+#pragma warning restore CA1031
+    }
+
+    public static void StopBackground()
+    {
+        try
+        {
+            if (_daemonProcess is { HasExited: false })
+            {
+                _daemonProcess.Kill(entireProcessTree: true);
+                _daemonProcess.Dispose();
+                _daemonProcess = null;
+            }
+        }
+#pragma warning disable CA1031
+        catch { /* best effort */ }
+#pragma warning restore CA1031
+    }
+}


### PR DESCRIPTION
## Summary
TUI now automatically starts the gateway when entering interactive mode. No more manual `jdai gateway` or `jdai-daemon run` required.

### Behavior
- TUI starts → health check on `127.0.0.1:15790`
- If gateway running → connect and proceed
- If not → spawn `jdai-daemon run` in background → wait up to 10s for health
- On TUI exit → kill the spawned daemon (non-persistent)
- Skipped for subcommands, `--gateway` flag, and print mode

### Files
- `GatewayAutoStart.cs` — background process spawning with cleanup on exit
- `Program.cs` — auto-start wired between update check and TUI loop

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)