### PR TITLE
chore(deps): ignore SixLabors.ImageSharp major updates (v4 requires paid license)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
       nuget-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "SixLabors.ImageSharp"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directories:


### PR DESCRIPTION
## Summary
- SixLabors.ImageSharp 4.0.0 requires a paid commercial license (build fails with "No Six Labors license found")
- Adds a Dependabot `ignore` rule for major-version bumps of `SixLabors.ImageSharp` under the nuget group so we stay on the OSS-licensed 3.x line
- Unblocks the grouped nuget PR (#551) so the remaining 20 good updates can be recreated without the offending bump

## Test plan
- [x] YAML syntax matches existing file style
- [ ] CI checks pass on this PR