### PR TITLE
[JD.AI] Suppress unfixable SQLitePCLRaw NU1903 audit advisory in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,4 +39,25 @@
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
   </ItemGroup>
 
+  <!--
+    NuGet audit suppressions.
+
+    GHSA-2m69-gcr7-jv3q (NU1903): high-severity advisory against the native
+    SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11, pulled in transitively via
+    Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite 10.0.9. The
+    underlying SQLite CVE (CVE-2025-6965) is fixed in SQLite 3.50.2, but the
+    SQLitePCLRaw wrapper packages have not yet shipped a patched release, so
+    there is no version to bump to. Because the repo treats warnings as errors
+    under CI (TreatWarningsAsErrors when CI=true), this otherwise-warning breaks
+    dotnet restore and fails every CI workflow.
+
+    Scoped to this single advisory only - all other NuGet audit warnings remain
+    errors. Remove once a patched SQLitePCLRaw.lib.e_sqlite3 (> 2.1.11) ships
+    and the SQLite package versions are bumped to consume it.
+  -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
+
 </Project>


### PR DESCRIPTION
## Problem

The **Integration Tests** workflow (and every other CI workflow that runs `dotnet restore`) has been failing on `main` since ~2026-06-20. Root cause is **not** the Flawright/RealInputMode E2E issue.

`dotnet restore` fails at restore time because NuGet audit promotes advisory **GHSA-2m69-gcr7-jv3q** to error **NU1903**:

> Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability

`Directory.Build.props` sets `TreatWarningsAsErrors=true` when `CI=true`, so this audit warning becomes a hard error and the job dies before tests run. `SQLitePCLRaw.lib.e_sqlite3` is a transitive dependency of `Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore.Sqlite` 10.0.9. The advisory was published 2026-06-18 (matching the failure onset).

## Why suppression (not a bump)

The underlying SQLite CVE (CVE-2025-6965) is fixed in SQLite 3.50.2, but the SQLitePCLRaw wrapper packages have **no patched release** (advisory lists patched version: None). There is no version to bump to.

## Fix

Add a **scoped** `NuGetAuditSuppress` for this single advisory in `Directory.Build.props`. All other audit warnings continue to be treated as errors. A comment documents removal once a patched wrapper ships.

## Verification

Reproduced `CI=true dotnet restore` failing with NU1903 before the change, and passing (exit 0, no NU1903) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)