### PR TITLE
fix: resolve formatting violations and group dependabot updates

### DIFF
--- a/src/JD.AI.Workflows/History/WorkflowHistoryVisualizationExtensions.cs
+++ b/src/JD.AI.Workflows/History/WorkflowHistoryVisualizationExtensions.cs
@@ -35,9 +35,9 @@ public static class WorkflowHistoryVisualizationExtensions
             var shape = node.Kind switch
             {
                 AgentStepKind.Conditional => $"{nodeId}{{{{{label}}}}}",
-                AgentStepKind.Loop       => $"{nodeId}[/{label}\\]",
-                AgentStepKind.Nested     => $"{nodeId}[[{label}]]",
-                _                        => $"{nodeId}[\"{label}\"]",
+                AgentStepKind.Loop => $"{nodeId}[/{label}\\]",
+                AgentStepKind.Nested => $"{nodeId}[[{label}]]",
+                _ => $"{nodeId}[\"{label}\"]",
             };
             sb.AppendLine($"    {shape}");
         }
@@ -145,9 +145,9 @@ internal sealed class FilteredWorkflowHistoryGraph
             var shape = node.Kind switch
             {
                 AgentStepKind.Conditional => $"{nodeId}{{{{{label}}}}}",
-                AgentStepKind.Loop       => $"{nodeId}[/{label}\\]",
-                AgentStepKind.Nested     => $"{nodeId}[[{label}]]",
-                _                        => $"{nodeId}[\"{label}\"]",
+                AgentStepKind.Loop => $"{nodeId}[/{label}\\]",
+                AgentStepKind.Nested => $"{nodeId}[[{label}]]",
+                _ => $"{nodeId}[\"{label}\"]",
             };
             sb.AppendLine($"    {shape}");
         }

--- a/src/JD.AI/Commands/UpdateCliHandler.cs
+++ b/src/JD.AI/Commands/UpdateCliHandler.cs
@@ -41,7 +41,8 @@ internal static class UpdateCliHandler
 
     /// <summary>Factory for applying a multi-tool update plan. Override in tests.</summary>
     internal static Func<UpdatePlan, bool, Action<InstalledTool, InstallResult>?, CancellationToken, Task>
-        ApplyAllToolUpdatesAsync { get; set; } = JDAIToolkit.ApplyAllAsync;
+        ApplyAllToolUpdatesAsync
+    { get; set; } = JDAIToolkit.ApplyAllAsync;
 
     public static async Task<int> RunAsync(string subcommand, string[] args)
     {

--- a/src/JD.AI/Startup/WelcomeMotdProvider.cs
+++ b/src/JD.AI/Startup/WelcomeMotdProvider.cs
@@ -1,5 +1,5 @@
-using JD.AI.Core.Config;
 using System.Text;
+using JD.AI.Core.Config;
 
 namespace JD.AI.Startup;
 

--- a/tests/JD.AI.Gateway.Tests/Commands/ConfigCommandTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Commands/ConfigCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using JD.AI.Core.Channels;
 using JD.AI.Core.Commands;
@@ -8,7 +9,6 @@ using JD.AI.Gateway.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using NSubstitute;
-using System.Reflection;
 
 namespace JD.AI.Gateway.Tests.Commands;
 

--- a/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
+++ b/tests/JD.AI.Gateway.Tests/Commands/GatewayCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentAssertions;
 using JD.AI.Core.Channels;
 using JD.AI.Core.Commands;
@@ -9,7 +10,6 @@ using JD.AI.Gateway.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.SemanticKernel;
 using NSubstitute;
-using System.Reflection;
 
 namespace JD.AI.Gateway.Tests.Commands;
 
@@ -176,7 +176,8 @@ public class GatewayCommandTests
             MakeContext("route", new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["agent"] = "ollama"
-            }) with { ChannelId = "" });
+            }) with
+            { ChannelId = "" });
 
         result.Success.Should().BeTrue();
         _router.GetAgentForChannel("discord").Should().Be(agentId);
@@ -423,7 +424,8 @@ public class GatewayCommandTests
             MakeContext("provider", new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["name"] = "copilot"
-            }) with { ChannelId = "" });
+            }) with
+            { ChannelId = "" });
 
         result.Success.Should().BeTrue();
         _router.GetAgentForChannel("discord").Should().NotBe(agentId);

--- a/tests/JD.AI.Specs/Features/Core/Agent/AgentLifecycle.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/AgentLifecycle.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "core",
                 "agent"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Lifecycle", "    As a user of the AI agent\n    I want to create sessions, send messages, and r" +
-                "eceive responses\n    So that I can interact with AI models reliably", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Lifecycle", "    As a user of the AI agent\r\n    I want to create sessions, send messages, and " +
+                "receive responses\r\n    So that I can interact with AI models reliably", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/AgentStreaming.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/AgentStreaming.feature.cs
@@ -30,9 +30,9 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "streaming"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Streaming", "    As a user of the AI agent\n    I want to receive streaming responses with thin" +
-                "king and content\n    So that I see tokens as they arrive and can observe reasoni" +
-                "ng", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Streaming", "    As a user of the AI agent\r\n    I want to receive streaming responses with thi" +
+                "nking and content\r\n    So that I see tokens as they arrive and can observe reaso" +
+                "ning", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/Checkpointing.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/Checkpointing.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "checkpointing"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Checkpointing", "    As a user of the AI agent\n    I want to create and restore checkpoints of pro" +
-                "ject state\n    So that I can recover from unwanted changes", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Checkpointing", "    As a user of the AI agent\r\n    I want to create and restore checkpoints of pr" +
+                "oject state\r\n    So that I can recover from unwanted changes", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/ConversationTransform.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/ConversationTransform.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "conversation-transform"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Conversation Transformation", "    As a user switching AI models\n    I want conversation history to be transform" +
-                "ed appropriately\n    So that the new model has proper context", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Conversation Transformation", "    As a user switching AI models\r\n    I want conversation history to be transfor" +
+                "med appropriately\r\n    So that the new model has proper context", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/ModelSwitching.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/ModelSwitching.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "model-switching"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Model Switching", "    As a user of the AI agent\n    I want to switch between AI models during a ses" +
-                "sion\n    So that I can use the best model for each task", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Model Switching", "    As a user of the AI agent\r\n    I want to switch between AI models during a se" +
+                "ssion\r\n    So that I can use the best model for each task", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/Orchestration.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/Orchestration.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "orchestration"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Orchestration", "    As the orchestration system\n    I want to coordinate multiple subagents using" +
-                " different strategies\n    So that complex tasks are completed effectively", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Agent Orchestration", "    As the orchestration system\r\n    I want to coordinate multiple subagents usin" +
+                "g different strategies\r\n    So that complex tasks are completed effectively", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Agent/StreamingParser.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Agent/StreamingParser.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Agent
                 "agent",
                 "streaming-parser"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Streaming Content Parser", "    As the agent streaming pipeline\n    I want to correctly parse think tags from" +
-                " streaming content\n    So that thinking and response content are separated", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Agent", "Streaming Content Parser", "    As the agent streaming pipeline\r\n    I want to correctly parse think tags fro" +
+                "m streaming content\r\n    So that thinking and response content are separated", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Channels/ChannelAdapters.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Channels/ChannelAdapters.feature.cs
@@ -26,9 +26,9 @@ namespace JD.AI.Specs.Features.Core.Channels
         private static string[] featureTags = new string[] {
                 "channels"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Channels", "Channel Adapters", "  As the platform\n  I need messaging channel adapters for multiple platforms\n  So" +
-                " that I can receive and send messages across Discord, Slack, Telegram, Signal, a" +
-                "nd Web", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Channels", "Channel Adapters", "  As the platform\r\n  I need messaging channel adapters for multiple platforms\r\n  " +
+                "So that I can receive and send messages across Discord, Slack, Telegram, Signal," +
+                " and Web", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Channels/ChannelRegistry.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Channels/ChannelRegistry.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Channels
         private static string[] featureTags = new string[] {
                 "channels"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Channels", "Channel Registry", "  As a platform\n  I need to manage messaging channel adapters\n  So that I can rou" +
-                "te messages across platforms", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Channels", "Channel Registry", "  As a platform\r\n  I need to manage messaging channel adapters\r\n  So that I can r" +
+                "oute messages across platforms", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Commands/SlashCommands.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Commands/SlashCommands.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Commands
         private static string[] featureTags = new string[] {
                 "commands"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Commands", "Slash Commands", "  As a platform\n  I need command routing\n  So that users can invoke commands from" +
-                " any channel", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Commands", "Slash Commands", "  As a platform\r\n  I need command routing\r\n  So that users can invoke commands fr" +
+                "om any channel", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Config/AtomicConfigStore.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Config/AtomicConfigStore.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Core.Config
                 "core",
                 "config"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Config", "Atomic Config Store", "    As the configuration system\n    I want to read and write configuration safely" +
-                "\n    So that settings persist correctly even under concurrent access", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Config", "Atomic Config Store", "    As the configuration system\r\n    I want to read and write configuration safel" +
+                "y\r\n    So that settings persist correctly even under concurrent access", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Config/TuiSettings.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Config/TuiSettings.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Config
                 "config",
                 "tui"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Config", "TUI Settings", "    As a user of the AI agent\n    I want to configure the terminal UI display set" +
-                "tings\n    So that I can personalize my experience", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Config", "TUI Settings", "    As a user of the AI agent\r\n    I want to configure the terminal UI display se" +
+                "ttings\r\n    So that I can personalize my experience", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Events/EventBus.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Events/EventBus.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Events
         private static string[] featureTags = new string[] {
                 "events"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Events", "Event Bus", "  As a platform\n  I need a publish/subscribe event bus\n  So that components can c" +
-                "ommunicate through events", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Events", "Event Bus", "  As a platform\r\n  I need a publish/subscribe event bus\r\n  So that components can" +
+                " communicate through events", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Governance/AuditService.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Governance/AuditService.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Governance
         private static string[] featureTags = new string[] {
                 "governance"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Audit Service", "  As a governance system\n  I need to emit audit events to configured sinks\n  So t" +
-                "hat all actions are recorded for compliance", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Audit Service", "  As a governance system\r\n  I need to emit audit events to configured sinks\r\n  So" +
+                " that all actions are recorded for compliance", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Governance/AuditSinks.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Governance/AuditSinks.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Governance
         private static string[] featureTags = new string[] {
                 "governance"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Audit Sinks", "  As a governance system\n  I need audit events written to various destinations\n  " +
-                "So that audit data is persisted and accessible", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Audit Sinks", "  As a governance system\r\n  I need audit events written to various destinations\r\n" +
+                "  So that audit data is persisted and accessible", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Governance/BudgetTracking.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Governance/BudgetTracking.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Governance
         private static string[] featureTags = new string[] {
                 "governance"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Budget Tracking", "  As a governance system\n  I need to track spending against budget limits\n  So th" +
-                "at costs remain within configured thresholds", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Budget Tracking", "  As a governance system\r\n  I need to track spending against budget limits\r\n  So " +
+                "that costs remain within configured thresholds", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Governance/DataRedaction.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Governance/DataRedaction.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Governance
         private static string[] featureTags = new string[] {
                 "governance"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Data Redaction", "  As a governance system\n  I need to redact sensitive data\n  So that PII and secr" +
-                "ets are not sent to AI providers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Data Redaction", "  As a governance system\r\n  I need to redact sensitive data\r\n  So that PII and se" +
+                "crets are not sent to AI providers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Governance/PolicyEvaluation.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Governance/PolicyEvaluation.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Governance
         private static string[] featureTags = new string[] {
                 "governance"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Policy Evaluation", "  As a governance system\n  I need to evaluate requests against policies\n  So that" +
-                " I can enforce tool, provider, and model restrictions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Governance", "Policy Evaluation", "  As a governance system\r\n  I need to evaluate requests against policies\r\n  So th" +
+                "at I can enforce tool, provider, and model restrictions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/LocalModels/LocalModelDetection.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/LocalModels/LocalModelDetection.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.LocalModels
         private static string[] featureTags = new string[] {
                 "localmodels"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/LocalModels", "Local Model Detection", "  As a platform\n  I need to detect locally available models\n  So that users can u" +
-                "se local inference without cloud providers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/LocalModels", "Local Model Detection", "  As a platform\r\n  I need to detect locally available models\r\n  So that users can" +
+                " use local inference without cloud providers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Mcp/McpIntegration.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Mcp/McpIntegration.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Mcp
         private static string[] featureTags = new string[] {
                 "mcp"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Mcp", "MCP Integration", "  As a platform\n  I need MCP server management\n  So that I can discover and manag" +
-                "e Model Context Protocol servers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Mcp", "MCP Integration", "  As a platform\r\n  I need MCP server management\r\n  So that I can discover and man" +
+                "age Model Context Protocol servers", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Memory/VectorStore.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Memory/VectorStore.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Memory
         private static string[] featureTags = new string[] {
                 "memory"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Memory", "Vector Store", "  As a memory subsystem\n  I need vector storage and similarity search\n  So that I" +
-                " can store and retrieve embeddings efficiently", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Memory", "Vector Store", "  As a memory subsystem\r\n  I need vector storage and similarity search\r\n  So that" +
+                " I can store and retrieve embeddings efficiently", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Plugin/PluginLoading.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Plugin/PluginLoading.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Plugin
         private static string[] featureTags = new string[] {
                 "plugin"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Plugin", "Plugin Loading", "  As a platform\n  I need dynamic plugin loading\n  So that extensions can be added" +
-                " at runtime", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Plugin", "Plugin Loading", "  As a platform\r\n  I need dynamic plugin loading\r\n  So that extensions can be add" +
+                "ed at runtime", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/PromptCaching/PromptCaching.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/PromptCaching/PromptCaching.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Core.PromptCaching
                 "core",
                 "prompt-caching"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/PromptCaching", "Prompt Caching", "    As the prompt caching system\n    I want to apply cache headers for supported " +
-                "providers\n    So that repeated prompts are served faster and cheaper", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/PromptCaching", "Prompt Caching", "    As the prompt caching system\r\n    I want to apply cache headers for supported" +
+                " providers\r\n    So that repeated prompts are served faster and cheaper", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Provider/ModelSearch.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Provider/ModelSearch.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Provider
                 "provider",
                 "model-search"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Model Search", "    As a user of the AI agent\n    I want to search for models across all provider" +
-                "s\n    So that I can find the right model for my task", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Model Search", "    As a user of the AI agent\r\n    I want to search for models across all provide" +
+                "rs\r\n    So that I can find the right model for my task", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Provider/ProviderCredentials.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Provider/ProviderCredentials.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Provider
                 "provider",
                 "credentials"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Credentials", "    As a user of the AI agent\n    I want to securely store and retrieve API crede" +
-                "ntials\n    So that my keys are protected and persist between sessions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Credentials", "    As a user of the AI agent\r\n    I want to securely store and retrieve API cred" +
+                "entials\r\n    So that my keys are protected and persist between sessions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Provider/ProviderDetection.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Provider/ProviderDetection.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Core.Provider
                 "core",
                 "provider"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Detection", "    As the provider system\n    I want to detect available AI providers automatica" +
-                "lly\n    So that users can discover and use available models", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Detection", "    As the provider system\r\n    I want to detect available AI providers automatic" +
+                "ally\r\n    So that users can discover and use available models", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Provider/ProviderRegistry.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Provider/ProviderRegistry.feature.cs
@@ -28,9 +28,9 @@ namespace JD.AI.Specs.Features.Core.Provider
                 "core",
                 "provider"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Registry", "    As the provider management system\n    I want to register providers, build ker" +
-                "nels, and manage model selection\n    So that the agent can interact with multipl" +
-                "e AI backends", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Provider", "Provider Registry", "    As the provider management system\r\n    I want to register providers, build ke" +
+                "rnels, and manage model selection\r\n    So that the agent can interact with multi" +
+                "ple AI backends", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Security/ApiKeyAuth.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Security/ApiKeyAuth.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Security
         private static string[] featureTags = new string[] {
                 "security"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Security", "API Key Authentication", "  As a gateway security system\n  I need API key authentication\n  So that only aut" +
-                "horized users can access the system", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Security", "API Key Authentication", "  As a gateway security system\r\n  I need API key authentication\r\n  So that only a" +
+                "uthorized users can access the system", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Security/RateLimiting.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Security/RateLimiting.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Security
         private static string[] featureTags = new string[] {
                 "security"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Security", "Rate Limiting", "  As a gateway security system\n  I need rate limiting\n  So that no single client " +
-                "can overwhelm the system", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Security", "Rate Limiting", "  As a gateway security system\r\n  I need rate limiting\r\n  So that no single clien" +
+                "t can overwhelm the system", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Session/SessionExport.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Session/SessionExport.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Core.Session
                 "session",
                 "export"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Session", "Session Export", "    As a user of the AI agent\n    I want to export sessions to JSON and markdown\n" +
-                "    So that I can archive or share conversations", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Session", "Session Export", "    As a user of the AI agent\r\n    I want to export sessions to JSON and markdown" +
+                "\r\n    So that I can archive or share conversations", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Session/SessionPersistence.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Session/SessionPersistence.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Core.Session
                 "core",
                 "session"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Session", "Session Persistence", "    As a user of the AI agent\n    I want sessions to be saved and loaded from sto" +
-                "rage\n    So that I can resume conversations across restarts", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Session", "Session Persistence", "    As a user of the AI agent\r\n    I want sessions to be saved and loaded from st" +
+                "orage\r\n    So that I can resume conversations across restarts", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/BatchEditTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/BatchEditTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Batch Edit Tools", "  As an AI agent\n  I need to apply multiple edits atomically\n  So that coordinate" +
-                "d changes across files succeed or fail together", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Batch Edit Tools", "  As an AI agent\r\n  I need to apply multiple edits atomically\r\n  So that coordina" +
+                "ted changes across files succeed or fail together", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/ClipboardTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/ClipboardTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Clipboard Tools", "  As an AI agent\n  I need clipboard access\n  So that I can read and write system " +
-                "clipboard content", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Clipboard Tools", "  As an AI agent\r\n  I need clipboard access\r\n  So that I can read and write syste" +
+                "m clipboard content", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/DiffTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/DiffTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Diff Tools", "  As an AI agent\n  I need to create and apply patches\n  So that I can make struct" +
-                "ured multi-location file edits", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Diff Tools", "  As an AI agent\r\n  I need to create and apply patches\r\n  So that I can make stru" +
+                "ctured multi-location file edits", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/EnvironmentTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/EnvironmentTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Environment Tools", "  As an AI agent\n  I need to inspect the runtime environment\n  So that I can unde" +
-                "rstand the system context", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Environment Tools", "  As an AI agent\r\n  I need to inspect the runtime environment\r\n  So that I can un" +
+                "derstand the system context", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/FileTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/FileTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "File Tools", "  As an AI agent\n  I need file system operations\n  So that I can read, write, edi" +
-                "t, and list files", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "File Tools", "  As an AI agent\r\n  I need file system operations\r\n  So that I can read, write, e" +
+                "dit, and list files", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         
@@ -207,7 +207,7 @@ namespace JD.AI.Specs.Features.Core.Tool
   await this.FeatureBackgroundAsync();
 #line hidden
 #line 16
-    await testRunner.GivenAsync("a file \"lines.txt\" with content:", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5", ((global::Reqnroll.Table)(null)), "Given ");
+    await testRunner.GivenAsync("a file \"lines.txt\" with content:", "Line 1\r\nLine 2\r\nLine 3\r\nLine 4\r\nLine 5", ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
 #line 24
     await testRunner.WhenAsync("I read file \"lines.txt\" from line 2 to line 4", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");

--- a/tests/JD.AI.Specs/Features/Core/Tool/GitTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/GitTools.feature.cs
@@ -26,7 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Git Tools", "  As an AI agent\n  I need git operations\n  So that I can manage version control", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Git Tools", "  As an AI agent\r\n  I need git operations\r\n  So that I can manage version control" +
+                "", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/MemoryTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/MemoryTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Memory Tools", "  As an AI agent\n  I need semantic memory storage and retrieval\n  So that I can r" +
-                "emember and recall information across turns", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Memory Tools", "  As an AI agent\r\n  I need semantic memory storage and retrieval\r\n  So that I can" +
+                " remember and recall information across turns", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/NotebookTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/NotebookTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Notebook Tools", "  As an AI agent\n  I need to execute code snippets\n  So that I can run and test c" +
-                "ode in various languages", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Notebook Tools", "  As an AI agent\r\n  I need to execute code snippets\r\n  So that I can run and test" +
+                " code in various languages", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/QuestionTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/QuestionTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Question Tools", "  As an AI agent\n  I need to present structured questions to the user\n  So that I" +
-                " can gather specific information before proceeding", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Question Tools", "  As an AI agent\r\n  I need to present structured questions to the user\r\n  So that" +
+                " I can gather specific information before proceeding", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/SearchTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/SearchTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Search Tools", "  As an AI agent\n  I need to search code by pattern and file name\n  So that I can" +
-                " find relevant code quickly", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Search Tools", "  As an AI agent\r\n  I need to search code by pattern and file name\r\n  So that I c" +
+                "an find relevant code quickly", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/ShellTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/ShellTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Shell Tools", "  As an AI agent\n  I need to execute shell commands\n  So that I can run builds, t" +
-                "ests, and system operations", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Shell Tools", "  As an AI agent\r\n  I need to execute shell commands\r\n  So that I can run builds," +
+                " tests, and system operations", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/TaskTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/TaskTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Task Tools", "  As an AI agent\n  I need task management\n  So that I can track work items within" +
-                " a session", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Task Tools", "  As an AI agent\r\n  I need task management\r\n  So that I can track work items with" +
+                "in a session", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/ThinkTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/ThinkTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Think Tools", "  As an AI agent\n  I need a scratchpad for reasoning\n  So that I can organize tho" +
-                "ughts without side effects", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Think Tools", "  As an AI agent\r\n  I need a scratchpad for reasoning\r\n  So that I can organize t" +
+                "houghts without side effects", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         
@@ -223,7 +223,7 @@ namespace JD.AI.Specs.Features.Core.Tool
             {
                 await this.ScenarioStartAsync();
 #line 17
-    await testRunner.WhenAsync("I think:", "Step 1: Read the file\nStep 2: Parse the JSON\nStep 3: Update the field", ((global::Reqnroll.Table)(null)), "When ");
+    await testRunner.WhenAsync("I think:", "Step 1: Read the file\r\nStep 2: Parse the JSON\r\nStep 3: Update the field", ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 23
     await testRunner.ThenAsync("the think result should contain \"Step 1: Read the file\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");

--- a/tests/JD.AI.Specs/Features/Core/Tool/UsageTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/UsageTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Usage Tools", "  As an AI agent\n  I need to track token usage\n  So that I can report costs and m" +
-                "onitor consumption", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Usage Tools", "  As an AI agent\r\n  I need to track token usage\r\n  So that I can report costs and" +
+                " monitor consumption", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/WebSearchTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/WebSearchTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Web Search Tools", "  As an AI agent\n  I need web search capability\n  So that I can find current info" +
-                "rmation online", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Web Search Tools", "  As an AI agent\r\n  I need web search capability\r\n  So that I can find current in" +
+                "formation online", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Tool/WebTools.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Tool/WebTools.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Tool
         private static string[] featureTags = new string[] {
                 "tools"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Web Tools", "  As an AI agent\n  I need to fetch web content\n  So that I can retrieve informati" +
-                "on from URLs", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Tool", "Web Tools", "  As an AI agent\r\n  I need to fetch web content\r\n  So that I can retrieve informa" +
+                "tion from URLs", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Core/Workflows/WorkflowCapture.feature.cs
+++ b/tests/JD.AI.Specs/Features/Core/Workflows/WorkflowCapture.feature.cs
@@ -26,8 +26,8 @@ namespace JD.AI.Specs.Features.Core.Workflows
         private static string[] featureTags = new string[] {
                 "workflows"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Workflows", "Workflow Capture", "  As a platform\n  I need to capture workflow execution events\n  So that I can obs" +
-                "erve and replay workflow runs", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Core/Workflows", "Workflow Capture", "  As a platform\r\n  I need to capture workflow execution events\r\n  So that I can o" +
+                "bserve and replay workflow runs", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/AgentEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/AgentEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "agents"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Agent Endpoints", "    As a gateway consumer\n    I want to manage AI agent instances via the REST AP" +
-                "I\n    So that I can spawn, query, message, and stop agents", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Agent Endpoints", "    As a gateway consumer\r\n    I want to manage AI agent instances via the REST A" +
+                "PI\r\n    So that I can spawn, query, message, and stop agents", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/AuthMiddleware.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/AuthMiddleware.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "gateway",
                 "auth"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "API Key Auth Middleware", "    As a gateway administrator\n    I want API key authentication on protected end" +
-                "points\n    So that only authorized clients can access the gateway API", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "API Key Auth Middleware", "    As a gateway administrator\r\n    I want API key authentication on protected en" +
+                "dpoints\r\n    So that only authorized clients can access the gateway API", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/ChannelEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/ChannelEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "channels"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Channel Endpoints", "    As a gateway consumer\n    I want to manage messaging channels via the REST AP" +
-                "I\n    So that I can list, connect, and disconnect channel adapters", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Channel Endpoints", "    As a gateway consumer\r\n    I want to manage messaging channels via the REST A" +
+                "PI\r\n    So that I can list, connect, and disconnect channel adapters", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/ConfigEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/ConfigEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "config"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Gateway Config Endpoints", "    As a gateway administrator\n    I want to view and update gateway configuratio" +
-                "n via the REST API\n    So that I can manage the gateway at runtime", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Gateway Config Endpoints", "    As a gateway administrator\r\n    I want to view and update gateway configurati" +
+                "on via the REST API\r\n    So that I can manage the gateway at runtime", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/GatewayOrchestrator.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/GatewayOrchestrator.feature.cs
@@ -28,9 +28,9 @@ namespace JD.AI.Specs.Features.Gateway
                 "gateway",
                 "orchestrator"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Gateway Orchestrator", "    As a gateway operator\n    I want the gateway to start successfully and initia" +
-                "lize subsystems\n    So that all configured channels, agents, and routes are oper" +
-                "ational", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Gateway Orchestrator", "    As a gateway operator\r\n    I want the gateway to start successfully and initi" +
+                "alize subsystems\r\n    So that all configured channels, agents, and routes are op" +
+                "erational", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/HealthEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/HealthEndpoints.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "gateway",
                 "health"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Health Endpoints", "    As a gateway operator\n    I want health, ready, and liveness endpoints\n    So" +
-                " that I can monitor the gateway and integrate with orchestrators", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Health Endpoints", "    As a gateway operator\r\n    I want health, ready, and liveness endpoints\r\n    " +
+                "So that I can monitor the gateway and integrate with orchestrators", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/ProviderEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/ProviderEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "providers"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Provider Endpoints", "    As a gateway consumer\n    I want to detect and list AI providers via the REST" +
-                " API\n    So that I can discover available models", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Provider Endpoints", "    As a gateway consumer\r\n    I want to detect and list AI providers via the RES" +
+                "T API\r\n    So that I can discover available models", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/RateLimitMiddleware.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/RateLimitMiddleware.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "gateway",
                 "ratelimit"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Rate Limit Middleware", "    As a gateway administrator\n    I want rate limiting on API endpoints\n    So t" +
-                "hat the gateway is protected from abuse", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Rate Limit Middleware", "    As a gateway administrator\r\n    I want rate limiting on API endpoints\r\n    So" +
+                " that the gateway is protected from abuse", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/RoutingEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/RoutingEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "routing"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Routing Endpoints", "    As a gateway consumer\n    I want to manage channel-to-agent routing via the R" +
-                "EST API\n    So that I can control message flow between channels and agents", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Routing Endpoints", "    As a gateway consumer\r\n    I want to manage channel-to-agent routing via the " +
+                "REST API\r\n    So that I can control message flow between channels and agents", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/SessionEndpoints.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/SessionEndpoints.feature.cs
@@ -30,8 +30,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "api",
                 "sessions"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Session Endpoints", "    As a gateway consumer\n    I want to manage chat sessions via the REST API\n   " +
-                " So that I can list, retrieve, and close sessions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "Session Endpoints", "    As a gateway consumer\r\n    I want to manage chat sessions via the REST API\r\n " +
+                "   So that I can list, retrieve, and close sessions", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Specs/Features/Gateway/SignalRStreaming.feature.cs
+++ b/tests/JD.AI.Specs/Features/Gateway/SignalRStreaming.feature.cs
@@ -28,8 +28,8 @@ namespace JD.AI.Specs.Features.Gateway
                 "gateway",
                 "signalr"};
         
-        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "SignalR Streaming", "    As a gateway consumer\n    I want to connect to the agent hub via SignalR\n    " +
-                "So that I can receive streamed agent responses in real time", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
+        private static global::Reqnroll.FeatureInfo featureInfo = new global::Reqnroll.FeatureInfo(new global::System.Globalization.CultureInfo("en-US"), "Features/Gateway", "SignalR Streaming", "    As a gateway consumer\r\n    I want to connect to the agent hub via SignalR\r\n  " +
+                "  So that I can receive streamed agent responses in real time", global::Reqnroll.ProgrammingLanguage.CSharp, featureTags, InitializeCucumberMessages());
         
         private global::Xunit.Abstractions.ITestOutputHelper _testOutputHelper;
         

--- a/tests/JD.AI.Tests/Commands/GatewayCliTests.cs
+++ b/tests/JD.AI.Tests/Commands/GatewayCliTests.cs
@@ -1,10 +1,10 @@
-using JD.AI.Commands;
-using JD.AI.Core.Infrastructure;
-using JD.AI.Utilities;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
+using JD.AI.Commands;
+using JD.AI.Core.Infrastructure;
+using JD.AI.Utilities;
 
 namespace JD.AI.Tests.Commands;
 


### PR DESCRIPTION
## Summary

- Fixes pre-existing whitespace/import ordering formatting errors in 65 files that were blocking all dependabot PRs from passing CI
- Adds `commit-message.prefix: chore` to both dependabot ecosystems so future PRs use conventional commit format
- Adds grouping to both nuget and github-actions ecosystems so future updates are batched into single PRs

## After merge
Run `@dependabot rebase` on PRs #462-#466 to rebase them onto main with the formatting fixes applied.