### PR TITLE
chore(deps): grouped dependabot updates with 2-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 2
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -16,3 +24,11 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 2
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Matches the canonical dependabot config already in use across TinyBDD, Flawright, ExperimentFramework, and JD.Efcpt.Build
- Adds 48-hour `cooldown.default-days: 2` to satisfy minimum package age before a PR is opened
- Switches to grouped PRs per ecosystem (`all-dependencies` group with `"*"` pattern) — one PR per ecosystem per week instead of one per package
- Normalizes `commit-message.prefix` to `chore(deps)` for both NuGet and GitHub Actions ecosystems
- Raises NuGet `open-pull-requests-limit` from 5 to 10 to match sibling repos

## Test plan

- [ ] Verify `.github/dependabot.yml` renders correctly in the GitHub UI (Settings → Code security → Dependabot)
- [ ] Confirm no CI failures (config-only change, no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)