### PR TITLE
fix: stabilize WelcomeServiceStatusProbe RunCommandAsync test

### DIFF
--- a/src/JD.AI/Startup/WelcomeServiceStatusProbe.cs
+++ b/src/JD.AI/Startup/WelcomeServiceStatusProbe.cs
@@ -254,6 +254,14 @@ internal static class WelcomeServiceStatusProbe
             try
             {
                 await process.WaitForExitAsync(linkedCts.Token).ConfigureAwait(false);
+                // WaitForExitAsync does not guarantee that the redirected stdout/stderr
+                // streams have been fully flushed into the reader tasks before it returns
+                // (unlike the synchronous WaitForExit() overload). Calling the no-arg
+                // synchronous overload here ensures all pending stream data is drained
+                // before we await the reader tasks, eliminating a race on Linux CI where
+                // the process exits and the async wait completes before the OS has
+                // delivered all buffered output to the pipe.
+                process.WaitForExit();
                 var output = await outputTask.ConfigureAwait(false);
                 var error = await errorTask.ConfigureAwait(false);
                 return (process.ExitCode, output, error, false);


### PR DESCRIPTION
## Summary

- **Root cause:** `Process.WaitForExitAsync` does not guarantee that redirected stdout/stderr pipe data has been fully delivered to the async reader tasks before it returns. This is a documented .NET behaviour — unlike the synchronous `WaitForExit()` overload, the async version only waits for the process to exit, not for I/O completion on the redirected streams.
- **The race:** On Linux CI runners (which are more resource-constrained and schedule OS pipe flushes later), the sequence was: process exits → `WaitForExitAsync` unblocks → code awaits `outputTask`/`errorTask` → reads empty/partial strings before the OS has delivered all buffered pipe data. The test then saw `Output` not containing `"hello"` or `Error` not containing `"oops"`.
- **The fix:** Add `process.WaitForExit()` (no-arg synchronous overload) immediately after `WaitForExitAsync` returns. Microsoft's documentation explicitly states: *"To ensure that asynchronous event handling has been completed, call the WaitForExit() overload that takes no parameter after receiving a true return value from this overload."* This drains all pending pipe data before the reader tasks are consumed.

## Test plan

- [x] `RunCommandAsync_WhenCommandSucceeds_CapturesExitCodeOutputAndError` — ran 10 consecutive times locally, 10/10 passed
- [x] Full `WelcomeServiceStatusProbeExtendedTests` class — all 31 tests pass, 0 regressions
- [ ] CI green on this PR
- [ ] Dependabot PRs #484, #485, #486 will pick up the fix automatically when they rebase onto main

> **Note:** The flake does not reproduce locally on Windows (Windows pipe flushing semantics differ), but the hazard is real and the fix is correct per the .NET Process documentation. The fix is purely additive — `WaitForExit()` after `WaitForExitAsync` is a no-op when the process has already exited and streams are already drained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)