### PR TITLE
feat(workflows): add WorkflowOrchestrator — end-to-end detect→match→execute pipeline (#406)

### DIFF
--- a/src/JD.AI.Core/Security/ApiKeyRotation.cs
+++ b/src/JD.AI.Core/Security/ApiKeyRotation.cs
@@ -109,6 +109,20 @@ public sealed class ApiKeyRotation
         }
     }
 
+    /// <summary>Records a usage touch on the specified key.</summary>
+    public bool TouchKey(string key)
+    {
+        lock (_lock)
+        {
+            if (!_keys.TryGetValue(key, out var record))
+                return false;
+
+            record.LastUsedAt = DateTimeOffset.UtcNow;
+            record.UsageCount++;
+            return true;
+        }
+    }
+
     /// <summary>Gets all key records (for admin/audit purposes).</summary>
     public IReadOnlyList<ApiKeyRecord> GetAllKeys()
     {
@@ -138,6 +152,8 @@ public sealed class ApiKeyRecord
     public bool IsRevoked { get; set; }
     public DateTimeOffset? RevokedAt { get; set; }
     public string? PreviousKey { get; init; }
+    public DateTimeOffset? LastUsedAt { get; set; }
+    public long UsageCount { get; set; }
 
     /// <summary>Whether this key has passed its expiry date.</summary>
     public bool IsExpired => ExpiresAt.HasValue && DateTimeOffset.UtcNow > ExpiresAt.Value;

--- a/src/JD.AI.Daemon/Program.cs
+++ b/src/JD.AI.Daemon/Program.cs
@@ -374,6 +374,8 @@ static void RunDaemon(string[] args)
         new FileWorkflowCatalog(Path.Combine(DataDirectories.Root, "workflows")));
     builder.Services.AddSingleton<IWorkflowBridge, WorkflowBridge>();
     builder.Services.AddSingleton<IPromptIntentClassifier, TfIdfIntentClassifier>();
+    builder.Services.AddSingleton<IWorkflowMatcher, WorkflowMatcher>();
+    builder.Services.AddSingleton<IWorkflowOrchestrator, WorkflowOrchestrator>();
 
     // --- Channel factory & orchestrator ---
     builder.Services.AddSingleton<ChannelFactory>();

--- a/src/JD.AI.Gateway/Endpoints/WorkflowEndpoints.cs
+++ b/src/JD.AI.Gateway/Endpoints/WorkflowEndpoints.cs
@@ -80,5 +80,13 @@ public static class WorkflowEndpoints
         })
         .WithName("ClassifyPrompt")
         .WithDescription("Classify a prompt as workflow or conversation using TF-IDF intent classification.");
+
+        group.MapPost("/process", async (WorkflowProcessRequest request, IWorkflowOrchestrator orchestrator, CancellationToken ct) =>
+        {
+            var result = await orchestrator.ProcessAsync(request.Prompt, ct: ct);
+            return Results.Ok(result);
+        })
+        .WithName("ProcessWorkflow")
+        .WithDescription("End-to-end workflow pipeline: classify prompt, match against catalog, and execute if found.");
     }
 }

--- a/src/JD.AI.Gateway/Models/WorkflowModels.cs
+++ b/src/JD.AI.Gateway/Models/WorkflowModels.cs
@@ -2,3 +2,4 @@ namespace JD.AI.Gateway.Models;
 
 public record WorkflowRunRequest(string WorkflowName, string? Version, string Prompt, string? SessionId);
 public record WorkflowClassifyRequest(string Prompt);
+public record WorkflowProcessRequest(string Prompt);

--- a/src/JD.AI.Gateway/Program.cs
+++ b/src/JD.AI.Gateway/Program.cs
@@ -158,6 +158,8 @@ builder.Services.AddSingleton<IWorkflowCatalog>(_ =>
     new FileWorkflowCatalog(Path.Combine(DataDirectories.Root, "workflows")));
 builder.Services.AddSingleton<IWorkflowBridge, WorkflowBridge>();
 builder.Services.AddSingleton<IPromptIntentClassifier, TfIdfIntentClassifier>();
+builder.Services.AddSingleton<IWorkflowMatcher, WorkflowMatcher>();
+builder.Services.AddSingleton<IWorkflowOrchestrator, WorkflowOrchestrator>();
 
 // --- Channel factory & orchestrator ---
 builder.Services.AddSingleton<ChannelFactory>();

--- a/src/JD.AI.Workflows/Interfaces.cs
+++ b/src/JD.AI.Workflows/Interfaces.cs
@@ -47,3 +47,13 @@ public interface IWorkflowEmitter
 {
     WorkflowArtifact Emit(AgentWorkflowDefinition definition, WorkflowExportFormat format = WorkflowExportFormat.Json);
 }
+
+/// <summary>
+/// Orchestrates the full workflow pipeline: classify → match → execute.
+/// Single entry point for the detect-match-execute workflow pipeline.
+/// </summary>
+public interface IWorkflowOrchestrator
+{
+    Task<WorkflowOrchestratorResult> ProcessAsync(
+        string prompt, Steps.AgentWorkflowData? data = null, CancellationToken ct = default);
+}

--- a/src/JD.AI.Workflows/WorkflowOrchestrator.cs
+++ b/src/JD.AI.Workflows/WorkflowOrchestrator.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics;
+using JD.AI.Workflows.Steps;
+
+namespace JD.AI.Workflows;
+
+/// <summary>
+/// Orchestrates the full workflow pipeline:
+/// 1. Classify prompt (is this a workflow?)
+/// 2. Match against catalog (do we have a workflow for this?)
+/// 3. If match found, execute via WorkflowBridge
+/// 4. If no match, return "planning needed" result
+/// </summary>
+public sealed class WorkflowOrchestrator : IWorkflowOrchestrator
+{
+    private readonly IPromptIntentClassifier _classifier;
+    private readonly IWorkflowMatcher _matcher;
+    private readonly IWorkflowBridge _bridge;
+
+    public WorkflowOrchestrator(
+        IPromptIntentClassifier classifier,
+        IWorkflowMatcher matcher,
+        IWorkflowBridge bridge)
+    {
+        _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
+        _matcher = matcher ?? throw new ArgumentNullException(nameof(matcher));
+        _bridge = bridge ?? throw new ArgumentNullException(nameof(bridge));
+    }
+
+    /// <inheritdoc/>
+    public async Task<WorkflowOrchestratorResult> ProcessAsync(
+        string prompt,
+        AgentWorkflowData? data = null,
+        CancellationToken ct = default)
+    {
+        // 1. Classify
+        if (string.IsNullOrWhiteSpace(prompt))
+            return WorkflowOrchestratorResult.PassThrough(
+                new IntentClassification(false, 0.0, []));
+
+        var intent = _classifier.Classify(prompt);
+        if (!intent.IsWorkflow)
+            return WorkflowOrchestratorResult.PassThrough(intent);
+
+        // 2. Match
+        var match = await _matcher.MatchAsync(new AgentRequest(prompt), ct)
+            .ConfigureAwait(false);
+
+        if (match is null)
+            return WorkflowOrchestratorResult.PlanningNeeded(intent, prompt);
+
+        // 3. Execute
+        data ??= new AgentWorkflowData { Prompt = prompt };
+
+        try
+        {
+            var result = await _bridge.ExecuteAsync(match.Definition, data, ct)
+                .ConfigureAwait(false);
+
+            return result.Success
+                ? WorkflowOrchestratorResult.Executed(intent, match, result)
+                : WorkflowOrchestratorResult.Failed(intent, match, result);
+        }
+        catch (Exception ex)
+        {
+            var errorResult = new WorkflowBridgeResult
+            {
+                Success = false,
+                Errors = [ex.Message],
+            };
+            return WorkflowOrchestratorResult.Failed(intent, match, errorResult);
+        }
+    }
+}

--- a/src/JD.AI.Workflows/WorkflowOrchestratorResult.cs
+++ b/src/JD.AI.Workflows/WorkflowOrchestratorResult.cs
@@ -1,0 +1,76 @@
+namespace JD.AI.Workflows;
+
+/// <summary>
+/// Outcome of the orchestrator pipeline: pass-through, planning needed,
+/// executed successfully, or execution failed.
+/// </summary>
+public enum WorkflowOutcome
+{
+    /// <summary>Not a workflow — route to agent normally.</summary>
+    PassThrough,
+
+    /// <summary>Workflow detected but not in catalog — prompt user to plan it.</summary>
+    PlanningNeeded,
+
+    /// <summary>Workflow found and executed successfully.</summary>
+    Executed,
+
+    /// <summary>Workflow found but execution failed.</summary>
+    ExecutionFailed,
+}
+
+/// <summary>
+/// Result of the full detect-match-execute pipeline.
+/// </summary>
+public sealed class WorkflowOrchestratorResult
+{
+    public WorkflowOutcome Outcome { get; init; }
+    public IntentClassification Intent { get; init; } = new(false, 0.0, []);
+    public WorkflowMatchResult? Match { get; init; }
+    public WorkflowBridgeResult? ExecutionResult { get; init; }
+    public string? PlanningPrompt { get; init; }
+
+    /// <summary>Not a workflow — pass through to normal agent handling.</summary>
+    public static WorkflowOrchestratorResult PassThrough(IntentClassification intent) =>
+        new()
+        {
+            Outcome = WorkflowOutcome.PassThrough,
+            Intent = intent,
+        };
+
+    /// <summary>Workflow detected but no catalog match — needs planning.</summary>
+    public static WorkflowOrchestratorResult PlanningNeeded(
+        IntentClassification intent, string prompt) =>
+        new()
+        {
+            Outcome = WorkflowOutcome.PlanningNeeded,
+            Intent = intent,
+            PlanningPrompt = prompt,
+        };
+
+    /// <summary>Workflow matched and executed successfully.</summary>
+    public static WorkflowOrchestratorResult Executed(
+        IntentClassification intent,
+        WorkflowMatchResult match,
+        WorkflowBridgeResult result) =>
+        new()
+        {
+            Outcome = WorkflowOutcome.Executed,
+            Intent = intent,
+            Match = match,
+            ExecutionResult = result,
+        };
+
+    /// <summary>Workflow matched but execution failed.</summary>
+    public static WorkflowOrchestratorResult Failed(
+        IntentClassification intent,
+        WorkflowMatchResult match,
+        WorkflowBridgeResult result) =>
+        new()
+        {
+            Outcome = WorkflowOutcome.ExecutionFailed,
+            Intent = intent,
+            Match = match,
+            ExecutionResult = result,
+        };
+}

--- a/tests/JD.AI.Tests/Workflows/WorkflowOrchestratorTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowOrchestratorTests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using JD.AI.Workflows;
+using JD.AI.Workflows.Steps;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace JD.AI.Tests.Workflows;
+
+public sealed class WorkflowOrchestratorTests
+{
+    private readonly IPromptIntentClassifier _classifier = Substitute.For<IPromptIntentClassifier>();
+    private readonly IWorkflowMatcher _matcher = Substitute.For<IWorkflowMatcher>();
+    private readonly IWorkflowBridge _bridge = Substitute.For<IWorkflowBridge>();
+    private readonly WorkflowOrchestrator _orchestrator;
+
+    public WorkflowOrchestratorTests()
+    {
+        _orchestrator = new WorkflowOrchestrator(_classifier, _matcher, _bridge);
+    }
+
+    [Fact]
+    public async Task NullPrompt_ReturnsPassThrough()
+    {
+        var result = await _orchestrator.ProcessAsync(null!);
+
+        result.Outcome.Should().Be(WorkflowOutcome.PassThrough);
+        result.Intent.IsWorkflow.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EmptyPrompt_ReturnsPassThrough()
+    {
+        var result = await _orchestrator.ProcessAsync("");
+
+        result.Outcome.Should().Be(WorkflowOutcome.PassThrough);
+    }
+
+    [Fact]
+    public async Task WhitespacePrompt_ReturnsPassThrough()
+    {
+        var result = await _orchestrator.ProcessAsync("   ");
+
+        result.Outcome.Should().Be(WorkflowOutcome.PassThrough);
+    }
+
+    [Fact]
+    public async Task ConversationPrompt_ReturnsPassThrough()
+    {
+        _classifier.Classify("hello there")
+            .Returns(new IntentClassification(false, 0.1, []));
+
+        var result = await _orchestrator.ProcessAsync("hello there");
+
+        result.Outcome.Should().Be(WorkflowOutcome.PassThrough);
+        result.Intent.IsWorkflow.Should().BeFalse();
+        result.Match.Should().BeNull();
+        result.ExecutionResult.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowPrompt_EmptyCatalog_ReturnsPlanningNeeded()
+    {
+        _classifier.Classify("deploy the app then run tests")
+            .Returns(new IntentClassification(true, 0.85, ["deploy", "then", "tests"]));
+        _matcher.MatchAsync(Arg.Any<AgentRequest>(), Arg.Any<CancellationToken>())
+            .Returns((WorkflowMatchResult?)null);
+
+        var result = await _orchestrator.ProcessAsync("deploy the app then run tests");
+
+        result.Outcome.Should().Be(WorkflowOutcome.PlanningNeeded);
+        result.Intent.IsWorkflow.Should().BeTrue();
+        result.PlanningPrompt.Should().Be("deploy the app then run tests");
+        result.Match.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowPrompt_MatchFound_ExecutesAndReturnsResult()
+    {
+        var prompt = "deploy the app";
+        var definition = new AgentWorkflowDefinition
+        {
+            Name = "deploy",
+            Tags = ["deploy"],
+            Steps = [AgentStepDefinition.RunSkill("deploy")],
+        };
+        var matchResult = new WorkflowMatchResult(definition, 1.0f, "exact");
+        var bridgeResult = new WorkflowBridgeResult
+        {
+            Success = true,
+            FinalOutput = "Deployed successfully",
+            Duration = TimeSpan.FromMilliseconds(100),
+        };
+
+        _classifier.Classify(prompt)
+            .Returns(new IntentClassification(true, 0.9, ["deploy"]));
+        _matcher.MatchAsync(Arg.Any<AgentRequest>(), Arg.Any<CancellationToken>())
+            .Returns(matchResult);
+        _bridge.ExecuteAsync(definition, Arg.Any<AgentWorkflowData>(), Arg.Any<CancellationToken>())
+            .Returns(bridgeResult);
+
+        var result = await _orchestrator.ProcessAsync(prompt);
+
+        result.Outcome.Should().Be(WorkflowOutcome.Executed);
+        result.Match.Should().Be(matchResult);
+        result.ExecutionResult.Should().Be(bridgeResult);
+        result.ExecutionResult!.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WorkflowPrompt_ExecutionFails_ReturnsExecutionFailed()
+    {
+        var prompt = "deploy the app";
+        var definition = new AgentWorkflowDefinition
+        {
+            Name = "deploy",
+            Tags = ["deploy"],
+            Steps = [AgentStepDefinition.RunSkill("deploy")],
+        };
+        var matchResult = new WorkflowMatchResult(definition, 1.0f, "exact");
+        var bridgeResult = new WorkflowBridgeResult
+        {
+            Success = false,
+            Errors = ["Step 'deploy' failed: connection refused"],
+            Duration = TimeSpan.FromMilliseconds(50),
+        };
+
+        _classifier.Classify(prompt)
+            .Returns(new IntentClassification(true, 0.9, ["deploy"]));
+        _matcher.MatchAsync(Arg.Any<AgentRequest>(), Arg.Any<CancellationToken>())
+            .Returns(matchResult);
+        _bridge.ExecuteAsync(definition, Arg.Any<AgentWorkflowData>(), Arg.Any<CancellationToken>())
+            .Returns(bridgeResult);
+
+        var result = await _orchestrator.ProcessAsync(prompt);
+
+        result.Outcome.Should().Be(WorkflowOutcome.ExecutionFailed);
+        result.Match.Should().Be(matchResult);
+        result.ExecutionResult!.Success.Should().BeFalse();
+        result.ExecutionResult.Errors.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task WorkflowPrompt_ExecutionThrows_ReturnsExecutionFailed()
+    {
+        var prompt = "deploy the app";
+        var definition = new AgentWorkflowDefinition
+        {
+            Name = "deploy",
+            Tags = ["deploy"],
+            Steps = [AgentStepDefinition.RunSkill("deploy")],
+        };
+        var matchResult = new WorkflowMatchResult(definition, 1.0f, "exact");
+
+        _classifier.Classify(prompt)
+            .Returns(new IntentClassification(true, 0.9, ["deploy"]));
+        _matcher.MatchAsync(Arg.Any<AgentRequest>(), Arg.Any<CancellationToken>())
+            .Returns(matchResult);
+        _bridge.ExecuteAsync(definition, Arg.Any<AgentWorkflowData>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Kernel not set"));
+
+        var result = await _orchestrator.ProcessAsync(prompt);
+
+        result.Outcome.Should().Be(WorkflowOutcome.ExecutionFailed);
+        result.Match.Should().Be(matchResult);
+        result.ExecutionResult!.Success.Should().BeFalse();
+        result.ExecutionResult.Errors.Should().Contain(e => e.Contains("Kernel not set"));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_PassesProvidedDataTobridge()
+    {
+        var prompt = "deploy the app";
+        var definition = new AgentWorkflowDefinition
+        {
+            Name = "deploy",
+            Tags = ["deploy"],
+            Steps = [AgentStepDefinition.RunSkill("deploy")],
+        };
+        var matchResult = new WorkflowMatchResult(definition, 1.0f, "exact");
+        var customData = new AgentWorkflowData { Prompt = prompt, FinalResult = "pre-set" };
+        var bridgeResult = new WorkflowBridgeResult { Success = true };
+
+        _classifier.Classify(prompt)
+            .Returns(new IntentClassification(true, 0.9, ["deploy"]));
+        _matcher.MatchAsync(Arg.Any<AgentRequest>(), Arg.Any<CancellationToken>())
+            .Returns(matchResult);
+        _bridge.ExecuteAsync(definition, customData, Arg.Any<CancellationToken>())
+            .Returns(bridgeResult);
+
+        var result = await _orchestrator.ProcessAsync(prompt, customData);
+
+        result.Outcome.Should().Be(WorkflowOutcome.Executed);
+        await _bridge.Received(1).ExecuteAsync(definition, customData, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
The final piece connecting the workflow pipeline end-to-end. A single entry point that chains classifier → catalog matcher → bridge execution.

### Flow
```
User prompt
    ↓
IPromptIntentClassifier → is this a workflow?
    ↓ no → PassThrough (route to agent normally)
    ↓ yes
IWorkflowMatcher → do we have a workflow for this?
    ↓ no → PlanningNeeded (prompt user to design workflow)
    ↓ yes
IWorkflowBridge → execute deterministically
    ↓
WorkflowOrchestratorResult (Executed or ExecutionFailed)
```

### Files
- `WorkflowOrchestrator.cs` — orchestrator implementation
- `WorkflowOrchestratorResult.cs` — result model with 4 outcomes
- `IWorkflowOrchestrator` interface
- Gateway endpoint: `POST /api/v1/workflows/process`
- DI registrations in Gateway + Daemon
- 9 unit tests covering all paths

### Also fixes
- Pre-existing build errors in `ApiKeyRotation.cs` (missing members)

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)