### PR TITLE
chore(deps): Bump the all-dependencies group with 48 updates (replaces #530)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2025.3.3",
+      "version": "2026.1.2",
       "commands": [
         "jb"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,25 @@
   <!-- Build infrastructure -->
   <ItemGroup>
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.19" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.73.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.91" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.76.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   <!-- Application -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.ML" Version="4.0.0" />
-    <PackageVersion Include="Markdig" Version="1.1.1" />
-    <PackageVersion Include="YamlDotNet" Version="17.0.0" />
-    <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.71" />
-    <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.41" />
+    <PackageVersion Include="Microsoft.ML" Version="5.0.0" />
+    <PackageVersion Include="Markdig" Version="1.2.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
+    <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.90" />
+    <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.90" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="1.0.30" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.46" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.55" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.OpenAICodex" Version="0.1.26" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.76.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.76.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.76.0" />
@@ -31,14 +31,14 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.72.0-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Amazon" Version="1.72.0-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.HuggingFace" Version="1.72.0-preview" />
-    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="WorkflowFramework" Version="0.15.0" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageVersion Include="LLamaSharp" Version="0.26.0" />
-    <PackageVersion Include="LLamaSharp.Backend.Cpu" Version="0.26.0" />
-    <PackageVersion Include="SSH.NET" Version="2024.2.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="4.0.0" />
+    <PackageVersion Include="LLamaSharp" Version="0.27.0" />
+    <PackageVersion Include="LLamaSharp.Backend.Cpu" Version="0.27.0" />
+    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
   </ItemGroup>
   <!-- Distributed infrastructure -->
   <ItemGroup>
@@ -46,11 +46,11 @@
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.41" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
   </ItemGroup>
   <!-- Gateway -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.2.0" />
   </ItemGroup>
   <!-- Telemetry (OpenTelemetry) -->
@@ -61,15 +61,15 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
   </ItemGroup>
   <!-- Dashboard (Blazor WASM) -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-    <PackageVersion Include="MudBlazor" Version="8.5.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageVersion Include="MudBlazor" Version="9.4.0" />
   </ItemGroup>
   <!-- Channel adapters -->
   <ItemGroup>
@@ -77,15 +77,15 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
-    <PackageVersion Include="NSec.Cryptography" Version="25.4.0" />
-    <PackageVersion Include="SlackNet" Version="0.17.9" />
-    <PackageVersion Include="Telegram.Bot" Version="22.7.0" />
+    <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageVersion Include="SlackNet" Version="0.17.10" />
+    <PackageVersion Include="Telegram.Bot" Version="22.10.0.1" />
   </ItemGroup>
   <!-- Daemon / service hosting -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.3" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="10.0.8" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
   </ItemGroup>
   <!-- Testing -->
   <ItemGroup>
@@ -94,15 +94,15 @@
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="TinyBDD.Xunit" Version="0.6.1" />
+    <PackageVersion Include="TinyBDD.Xunit" Version="0.19.16" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.58.0" />
-    <PackageVersion Include="Reqnroll" Version="3.3.3" />
-    <PackageVersion Include="Reqnroll.xUnit" Version="3.3.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.xUnit" Version="3.3.4" />
   </ItemGroup>
 </Project>

--- a/src/JD.AI.Plugins.SDK/JD.AI.Plugins.SDK.csproj
+++ b/src/JD.AI.Plugins.SDK/JD.AI.Plugins.SDK.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.8" />
     <PackageReference Include="Microsoft.SemanticKernel" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

This is a clean re-application of the grouped dependabot PR #530 on top of current main.

PR #530 (created by dependabot via grouped config) became conflicting because individual PRs #522-524, #526 were merged while #530 was in flight, causing CRLF-based three-way merge conflicts that GitHub could not auto-resolve.

### Key changes
- **JD.SemanticKernel.Connectors.GitHubCopilot** 0.1.46 → 0.1.55 (the package from original PR #525)
- JD.SemanticKernel.Extensions 0.1.71 → 0.1.90
- JD.SemanticKernel.Extensions.Mcp 0.1.41 → 0.1.90
- Microsoft.EntityFrameworkCore 9.0.6 → 10.0.8
- MudBlazor 8.5.1 → 9.4.0
- Microsoft.ML 4.0.0 → 5.0.0
- YamlDotNet 17.0.0 → 18.0.0
- NSec.Cryptography 25.4.0 → 26.4.0
- SSH.NET 2024.2.0 → 2025.1.0
- Plus ~39 other package updates (all *.* bumps to 10.0.8 or latest stable)
- JD.AI.Plugins.SDK.csproj: added VersionOverride for Extensions packages
- jetbrains.resharper.globaltools: 2025.3.3 → 2026.1.2

### Closes
Supersedes dependabot PR #530 (conflicting).
Covers original task item PR #525 (GitHubCopilot 0.1.46 → 0.1.55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)