### PR TITLE
fix: comment out missing MapApiKeyEndpoints to unbreak CI

### DIFF
--- a/src/JD.AI.Gateway/Program.cs
+++ b/src/JD.AI.Gateway/Program.cs
@@ -323,7 +323,7 @@ app.MapPluginEndpoints();
 app.MapMemoryEndpoints();
 app.MapRoutingEndpoints();
 app.MapGatewayConfigEndpoints();
-app.MapApiKeyEndpoints();
+// app.MapApiKeyEndpoints(); // Enabled by PR #426
 app.MapAuditEndpoints();
 app.MapWorkflowEndpoints();
 


### PR DESCRIPTION
## Problem
CI and Integration Tests failing on main — `MapApiKeyEndpoints()` called in Gateway Program.cs but the `ApiKeyEndpoints.cs` file doesn't exist on main. It was added as an untracked file during PR #430 but never committed.

## Fix
Commented out the call until PR #426 (API key management) merges with the actual implementation.

## Affected workflows
- CI (build failure)
- Integration Tests (build failure)