### PR TITLE
chore(deps): bump JD.SemanticKernel.Connectors.GitHubCopilot 0.1.46 to 0.1.55

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.71" />
     <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.41" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="1.0.30" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.46" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.55" />
     <PackageVersion Include="JD.SemanticKernel.Connectors.OpenAICodex" Version="0.1.26" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />


### PR DESCRIPTION
## Summary

- Bumps `JD.SemanticKernel.Connectors.GitHubCopilot` from 0.1.46 to 0.1.55 in `Directory.Packages.props`
- Minimal scope: single-line change, no other package updates
- Completes the original PR #525 (dependabot) intent; that PR was closed as superseded by the grouped update PR #530
- The grouped update PR (#530/#531) included MudBlazor 8->9 and ImageSharp 3->4 which have breaking changes; this PR deliberately excludes those

## Related

Supersedes #531 (the grouped deps fix PR that failed CI due to MudBlazor v9 and ImageSharp v4 breaking changes)

Generated with Claude Code