### PR TITLE
fix: suppress CS0618 for AddZipkinExporter and add Ollama training handlers

### DIFF
--- a/src/JD.AI.Telemetry/Extensions/TelemetryServiceExtensions.cs
+++ b/src/JD.AI.Telemetry/Extensions/TelemetryServiceExtensions.cs
@@ -98,11 +98,13 @@ public static class TelemetryServiceExtensions
                 break;
 
             case "zipkin":
+#pragma warning disable CS0618 // OpenTelemetry deprecated Zipkin exporter; keep existing config support until migrated.
                 tracing.AddZipkinExporter(o =>
                 {
                     if (TryParseEndpoint(endpoint, out var uri))
                         o.Endpoint = uri;
                 });
+#pragma warning restore CS0618
                 break;
 
             default: // "console"

--- a/tools/JD.AI.Workflows.Training/AiTrainingDataSynthesizer.cs
+++ b/tools/JD.AI.Workflows.Training/AiTrainingDataSynthesizer.cs
@@ -12,9 +12,9 @@ public sealed class AiTrainingDataSynthesizer : IDisposable
     private readonly string _model;
     private int _generated;
 
-    public AiTrainingDataSynthesizer(string model = "qwen3.5:9b")
+    public AiTrainingDataSynthesizer(string model = "qwen3.5:9b", string ollamaHost = "http://localhost:11434")
     {
-        _ollama = new OllamaClient(model);
+        _ollama = new OllamaClient(model, ollamaHost);
         _model = model;
     }
 

--- a/tools/JD.AI.Workflows.Training/Program.cs
+++ b/tools/JD.AI.Workflows.Training/Program.cs
@@ -44,9 +44,83 @@ public static class Program
             ? args[outputArgIdx + 1]
             : "../../src/JD.AI.Workflows/Models/intent_classifier.zip";
 
+        var ollamaGenerateArgIdx = Array.IndexOf(args, "--ollama-generate");
+        int? ollamaGenerateCount = ollamaGenerateArgIdx >= 0 && ollamaGenerateArgIdx + 1 < args.Length
+            ? int.Parse(args[ollamaGenerateArgIdx + 1], System.Globalization.CultureInfo.InvariantCulture)
+            : null;
+        var ollamaValidate = args.Contains("--ollama-validate");
+
         if (benchmark)
         {
             RunBenchmark();
+            return 0;
+        }
+
+        // ── Ollama-synthesized training data generation ──────────────────
+        if (ollamaGenerateCount.HasValue)
+        {
+            var ollamaHost = Environment.GetEnvironmentVariable("OLLAMA_HOST") ?? "http://localhost:11434";
+            var dir = Path.GetDirectoryName(Path.GetFullPath(outputPath));
+            var jsonlPath = dir is not null
+                ? Path.Combine(dir, "ollama_training_data.jsonl")
+                : "ollama_training_data.jsonl";
+
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            List<TrainingDataGenerator.LabeledPrompt> generated = [];
+            using (var synthesizer = new AiTrainingDataSynthesizer(ollamaHost: ollamaHost))
+            {
+                await AnsiConsole.Progress()
+                    .StartAsync(async ctx =>
+                    {
+                        var task = ctx.AddTask("[green]Synthesizing training examples[/]",
+                            maxValue: ollamaGenerateCount.Value);
+                        generated = await synthesizer.GenerateAsync(
+                            ollamaGenerateCount.Value,
+                            (done, _) => task.Value = done);
+                    });
+            }
+
+            TrainingDataGenerator.WriteCsv(generated, jsonlPath);
+            AnsiConsole.MarkupLine($"[green]Synthesized {generated.Count} examples → {jsonlPath}[/]");
+            return 0;
+        }
+
+        // ── Ollama-based validation ──────────────────────────────────────
+        if (ollamaValidate)
+        {
+            if (dataPath is null)
+            {
+                AnsiConsole.MarkupLine("[red]--ollama-validate requires --data <path>[/]");
+                return 1;
+            }
+
+            if (!File.Exists(dataPath))
+            {
+                AnsiConsole.MarkupLine($"[red]Data file not found: {dataPath}[/]");
+                return 1;
+            }
+
+            var ollamaHost = Environment.GetEnvironmentVariable("OLLAMA_HOST") ?? "http://localhost:11434";
+            var prompts = TrainingDataGenerator.ReadCsv(dataPath);
+
+            List<ValidationResult> discrepancies = [];
+            using (var synthesizer = new AiTrainingDataSynthesizer(ollamaHost: ollamaHost))
+            {
+                await AnsiConsole.Progress()
+                    .StartAsync(async ctx =>
+                    {
+                        var task = ctx.AddTask("[green]Validating against Ollama[/]",
+                            maxValue: prompts.Count);
+                        discrepancies = await synthesizer.ValidateAsync(
+                            prompts,
+                            (done, _) => task.Value = done);
+                    });
+            }
+
+            await File.WriteAllTextAsync("validate_summary.txt", discrepancies.Count.ToString());
+            AnsiConsole.MarkupLine($"[cyan]Validation complete — {discrepancies.Count}/{prompts.Count} disagreements[/]");
             return 0;
         }
 


### PR DESCRIPTION
## Summary

Two fixes after PR #497 landed on main:

1. **Telemetry (CS0618)**: Wrap `AddZipkinExporter` call site in `src/JD.AI.Telemetry/Extensions/TelemetryServiceExtensions.cs` with `#pragma warning disable/restore CS0618` so the project compiles cleanly under TreatWarningsAsErrors.

2. **Ollama Training**: Add `--ollama-generate <count>` and `--ollama-validate` CLI handlers in `tools/JD.AI.Workflows.Training/Program.cs`, plus `OLLAMA_HOST` environment variable plumbing forwarded to `OllamaClient`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>