### PR TITLE
chore: upgrade GitHub Actions to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Determine version (NBGV)
         id: nbgv
-        uses: dotnet/nbgv@v0.5.1
+        uses: dotnet/nbgv@b944774b6878ef950cc14d1a72bf9c0ffafbb839 # node24 (unreleased past v0.5.1; pin SHA until v0.5.2 ships)
         with:
           setAllVars: true
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Determine version (NBGV)
         id: nbgv
-        uses: dotnet/nbgv@v0.5.1
+        uses: dotnet/nbgv@b944774b6878ef950cc14d1a72bf9c0ffafbb839 # node24 (unreleased past v0.5.1; pin SHA until v0.5.2 ships)
         with:
           setAllVars: true
 


### PR DESCRIPTION
## Summary

Upgrades `dotnet/nbgv` from the `v0.5.1` tag (Node.js 20) to a SHA pin on `master` that uses Node.js 24, resolving the intermittent `Value cannot be null (Parameter 'name')` error when the action writes empty-named variables to `$GITHUB_ENV`.

## Action Audit

| Action | Current | Latest | Runtime | Action |
|--------|---------|--------|---------|--------|
| `dotnet/nbgv` | `v0.5.1` | `v0.5.1` (tag) / `b944774` (master) | **node20** → **node24** | **Bumped to SHA** |
| `actions/checkout` | `v6` | `v6.0.2` | node24 | No change (major pinned) |
| `actions/setup-dotnet` | `v5` | `v5.2.0` | node24 | No change (major pinned) |
| `actions/upload-artifact` | `v7` | `v7.0.1` | node24 | No change (major pinned) |
| `actions/upload-pages-artifact` | `v5` | `v5.0.0` | composite | No change (major pinned) |
| `actions/deploy-pages` | `v5` | `v5.0.0` | node24 | No change (major pinned) |
| `actions/dependency-review-action` | `v4` | `v4.9.0` | node20 | No change — GitHub first-party, no v5 yet |
| `actions/labeler` | `v6` | `v6.0.1` | node24 | No change (major pinned) |
| `actions/stale` | `v10` | `v10.2.0` | node24 | No change (major pinned) |
| `actions/attest-sbom` | `v4` | `v4.1.0` | composite | No change (major pinned) |
| `codecov/codecov-action` | `v6` | `v6.0.0` | composite | No change (major pinned) |
| `softprops/action-gh-release` | `v3` | `v3.0.0` | node24 | No change (major pinned) |
| `github/codeql-action` | `v4` | latest bundle | node24 | No change (major pinned) |
| `docker/login-action` | `v4` | `v4.1.0` | node24 | No change (major pinned) |
| `docker/metadata-action` | `v6` | `v6.0.0` | node24 | No change (major pinned) |
| `docker/build-push-action` | `v7` | `v7.1.0` | node24 | No change (major pinned) |
| `anchore/sbom-action` | `v0` | `v0.24.0` | node24 | No change (major pinned) |
| `marocchino/sticky-pull-request-comment` | `v3` | `v3.0.4` | node24 | No change (major pinned) |
| `EnricoMi/publish-unit-test-result-action` | `v2` | `v2.23.0` | docker | No change (major pinned) |
| `codelytv/pr-size-labeler` | `v1` | `v1.10.4` | docker | No change (major pinned) |

## nbgv Node 24 Status

`dotnet/nbgv` **has not cut a new release** with node24. The `master` branch was updated to `node24` but the latest tag (`v0.5.1`, released 2026-03-25) still uses `node20`.

**Resolution:** Pinned to full commit SHA `b944774b6878ef950cc14d1a72bf9c0ffafbb839` (master HEAD as of 2026-04-18), which uses `node24`. This is the standard security practice for referencing unreleased action changes. Once `v0.5.2` (or later) is released with node24, the SHA should be swapped back to the tag.

## Files Changed

- `.github/workflows/ci.yml` — nbgv step bumped to SHA
- `.github/workflows/pr-validation.yml` — nbgv step bumped to SHA

## Test Plan

- [ ] PR Validation workflow passes on this PR
- [ ] CI workflow passes on merge to main
- [ ] No `Value cannot be null (Parameter 'name')` errors in nbgv steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)