### PR TITLE
fix: bump OTel packages (NU1902) and add fetch-depth for NBGV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Determine version (NBGV)
         id: nbgv
-        uses: dotnet/nbgv@v0.5.1
+        uses: dotnet/nbgv@b944774b6878ef950cc14d1a72bf9c0ffafbb839 # node24 (unreleased past v0.5.1; pin SHA until v0.5.2 ships)
         with:
           setAllVars: true
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Determine version (NBGV)
         id: nbgv
-        uses: dotnet/nbgv@v0.5.1
+        uses: dotnet/nbgv@b944774b6878ef950cc14d1a72bf9c0ffafbb839 # node24 (unreleased past v0.5.1; pin SHA until v0.5.2 ships)
         with:
           setAllVars: true
 

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install .NET 10
         uses: actions/setup-dotnet@v5

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.17" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.41" />
   </ItemGroup>
   <!-- Gateway -->
@@ -55,12 +55,12 @@
   </ItemGroup>
   <!-- Telemetry (OpenTelemetry) -->
   <ItemGroup>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
   </ItemGroup>
   <!-- Dashboard (Blazor WASM) -->
@@ -74,9 +74,9 @@
   <!-- Channel adapters -->
   <ItemGroup>
     <PackageVersion Include="Discord.Net" Version="3.19.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageVersion Include="NSec.Cryptography" Version="25.4.0" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="Telegram.Bot" Version="22.7.0" />
@@ -92,8 +92,8 @@
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="TinyBDD.Xunit" Version="0.6.1" />


### PR DESCRIPTION
## Summary
- bump OpenTelemetry packages to resolve NU1902 restore failures
- bump Microsoft.Extensions package baselines to 10.0.6 to resolve NU1605 downgrades
- fetch full git history in train-model for Nerdbank.GitVersioning

## Why
- `main` is red on restore/build due to `OpenTelemetry.Api 1.11.2`
- dependency update PRs for connector packages also fail on `Microsoft.Extensions.*` 10.0.5 -> 10.0.6 downgrades
- the scheduled/manual train-model workflow fails on shallow checkout

## Expected impact
- unblock `main` branch CI
- unblock dependency PRs #492-#496 after rerun or rebase

## Notes
- #493 should likely just need a rerun once base is fixed
- #492 may need a rebase because it also touches `Directory.Packages.props`
