### PR TITLE
fix: bump Microsoft.Extensions.* 10.0.7→10.0.8 to resolve NU1605 restore failures

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.24" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.41" />
   </ItemGroup>
   <!-- Gateway -->
@@ -74,9 +74,9 @@
   <!-- Channel adapters -->
   <ItemGroup>
     <PackageVersion Include="Discord.Net" Version="3.19.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="NSec.Cryptography" Version="25.4.0" />
     <PackageVersion Include="SlackNet" Version="0.17.9" />
     <PackageVersion Include="Telegram.Bot" Version="22.7.0" />
@@ -92,8 +92,8 @@
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="TinyBDD.Xunit" Version="0.6.1" />


### PR DESCRIPTION
## Problem

PRs #524 (ClaudeCode 1.0.30) and #526 (OpenAICodex 0.1.26) were merged without CI running (workflows didn't trigger on those dependabot PRs). When PR #525 (GitHubCopilot) later triggered a rebase + CI run, the CI revealed that the two previously-merged connector bumps introduced NU1605 downgrade errors.

Root cause: `ClaudeCode 1.0.30` and `OpenAICodex 0.1.26` now require `Microsoft.Extensions.* >= 10.0.8`, but `Directory.Packages.props` had them pinned at `10.0.7`.

## Fix

Bump 6 `Microsoft.Extensions.*` packages from `10.0.7` → `10.0.8` in `Directory.Packages.props`:

- `Microsoft.Extensions.DependencyInjection.Abstractions`
- `Microsoft.Extensions.DependencyInjection`
- `Microsoft.Extensions.Http`
- `Microsoft.Extensions.Hosting.Abstractions`
- `Microsoft.Extensions.Logging.Abstractions`
- `Microsoft.Extensions.Options`

## Testing

This unblocks `dotnet restore` for all projects. Once merged, PR #525 (GitHubCopilot 0.1.55) should be rebased and CI should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)