### PR TITLE
fix(deps): bump SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (GHSA-2m69-gcr7-jv3q)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,25 +39,5 @@
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
   </ItemGroup>
 
-  <!--
-    NuGet audit suppressions.
-
-    GHSA-2m69-gcr7-jv3q (NU1903): high-severity advisory against the native
-    SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11, pulled in transitively via
-    Microsoft.Data.Sqlite / Microsoft.EntityFrameworkCore.Sqlite 10.0.9. The
-    underlying SQLite CVE (CVE-2025-6965) is fixed in SQLite 3.50.2, but the
-    SQLitePCLRaw wrapper packages have not yet shipped a patched release, so
-    there is no version to bump to. Because the repo treats warnings as errors
-    under CI (TreatWarningsAsErrors when CI=true), this otherwise-warning breaks
-    dotnet restore and fails every CI workflow.
-
-    Scoped to this single advisory only - all other NuGet audit warnings remain
-    errors. Remove once a patched SQLitePCLRaw.lib.e_sqlite3 (> 2.1.11) ships
-    and the SQLite package versions are bumped to consume it.
-  -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
-
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.77.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.77.0" />

--- a/src/JD.AI.Channels.Queue/JD.AI.Channels.Queue.csproj
+++ b/src/JD.AI.Channels.Queue/JD.AI.Channels.Queue.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 

--- a/src/JD.AI.Core/JD.AI.Core.csproj
+++ b/src/JD.AI.Core/JD.AI.Core.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="JD.SemanticKernel.Connectors.GitHubCopilot" />
     <PackageReference Include="JD.SemanticKernel.Connectors.OpenAICodex" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.SemanticKernel" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" />

--- a/src/JD.AI.Workflows/JD.AI.Workflows.csproj
+++ b/src/JD.AI.Workflows/JD.AI.Workflows.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.SemanticKernel" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JD.AI/JD.AI.csproj
+++ b/src/JD.AI/JD.AI.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="HtmlAgilityPack" />
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
 
   <!-- Core library (agents, orchestration, checkpointing) -->


### PR DESCRIPTION
## Summary

- Pins `SQLitePCLRaw.lib.e_sqlite3` to **3.50.3** in `Directory.Packages.props` — this version bundles SQLite 3.50.2 which contains the fix for CVE-2025-6965 (GHSA-2m69-gcr7-jv3q)
- Adds explicit `<PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />` (no version; CPM pins it) to the four projects that directly reference `Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore.Sqlite`: `JD.AI`, `JD.AI.Core`, `JD.AI.Channels.Queue`, `JD.AI.Workflows`
- Removes the `NuGetAuditSuppress` block for GHSA-2m69-gcr7-jv3q from `Directory.Build.props` — the suppression comment noted it should be removed once a patched release ships; 3.50.3 is that release (also successfully applied to QuickApiMapper #125, McpManager #116, WrapGod #227, PokManagerUI #121 with no EF Core 9.x/10.x incompatibilities)

## Test plan

- [x] `dotnet restore` — clean, no NU1903 advisory warnings
- [x] `dotnet build --no-restore -warnaserror` — Build succeeded, 0 warnings, 0 errors (with `TreatWarningsAsErrors=true` active)
- [ ] CI Integration Tests green
- [ ] Dependabot alert for GHSA-2m69-gcr7-jv3q closes automatically after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)