### PR TITLE
fix(deps): pin Microsoft.OpenApi to 2.7.5 (GHSA-v5pm-xwqc-g5wc)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
   <!-- Gateway -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.2.0" />
   </ItemGroup>
   <!-- Telemetry (OpenTelemetry) -->

--- a/src/JD.AI.Gateway/JD.AI.Gateway.csproj
+++ b/src/JD.AI.Gateway/JD.AI.Gateway.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Co-Authored-By: Claude <noreply@anthropic.com>
