### PR TITLE
fix: MA0002 ordinal comparisons and CS8602 nullable derefs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2026.1.4",
+      "version": "2026.2.0.1",
       "commands": [
         "jb"
       ],
       "rollForward": false
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.10",
+      "version": "5.5.11",
       "commands": [
         "reportgenerator"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,9 @@
   <ItemGroup>
     <!-- Pin transitively-referenced AngleSharp (pulled in by bunit) above 1.4.0, which has a known
          moderate-severity mXSS vulnerability (GHSA-pgww-w46g-26qg), fixed in 1.5.0. -->
-    <PackageVersion Include="AngleSharp" Version="1.5.0" />
+    <PackageVersion Include="AngleSharp" Version="1.7.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.123" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.138" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.78.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
@@ -18,11 +18,11 @@
     <PackageVersion Include="Microsoft.ML" Version="5.0.0" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
-    <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.113" />
-    <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.113" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="1.0.44" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.74" />
-    <PackageVersion Include="JD.SemanticKernel.Connectors.OpenAICodex" Version="0.1.40" />
+    <PackageVersion Include="JD.SemanticKernel.Extensions" Version="0.1.117" />
+    <PackageVersion Include="JD.SemanticKernel.Extensions.Mcp" Version="0.1.117" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.ClaudeCode" Version="1.0.48" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.GitHubCopilot" Version="0.1.78" />
+    <PackageVersion Include="JD.SemanticKernel.Connectors.OpenAICodex" Version="0.1.45" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Amazon" Version="1.72.0-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.HuggingFace" Version="1.72.0-preview" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
-    <PackageVersion Include="WorkflowFramework" Version="1.0.4" />
+    <PackageVersion Include="WorkflowFramework" Version="1.0.5" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
@@ -46,11 +46,11 @@
   </ItemGroup>
   <!-- Distributed infrastructure -->
   <ItemGroup>
-    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.100.5" />
+    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.100.7" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="StackExchange.Redis" Version="3.0.17" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.1.0" />
   </ItemGroup>
   <!-- Gateway -->
   <ItemGroup>
@@ -84,7 +84,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
     <PackageVersion Include="SlackNet" Version="0.17.10" />
-    <PackageVersion Include="Telegram.Bot" Version="22.10.2" />
+    <PackageVersion Include="Telegram.Bot" Version="22.10.2.1" />
   </ItemGroup>
   <!-- Daemon / service hosting -->
   <ItemGroup>
@@ -94,14 +94,14 @@
   </ItemGroup>
   <!-- Testing -->
   <ItemGroup>
-    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="bunit" Version="2.8.6" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="TinyBDD.Xunit" Version="0.19.29" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
+    <PackageVersion Include="TinyBDD.Xunit" Version="0.19.31" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />

--- a/tests/JD.AI.Gateway.Tests/ChannelFactoryTests.cs
+++ b/tests/JD.AI.Gateway.Tests/ChannelFactoryTests.cs
@@ -18,7 +18,7 @@ public sealed class ChannelFactoryTests
         // Provide a NullLogger so the DurableQueueChannelDecorator can be constructed.
         // NSubstitute mocks return a mock object for unconfigured calls; we explicitly
         // return NullLogger so GetRequiredService resolves correctly.
-        sp.GetService(Arg.Is<Type>(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(ILogger<>)))
+        sp.GetService(Arg.Is<Type>(t => t!.IsGenericType && t.GetGenericTypeDefinition() == typeof(ILogger<>)))
             .Returns(NullLogger<DurableQueueChannelDecorator>.Instance);
         _factory = new ChannelFactory(sp, NullLogger<ChannelFactory>.Instance);
     }

--- a/tests/JD.AI.Sandbox.Tests/SandboxPolicyTests.cs
+++ b/tests/JD.AI.Sandbox.Tests/SandboxPolicyTests.cs
@@ -44,8 +44,8 @@ public class SandboxPolicyTests
         };
 
         Assert.Equal(2, policy.AllowedPaths.Count);
-        Assert.Contains("/tmp/sandbox", policy.AllowedPaths);
-        Assert.Contains("/var/data", policy.AllowedPaths);
+        Assert.Contains("/tmp/sandbox", policy.AllowedPaths, StringComparer.Ordinal);
+        Assert.Contains("/var/data", policy.AllowedPaths, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Specs/StepDefinitions/Core/CheckpointingSteps.cs
+++ b/tests/JD.AI.Specs/StepDefinitions/Core/CheckpointingSteps.cs
@@ -176,7 +176,7 @@ public sealed class CheckpointingSteps
         Directory.Exists(checkpointRoot).Should().BeTrue();
         var cpDirs = Directory.GetDirectories(checkpointRoot);
         cpDirs.Should().NotBeEmpty();
-        var latestCp = cpDirs.OrderDescending().First();
+        var latestCp = cpDirs.OrderDescending(StringComparer.Ordinal).First();
         File.Exists(Path.Combine(latestCp, "Program.cs")).Should().BeTrue();
     }
 

--- a/tests/JD.AI.Tests/Agent/ToolConfirmationFilterInvocationTests.cs
+++ b/tests/JD.AI.Tests/Agent/ToolConfirmationFilterInvocationTests.cs
@@ -298,7 +298,7 @@ public sealed class ToolConfirmationFilterInvocationTests
         output.ToolPromptCount.Should().Be(0);
         await session.EventBus.Received(1).PublishAsync(
             Arg.Is<JD.AI.Core.Events.GatewayEvent>(e =>
-                string.Equals(e.EventType, "tool.audit", StringComparison.Ordinal) &&
+                string.Equals(e!.EventType, "tool.audit", StringComparison.Ordinal) &&
                 string.Equals(e.SourceId, session.SessionInfo!.Id, StringComparison.Ordinal) &&
                 e.GetType() == typeof(JD.AI.Core.Events.ToolAuditEntry) &&
                 string.Equals(((JD.AI.Core.Events.ToolAuditEntry)e).Decision, "Allowed", StringComparison.Ordinal)),

--- a/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/AgentDefinitionRegistryTests.cs
@@ -106,8 +106,8 @@ public sealed class AgentDefinitionRegistryTests : IDisposable
         Assert.NotNull(def);
         Assert.Equal("PR Reviewer", def.DisplayName);
         Assert.Equal("1.2", def.Version);
-        Assert.Contains("code-review", def.Tags);
-        Assert.Contains("pr-workflow", def.Workflows);
+        Assert.Contains("code-review", def.Tags, StringComparer.Ordinal);
+        Assert.Contains("pr-workflow", def.Workflows, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
+++ b/tests/JD.AI.Tests/Agents/FileAgentDefinitionRegistryTests.cs
@@ -327,9 +327,9 @@ public sealed class FileAgentDefinitionRegistryTests : IDisposable
     [Fact]
     public void All_ContainsAllThreeEnvironments()
     {
-        Assert.Contains(AgentEnvironments.Dev, AgentEnvironments.All);
-        Assert.Contains(AgentEnvironments.Staging, AgentEnvironments.All);
-        Assert.Contains(AgentEnvironments.Prod, AgentEnvironments.All);
+        Assert.Contains(AgentEnvironments.Dev, AgentEnvironments.All, StringComparer.Ordinal);
+        Assert.Contains(AgentEnvironments.Staging, AgentEnvironments.All, StringComparer.Ordinal);
+        Assert.Contains(AgentEnvironments.Prod, AgentEnvironments.All, StringComparer.Ordinal);
     }
 
     // ── IAgentDefinitionRegistry sync interface (memory cache) ────────────

--- a/tests/JD.AI.Tests/Agents/ToolExecutionPermissionEvaluatorTests.cs
+++ b/tests/JD.AI.Tests/Agents/ToolExecutionPermissionEvaluatorTests.cs
@@ -110,7 +110,7 @@ public sealed class ToolExecutionPermissionEvaluatorTests
         result.Decision.Should().Be(ToolExecutionGateDecision.AllowWithoutPrompt);
         _ = mockBus.Received(1).PublishAsync(
             Arg.Is<GatewayEvent>(e =>
-                e.EventType == "tool.audit" &&
+                e!.EventType == "tool.audit" &&
                 e.SourceId == "sess-123"),
             Arg.Any<CancellationToken>());
     }
@@ -159,7 +159,7 @@ public sealed class ToolExecutionPermissionEvaluatorTests
 
         await mockBus.Received(1).PublishAsync(
             Arg.Is<GatewayEvent>(e =>
-                e.EventType == "tool.audit" &&
+                e!.EventType == "tool.audit" &&
                 e.SourceId == "sess-456"),
             Arg.Any<CancellationToken>());
     }

--- a/tests/JD.AI.Tests/AskQuestionsTests.cs
+++ b/tests/JD.AI.Tests/AskQuestionsTests.cs
@@ -26,7 +26,7 @@ public sealed class AskQuestionsTests
         var a = new AskQuestionsRequest();
         var b = new AskQuestionsRequest();
 
-        Assert.NotEqual(a.Id, b.Id);
+        Assert.NotEqual(a.Id, b.Id, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Commands/CommandContextTests.cs
+++ b/tests/JD.AI.Tests/Commands/CommandContextTests.cs
@@ -73,6 +73,6 @@ public class CommandContextTests
         };
 
         Assert.Equal(3, param.Choices.Count);
-        Assert.Contains("green", param.Choices);
+        Assert.Contains("green", param.Choices, StringComparer.Ordinal);
     }
 }

--- a/tests/JD.AI.Tests/Commands/ToolHistoryActionServiceTests.cs
+++ b/tests/JD.AI.Tests/Commands/ToolHistoryActionServiceTests.cs
@@ -42,7 +42,7 @@ public sealed class ToolHistoryActionServiceTests
             var profile = await store.GetToolPermissionProfileAsync(tempDirectory);
 
             Assert.Contains("Allowed", result);
-            Assert.Contains("run_command", profile.GlobalAllowed);
+            Assert.Contains("run_command", profile.GlobalAllowed, StringComparer.Ordinal);
             Assert.True(session.ToolPermissionProfile.IsExplicitlyAllowed("run_command"));
         }
         finally
@@ -68,7 +68,7 @@ public sealed class ToolHistoryActionServiceTests
             var profile = await store.GetToolPermissionProfileAsync(tempDirectory);
 
             Assert.Contains("Allowed", result);
-            Assert.Contains("read_file", profile.ProjectAllowed);
+            Assert.Contains("read_file", profile.ProjectAllowed, StringComparer.Ordinal);
             Assert.True(session.ToolPermissionProfile.IsExplicitlyAllowed("read_file"));
         }
         finally
@@ -94,7 +94,7 @@ public sealed class ToolHistoryActionServiceTests
             var profile = await store.GetToolPermissionProfileAsync(tempDirectory);
 
             Assert.Contains("Denied", result);
-            Assert.Contains("run_command", profile.GlobalDenied);
+            Assert.Contains("run_command", profile.GlobalDenied, StringComparer.Ordinal);
             Assert.True(session.ToolPermissionProfile.IsExplicitlyDenied("run_command"));
         }
         finally
@@ -120,7 +120,7 @@ public sealed class ToolHistoryActionServiceTests
             var profile = await store.GetToolPermissionProfileAsync(tempDirectory);
 
             Assert.Contains("Denied", result);
-            Assert.Contains("git_push", profile.ProjectDenied);
+            Assert.Contains("git_push", profile.ProjectDenied, StringComparer.Ordinal);
             Assert.True(session.ToolPermissionProfile.IsExplicitlyDenied("git_push"));
         }
         finally

--- a/tests/JD.AI.Tests/Credentials/AwsSecretsManagerCredentialStoreAdditionalTests.cs
+++ b/tests/JD.AI.Tests/Credentials/AwsSecretsManagerCredentialStoreAdditionalTests.cs
@@ -105,7 +105,7 @@ public sealed class AwsSecretsManagerCredentialStoreAdditionalTests
         // Test prefix concatenation via GetAsync returning expected secretId
         var client = Substitute.For<IAmazonSecretsManager>();
         client.GetSecretValueAsync(
-                Arg.Is<GetSecretValueRequest>(r => string.Equals(r.SecretId, "prefix/mykey", StringComparison.Ordinal)),
+                Arg.Is<GetSecretValueRequest>(r => string.Equals(r!.SecretId, "prefix/mykey", StringComparison.Ordinal)),
                 Arg.Any<CancellationToken>())
             .Returns(new GetSecretValueResponse { SecretString = "found" });
 

--- a/tests/JD.AI.Tests/Credentials/AwsSecretsManagerCredentialStoreTests.cs
+++ b/tests/JD.AI.Tests/Credentials/AwsSecretsManagerCredentialStoreTests.cs
@@ -31,7 +31,7 @@ public sealed class AwsSecretsManagerCredentialStoreTests
     public async Task GetAsync_ReturnsValue_WhenSecretExists()
     {
         _client.GetSecretValueAsync(
-                   Arg.Is<GetSecretValueRequest>(r => r.SecretId == "jdai/mykey"),
+                   Arg.Is<GetSecretValueRequest>(r => r!.SecretId == "jdai/mykey"),
                    Arg.Any<CancellationToken>())
                .Returns(new GetSecretValueResponse { SecretString = "thevalue" });
 
@@ -55,14 +55,14 @@ public sealed class AwsSecretsManagerCredentialStoreTests
     public async Task SetAsync_CallsPutSecretValueAsync_WhenSecretExists()
     {
         _client.PutSecretValueAsync(
-                   Arg.Is<PutSecretValueRequest>(r => r.SecretId == "jdai/api-key" && r.SecretString == "val"),
+                   Arg.Is<PutSecretValueRequest>(r => r!.SecretId == "jdai/api-key" && r.SecretString == "val"),
                    Arg.Any<CancellationToken>())
                .Returns(new PutSecretValueResponse());
 
         await _sut.SetAsync("api-key", "val");
 
         await _client.Received(1).PutSecretValueAsync(
-            Arg.Is<PutSecretValueRequest>(r => r.SecretId == "jdai/api-key"),
+            Arg.Is<PutSecretValueRequest>(r => r!.SecretId == "jdai/api-key"),
             Arg.Any<CancellationToken>());
     }
 
@@ -77,7 +77,7 @@ public sealed class AwsSecretsManagerCredentialStoreTests
         await _sut.SetAsync("new-key", "value");
 
         await _client.Received(1).CreateSecretAsync(
-            Arg.Is<CreateSecretRequest>(r => r.Name == "jdai/new-key" && r.SecretString == "value"),
+            Arg.Is<CreateSecretRequest>(r => r!.Name == "jdai/new-key" && r.SecretString == "value"),
             Arg.Any<CancellationToken>());
     }
 
@@ -90,7 +90,7 @@ public sealed class AwsSecretsManagerCredentialStoreTests
         await _sut.RemoveAsync("mykey");
 
         await _client.Received(1).DeleteSecretAsync(
-            Arg.Is<DeleteSecretRequest>(r => r.SecretId == "jdai/mykey"),
+            Arg.Is<DeleteSecretRequest>(r => r!.SecretId == "jdai/mykey"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/JD.AI.Tests/Daemon/Services/BridgeCommandServiceTests.cs
+++ b/tests/JD.AI.Tests/Daemon/Services/BridgeCommandServiceTests.cs
@@ -109,12 +109,12 @@ public sealed class BridgeCommandServiceTests
 
         var (prefixes, contains) = BridgeCommandService.BuildManagedSessionFilters(config);
 
-        Assert.Contains("agent:jdai-", prefixes);
-        Assert.Contains("agent:jdai-default:", prefixes);
-        Assert.Contains("g-agent-", contains);
-        Assert.Contains("jdai-default", contains);
-        Assert.Contains("signal:g-agent-", contains);
-        Assert.Contains("discord:g-agent-", contains);
+        Assert.Contains("agent:jdai-", prefixes, StringComparer.Ordinal);
+        Assert.Contains("agent:jdai-default:", prefixes, StringComparer.Ordinal);
+        Assert.Contains("g-agent-", contains, StringComparer.Ordinal);
+        Assert.Contains("jdai-default", contains, StringComparer.Ordinal);
+        Assert.Contains("signal:g-agent-", contains, StringComparer.Ordinal);
+        Assert.Contains("discord:g-agent-", contains, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Daemon/Services/UpdateServiceTests.cs
+++ b/tests/JD.AI.Tests/Daemon/Services/UpdateServiceTests.cs
@@ -142,7 +142,7 @@ public sealed class UpdateServiceTests
         await svc.ApplyUpdateAsync();
 
         await events.Received().PublishAsync(
-            Arg.Is<GatewayEvent>(e => e.EventType == "gateway.update.draining"),
+            Arg.Is<GatewayEvent>(e => e!.EventType == "gateway.update.draining"),
             Arg.Any<CancellationToken>());
     }
 
@@ -156,7 +156,7 @@ public sealed class UpdateServiceTests
         await svc.ApplyUpdateAsync();
 
         await events.Received().PublishAsync(
-            Arg.Is<GatewayEvent>(e => e.EventType == "gateway.update.applying"),
+            Arg.Is<GatewayEvent>(e => e!.EventType == "gateway.update.applying"),
             Arg.Any<CancellationToken>());
     }
 
@@ -174,7 +174,7 @@ public sealed class UpdateServiceTests
 
         var events = Substitute.For<IEventBus>();
         events.PublishAsync(
-                Arg.Is<GatewayEvent>(e => e.EventType == "gateway.update.draining"),
+                Arg.Is<GatewayEvent>(e => e!.EventType == "gateway.update.draining"),
                 Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
@@ -211,7 +211,7 @@ public sealed class UpdateServiceTests
 
         // The draining event should have been published (we used the primed update, not a fresh check)
         await events.Received().PublishAsync(
-            Arg.Is<GatewayEvent>(e => e.EventType == "gateway.update.draining"),
+            Arg.Is<GatewayEvent>(e => e!.EventType == "gateway.update.draining"),
             Arg.Any<CancellationToken>());
     }
 
@@ -278,7 +278,7 @@ public sealed class UpdateServiceTests
 
         // At least the "draining" event should have been published
         await events.Received().PublishAsync(
-            Arg.Is<GatewayEvent>(e => e.EventType == "gateway.update.draining"),
+            Arg.Is<GatewayEvent>(e => e!.EventType == "gateway.update.draining"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/JD.AI.Tests/Dashboard/GatewayAuthGateTests.cs
+++ b/tests/JD.AI.Tests/Dashboard/GatewayAuthGateTests.cs
@@ -86,7 +86,7 @@ public sealed class GatewayAuthGateTests : DashboardBunitTestContext
         await cut.Find("[data-testid='connect-button']").ClickAsync(new());
 
         await signalR.Received().ConnectAsync(
-            Arg.Is<string>(s => s.StartsWith("ws://")),
+            Arg.Is<string>(s => s!.StartsWith("ws://")),
             Arg.Any<string?>());
     }
 }

--- a/tests/JD.AI.Tests/Dashboard/LogsPageBunitTests.cs
+++ b/tests/JD.AI.Tests/Dashboard/LogsPageBunitTests.cs
@@ -168,7 +168,7 @@ public sealed class LogsPageBunitTests : DashboardBunitTestContext
         cut.WaitForAssertion(() =>
         {
             var chip = cut.Find("[data-testid='log-level-chip-evt-1']");
-            Assert.Contains("mud-chip-color-error", chip.ClassList);
+            Assert.Contains("mud-chip-color-error", chip.ClassList, StringComparer.Ordinal);
         });
     }
 
@@ -185,7 +185,7 @@ public sealed class LogsPageBunitTests : DashboardBunitTestContext
         cut.WaitForAssertion(() =>
         {
             var chip = cut.Find("[data-testid='log-level-chip-evt-2']");
-            Assert.Contains("mud-chip-color-info", chip.ClassList);
+            Assert.Contains("mud-chip-color-info", chip.ClassList, StringComparer.Ordinal);
         });
     }
 

--- a/tests/JD.AI.Tests/Dashboard/SettingsLogsTabBunitTests.cs
+++ b/tests/JD.AI.Tests/Dashboard/SettingsLogsTabBunitTests.cs
@@ -66,7 +66,7 @@ public sealed class SettingsLogsTabBunitTests : DashboardBunitTestContext
         cut.WaitForAssertion(() =>
         {
             var chip = cut.Find("[data-testid='log-level-chip-evt-1']");
-            Assert.Contains("mud-chip-color-error", chip.ClassList);
+            Assert.Contains("mud-chip-color-error", chip.ClassList, StringComparer.Ordinal);
         });
     }
 

--- a/tests/JD.AI.Tests/Governance/ApprovalServiceTests.cs
+++ b/tests/JD.AI.Tests/Governance/ApprovalServiceTests.cs
@@ -190,8 +190,8 @@ public sealed class ApprovalServiceTests
             MakeDoc(new PolicySpec { Tools = new ToolPolicy { RequireApprovalFor = ["tool_b"] } }),
         };
         var resolved = PolicyResolver.Resolve(docs);
-        Assert.Contains("tool_a", resolved.Tools?.RequireApprovalFor ?? []);
-        Assert.Contains("tool_b", resolved.Tools?.RequireApprovalFor ?? []);
+        Assert.Contains("tool_a", resolved.Tools?.RequireApprovalFor ?? [], StringComparer.Ordinal);
+        Assert.Contains("tool_b", resolved.Tools?.RequireApprovalFor ?? [], StringComparer.Ordinal);
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────

--- a/tests/JD.AI.Tests/Governance/Audit/AuditIntegrationTests.cs
+++ b/tests/JD.AI.Tests/Governance/Audit/AuditIntegrationTests.cs
@@ -50,7 +50,7 @@ public class AuditIntegrationTests
 
         await sink.Received(1).WriteAsync(
             Arg.Is<AuditEvent>(e =>
-                e.PolicyResult == PolicyDecision.Deny &&
+                e!.PolicyResult == PolicyDecision.Deny &&
                 e.Severity == AuditSeverity.Warning),
             Arg.Any<CancellationToken>());
     }
@@ -84,10 +84,10 @@ public class AuditIntegrationTests
 
         await sink.Received(2).WriteAsync(Arg.Any<AuditEvent>(), Arg.Any<CancellationToken>());
         await sink.Received(1).WriteAsync(
-            Arg.Is<AuditEvent>(e => e.Action == "session.create"),
+            Arg.Is<AuditEvent>(e => e!.Action == "session.create"),
             Arg.Any<CancellationToken>());
         await sink.Received(1).WriteAsync(
-            Arg.Is<AuditEvent>(e => e.Action == "session.close"),
+            Arg.Is<AuditEvent>(e => e!.Action == "session.close"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/JD.AI.Tests/Governance/Audit/AuditServiceTests.cs
+++ b/tests/JD.AI.Tests/Governance/Audit/AuditServiceTests.cs
@@ -113,7 +113,7 @@ public sealed class AuditServiceTests
         await service.EmitAsync(evt);
 
         await sink.Received(1).WriteAsync(Arg.Is<AuditEvent>(e =>
-            e.PolicyResult == PolicyDecision.Deny &&
+            e!.PolicyResult == PolicyDecision.Deny &&
             e.Severity == AuditSeverity.Warning), default);
     }
 

--- a/tests/JD.AI.Tests/Governance/CompliancePresetTests.cs
+++ b/tests/JD.AI.Tests/Governance/CompliancePresetTests.cs
@@ -32,10 +32,10 @@ public sealed class CompliancePresetTests
     public void AvailablePresets_ContainsAllFour()
     {
         var presets = CompliancePresetLoader.AvailablePresets;
-        Assert.Contains("jdai/compliance/soc2", presets);
-        Assert.Contains("jdai/compliance/gdpr", presets);
-        Assert.Contains("jdai/compliance/hipaa", presets);
-        Assert.Contains("jdai/compliance/pci-dss", presets);
+        Assert.Contains("jdai/compliance/soc2", presets, StringComparer.Ordinal);
+        Assert.Contains("jdai/compliance/gdpr", presets, StringComparer.Ordinal);
+        Assert.Contains("jdai/compliance/hipaa", presets, StringComparer.Ordinal);
+        Assert.Contains("jdai/compliance/pci-dss", presets, StringComparer.Ordinal);
     }
 
     // ── PolicyResolver preset expansion ───────────────────────────────────
@@ -201,8 +201,8 @@ public sealed class CompliancePresetTests
 
         var resolved = PolicyResolver.Resolve([doc1, doc2]);
         var names = resolved.Data?.Classifications.Select(c => c.Name).ToList() ?? [];
-        Assert.Contains("SSN", names);
-        Assert.Contains("PAN", names);
+        Assert.Contains("SSN", names, StringComparer.Ordinal);
+        Assert.Contains("PAN", names, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/InstructionsLoaderTests.cs
+++ b/tests/JD.AI.Tests/InstructionsLoaderTests.cs
@@ -147,15 +147,15 @@ public sealed class InstructionsLoaderTests : IDisposable
 
         var chain = InstructionsLoader.GetDirectoryChain(nested);
 
-        Assert.Contains(_tempDir, chain);
-        Assert.DoesNotContain(Directory.GetParent(_tempDir)?.FullName ?? "", chain);
+        Assert.Contains(_tempDir, chain, StringComparer.Ordinal);
+        Assert.DoesNotContain(Directory.GetParent(_tempDir)?.FullName ?? "", chain, StringComparer.Ordinal);
     }
 
     [Fact]
     public void GetDirectoryChain_IncludesStartDir()
     {
         var chain = InstructionsLoader.GetDirectoryChain(_tempDir);
-        Assert.Contains(_tempDir, chain);
+        Assert.Contains(_tempDir, chain, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Mcp/CuratedMcpCatalogTests.cs
+++ b/tests/JD.AI.Tests/Mcp/CuratedMcpCatalogTests.cs
@@ -145,7 +145,7 @@ public sealed class CuratedMcpCatalogTests
         var entry = CuratedMcpCatalog.All.First(e => string.Equals(e.Id, "azure-devops", StringComparison.Ordinal));
 
         Assert.NotNull(entry.DefaultArgs);
-        Assert.Contains("{organization}", entry.DefaultArgs);
+        Assert.Contains("{organization}", entry.DefaultArgs, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public sealed class CuratedMcpCatalogTests
 
         Assert.Equal(CuratedMcpTransport.Stdio, entry.Transport);
         Assert.Equal("uvx", entry.Command);
-        Assert.Contains("windows-mcp", entry.DefaultArgs!);
+        Assert.Contains("windows-mcp", entry.DefaultArgs!, StringComparer.Ordinal);
     }
 
     // ── CuratedMcpEntry record equality ──────────────────────────────────────

--- a/tests/JD.AI.Tests/MemoryToolsTests.cs
+++ b/tests/JD.AI.Tests/MemoryToolsTests.cs
@@ -31,7 +31,7 @@ public sealed class MemoryToolsTests
 
         await _memory.Received(1).StoreAsync(
             "text",
-            Arg.Is<IDictionary<string, string>>(d => d.ContainsKey("category") && d["category"] == "decision"),
+            Arg.Is<IDictionary<string, string>>(d => d!.ContainsKey("category") && d["category"] == "decision"),
             Arg.Any<string?>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/JD.AI.Tests/MultiTenancy/TenantScopedCredentialStoreTests.cs
+++ b/tests/JD.AI.Tests/MultiTenancy/TenantScopedCredentialStoreTests.cs
@@ -55,8 +55,8 @@ public sealed class TenantScopedCredentialStoreTests
         var keys = await sut.ListKeysAsync(string.Empty);
 
         Assert.Equal(2, keys.Count);
-        Assert.Contains("openai-key", keys);
-        Assert.Contains("github-token", keys);
+        Assert.Contains("openai-key", keys, StringComparer.Ordinal);
+        Assert.Contains("github-token", keys, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Orchestration/CoordinationStrategyTests.cs
+++ b/tests/JD.AI.Tests/Orchestration/CoordinationStrategyTests.cs
@@ -45,7 +45,9 @@ public sealed class VotingStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -60,10 +62,10 @@ public sealed class VotingStrategyTests
         Assert.Equal("voting", result.Strategy);
         // 3 agents + 1 aggregator = 4 results
         Assert.Equal(4, result.AgentResults.Count);
-        Assert.Contains("reviewer-1", result.AgentResults.Keys);
-        Assert.Contains("reviewer-2", result.AgentResults.Keys);
-        Assert.Contains("reviewer-3", result.AgentResults.Keys);
-        Assert.Contains("vote-aggregator", result.AgentResults.Keys);
+        Assert.Contains("reviewer-1", result.AgentResults.Keys, StringComparer.Ordinal);
+        Assert.Contains("reviewer-2", result.AgentResults.Keys, StringComparer.Ordinal);
+        Assert.Contains("reviewer-3", result.AgentResults.Keys, StringComparer.Ordinal);
+        Assert.Contains("vote-aggregator", result.AgentResults.Keys, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -82,7 +84,9 @@ public sealed class VotingStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -113,7 +117,9 @@ public sealed class VotingStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -181,7 +187,9 @@ public sealed class RelayStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 callOrder.Add(name);
                 return new AgentResult
                 {
@@ -221,7 +229,9 @@ public sealed class RelayStrategyTests
             .Returns(callInfo =>
             {
                 callCount++;
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 var output = callCount == 2 ? "[NO_CHANGES]" : $"Improved by {name}";
                 return new AgentResult
                 {
@@ -236,7 +246,7 @@ public sealed class RelayStrategyTests
         // Should have stopped after agent 2 returned [NO_CHANGES]
         Assert.Equal(2, callCount);
         Assert.Equal(2, result.AgentResults.Count);
-        Assert.DoesNotContain("third", result.AgentResults.Keys);
+        Assert.DoesNotContain("third", result.AgentResults.Keys, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -302,7 +312,9 @@ public sealed class MapReduceStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -316,9 +328,9 @@ public sealed class MapReduceStrategyTests
         Assert.True(result.Success);
         Assert.Equal("map-reduce", result.Strategy);
         Assert.Equal(3, result.AgentResults.Count);
-        Assert.Contains("mapper-1", result.AgentResults.Keys);
-        Assert.Contains("mapper-2", result.AgentResults.Keys);
-        Assert.Contains("reducer", result.AgentResults.Keys);
+        Assert.Contains("mapper-1", result.AgentResults.Keys, StringComparer.Ordinal);
+        Assert.Contains("mapper-2", result.AgentResults.Keys, StringComparer.Ordinal);
+        Assert.Contains("reducer", result.AgentResults.Keys, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -376,7 +388,9 @@ public sealed class MapReduceStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -434,7 +448,9 @@ public sealed class BlackboardStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -541,7 +557,9 @@ public sealed class PipelineStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,
@@ -575,7 +593,9 @@ public sealed class PipelineStrategyTests
                 Arg.Any<TeamContext>(), Arg.Any<Action<SubagentProgress>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var name = callInfo.Arg<SubagentConfig>().Name;
+                var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
+                var name = config.Name;
                 return new AgentResult
                 {
                     AgentName = name,

--- a/tests/JD.AI.Tests/Orchestration/MultiTurnExecutorTests.cs
+++ b/tests/JD.AI.Tests/Orchestration/MultiTurnExecutorTests.cs
@@ -321,6 +321,7 @@ public sealed class MultiTurnExecutorTests
             .Returns(callInfo =>
             {
                 var history = callInfo.Arg<ChatHistory>();
+                history.Should().NotBeNull();
                 historyCaptures.Add(new ChatHistory(history)); // Capture the state
                 var ct = callInfo.Arg<CancellationToken>();
 

--- a/tests/JD.AI.Tests/Orchestration/StrategyIntegrationTests.cs
+++ b/tests/JD.AI.Tests/Orchestration/StrategyIntegrationTests.cs
@@ -52,6 +52,7 @@ public class StrategyIntegrationTests
             .Returns(callInfo =>
             {
                 var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
                 return Task.FromResult(MakeResult(config.Name, $"output-of-{config.Name}"));
             });
 
@@ -99,6 +100,7 @@ public class StrategyIntegrationTests
             .Returns(callInfo =>
             {
                 var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
                 return Task.FromResult(MakeResult(config.Name, $"findings-from-{config.Name}"));
             });
 
@@ -141,6 +143,7 @@ public class StrategyIntegrationTests
             .Returns(callInfo =>
             {
                 var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
                 return Task.FromResult(MakeResult(config.Name, $"argument-by-{config.Name}"));
             });
 
@@ -179,6 +182,7 @@ public class StrategyIntegrationTests
             .Returns(callInfo =>
             {
                 var config = callInfo.Arg<SubagentConfig>();
+                Assert.NotNull(config);
                 var output = config.Name.StartsWith("supervisor", StringComparison.Ordinal)
                     ? "APPROVED: All work looks great, well done!"
                     : $"completed-{config.Name}";

--- a/tests/JD.AI.Tests/Plugins/PluginRegistryStoreTests.cs
+++ b/tests/JD.AI.Tests/Plugins/PluginRegistryStoreTests.cs
@@ -33,7 +33,7 @@ public sealed class PluginRegistryStoreTests
             Assert.Single(list);
             Assert.Equal("Sample Plugin", found!.Name);
             Assert.Equal("acme", found.Publisher);
-            Assert.Contains("service:*", found.Permissions);
+            Assert.Contains("service:*", found.Permissions, StringComparer.Ordinal);
 
             var removed = await store.RemoveAsync("sample.plugin");
             var empty = await store.ListAsync();

--- a/tests/JD.AI.Tests/PolicyRbacTests.cs
+++ b/tests/JD.AI.Tests/PolicyRbacTests.cs
@@ -192,7 +192,7 @@ public sealed class PolicyRbacTests
 
         Assert.Equal("alice", ctx.UserId);
         Assert.Equal("developer", ctx.RoleName);
-        Assert.Contains("engineering", ctx.Groups!);
+        Assert.Contains("engineering", ctx.Groups!, StringComparer.Ordinal);
     }
 
     // ── PolicyResolver merges RolePolicy ─────────────────────────────────────
@@ -234,7 +234,7 @@ public sealed class PolicyRbacTests
 
         Assert.NotNull(resolved.Roles);
         Assert.True(resolved.Roles!.Definitions.TryGetValue("developer", out var def));
-        Assert.Contains("ReadFile", def!.AllowTools);
-        Assert.Contains("WriteFile", def.AllowTools);
+        Assert.Contains("ReadFile", def!.AllowTools, StringComparer.Ordinal);
+        Assert.Contains("WriteFile", def.AllowTools, StringComparer.Ordinal);
     }
 }

--- a/tests/JD.AI.Tests/ProjectHasherTests.cs
+++ b/tests/JD.AI.Tests/ProjectHasherTests.cs
@@ -25,6 +25,6 @@ public class ProjectHasherTests
     {
         var h1 = ProjectHasher.Hash("/path/a");
         var h2 = ProjectHasher.Hash("/path/b");
-        Assert.NotEqual(h1, h2);
+        Assert.NotEqual(h1, h2, StringComparer.Ordinal);
     }
 }

--- a/tests/JD.AI.Tests/ProviderOrchestratorSelectionTests.cs
+++ b/tests/JD.AI.Tests/ProviderOrchestratorSelectionTests.cs
@@ -105,7 +105,7 @@ public sealed class ProviderOrchestratorSelectionTests
 
         Assert.Equal("ollama-chat", decision.SelectedModel?.Id);
         Assert.NotNull(decision.FallbackModelIds);
-        Assert.Contains("claude-sonnet", decision.FallbackModelIds!);
+        Assert.Contains("claude-sonnet", decision.FallbackModelIds!, StringComparer.Ordinal);
     }
 
 

--- a/tests/JD.AI.Tests/Providers/Credentials/AuditingCredentialStoreTests.cs
+++ b/tests/JD.AI.Tests/Providers/Credentials/AuditingCredentialStoreTests.cs
@@ -22,7 +22,7 @@ public class AuditingCredentialStoreTests
         await store.GetAsync("key");
 
         await audit.Received(1).WriteAsync(
-            Arg.Is<AuditEvent>(e => e.Action == "secret.read" && e.Resource == "key"),
+            Arg.Is<AuditEvent>(e => e!.Action == "secret.read" && e.Resource == "key"),
             Arg.Any<CancellationToken>());
     }
 
@@ -39,7 +39,7 @@ public class AuditingCredentialStoreTests
         await store.SetAsync("key", "secret-value");
 
         await audit.Received(1).WriteAsync(
-            Arg.Is<AuditEvent>(e => e.Action == "secret.write"),
+            Arg.Is<AuditEvent>(e => e!.Action == "secret.write"),
             Arg.Any<CancellationToken>());
     }
 
@@ -56,7 +56,7 @@ public class AuditingCredentialStoreTests
         await store.RemoveAsync("key");
 
         await audit.Received(1).WriteAsync(
-            Arg.Is<AuditEvent>(e => e.Action == "secret.delete"),
+            Arg.Is<AuditEvent>(e => e!.Action == "secret.delete"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/JD.AI.Tests/Providers/OpenAICodexDetectorAdditionalTests.cs
+++ b/tests/JD.AI.Tests/Providers/OpenAICodexDetectorAdditionalTests.cs
@@ -378,7 +378,7 @@ public sealed class OpenAICodexDetectorAdditionalTests : IDisposable
         var c = OpenAICodexDetector.ComputeCodexKeyringAccountKey(@"/home/bob/.codex");
 
         Assert.Equal(a, b);
-        Assert.NotEqual(a, c);
+        Assert.NotEqual(a, c, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Security/PromptSafetyCheckerTests.cs
+++ b/tests/JD.AI.Tests/Security/PromptSafetyCheckerTests.cs
@@ -64,6 +64,6 @@ public sealed class PromptSafetyCheckerTests
 
         Assert.True(safe.IsSafe);
         Assert.False(unsafe_.IsSafe);
-        Assert.Contains("NoSwearing", unsafe_.Violations);
+        Assert.Contains("NoSwearing", unsafe_.Violations, StringComparer.Ordinal);
     }
 }

--- a/tests/JD.AI.Tests/Security/SecretPatternLibraryTests.cs
+++ b/tests/JD.AI.Tests/Security/SecretPatternLibraryTests.cs
@@ -15,7 +15,7 @@ public sealed class SecretPatternLibraryTests
         _ = patternName; // used as test display name
         var redactor = new Core.Governance.DataRedactor(SecretPatternLibrary.All);
         var redacted = redactor.Redact($"My key is {secret} and more text");
-        Assert.NotEqual($"My key is {secret} and more text", redacted);
+        Assert.NotEqual($"My key is {secret} and more text", redacted, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public sealed class SecretPatternLibraryTests
 
     [Fact]
     public void HighConfidence_IsSubsetOfAll() =>
-        Assert.All(SecretPatternLibrary.HighConfidence, p => Assert.Contains(p, SecretPatternLibrary.All));
+        Assert.All(SecretPatternLibrary.HighConfidence, p => Assert.Contains(p, SecretPatternLibrary.All, StringComparer.Ordinal));
 
     [Fact]
     public void PlainText_IsNotRedacted()

--- a/tests/JD.AI.Tests/SlashCommandRouterTests.cs
+++ b/tests/JD.AI.Tests/SlashCommandRouterTests.cs
@@ -315,8 +315,8 @@ public sealed class SlashCommandRouterTests : IClassFixture<TempDirectoryFixture
         Assert.NotNull(result);
         var events = await sink.QueryAsync(new AuditQuery { Limit = 20 });
         var actions = events.Events.Select(e => e.Action).ToList();
-        Assert.Contains("model.switch.requested", actions);
-        Assert.Contains("model.switch.applied", actions);
+        Assert.Contains("model.switch.requested", actions, StringComparer.Ordinal);
+        Assert.Contains("model.switch.applied", actions, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -594,7 +594,7 @@ public sealed class SlashCommandRouterTests : IClassFixture<TempDirectoryFixture
 
             Assert.NotNull(result);
             Assert.Contains("Allowed", result);
-            Assert.Contains("run_command", profile.GlobalAllowed);
+            Assert.Contains("run_command", profile.GlobalAllowed, StringComparer.Ordinal);
             Assert.True(_session.ToolPermissionProfile.IsExplicitlyAllowed("run_command"));
         }
         finally
@@ -622,7 +622,7 @@ public sealed class SlashCommandRouterTests : IClassFixture<TempDirectoryFixture
 
             Assert.NotNull(result);
             Assert.Contains("Denied", result);
-            Assert.Contains("git_push", profile.ProjectDenied);
+            Assert.Contains("git_push", profile.ProjectDenied, StringComparer.Ordinal);
             Assert.True(_session.ToolPermissionProfile.IsExplicitlyDenied("git_push"));
         }
         finally

--- a/tests/JD.AI.Tests/Startup/SessionConfiguratorTests.cs
+++ b/tests/JD.AI.Tests/Startup/SessionConfiguratorTests.cs
@@ -319,7 +319,7 @@ public sealed class SessionConfiguratorTests
 
             Assert.Equal(sourceSession.SessionInfo.Id, setup.Session.SessionInfo!.Id);
             Assert.NotNull(forkedSession);
-            Assert.NotEqual(sourceSession.SessionInfo.Id, forkedSession!.Id);
+            Assert.NotEqual(sourceSession.SessionInfo.Id, forkedSession!.Id, StringComparer.Ordinal);
             Assert.Equal(sourceSession.SessionInfo.MessageCount, forkedSession.MessageCount);
             Assert.Equal(sourceSession.SessionInfo.Turns.Count, forkedSession.Turns.Count);
             Assert.Equal("fork me", forkedSession.Turns[^1].Content);

--- a/tests/JD.AI.Tests/Startup/SetupCliHandlerTests.cs
+++ b/tests/JD.AI.Tests/Startup/SetupCliHandlerTests.cs
@@ -87,10 +87,10 @@ public sealed class SetupCliHandlerTests : IDisposable
 
         Assert.Equal(0, code);
         Assert.NotNull(receivedArgs);
-        Assert.Contains("--provider", receivedArgs!);
-        Assert.Contains("OpenAI Codex", receivedArgs!);
-        Assert.Contains("--model", receivedArgs!);
-        Assert.Contains("gpt-5.3-codex", receivedArgs!);
-        Assert.Contains("--skip-mcp", receivedArgs!);
+        Assert.Contains("--provider", receivedArgs!, StringComparer.Ordinal);
+        Assert.Contains("OpenAI Codex", receivedArgs!, StringComparer.Ordinal);
+        Assert.Contains("--model", receivedArgs!, StringComparer.Ordinal);
+        Assert.Contains("gpt-5.3-codex", receivedArgs!, StringComparer.Ordinal);
+        Assert.Contains("--skip-mcp", receivedArgs!, StringComparer.Ordinal);
     }
 }

--- a/tests/JD.AI.Tests/Tools/LoadoutYamlTests.cs
+++ b/tests/JD.AI.Tests/Tools/LoadoutYamlTests.cs
@@ -127,8 +127,8 @@ public sealed class LoadoutYamlTests : IDisposable
         var yaml = ToolLoadoutYamlSerializer.Serialize(loadout);
         var result = ToolLoadoutYamlSerializer.Deserialize(yaml);
 
-        Assert.Contains("docker*", result.DiscoverablePatterns);
-        Assert.Contains("kube*", result.DiscoverablePatterns);
+        Assert.Contains("docker*", result.DiscoverablePatterns, StringComparer.Ordinal);
+        Assert.Contains("kube*", result.DiscoverablePatterns, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -222,8 +222,8 @@ public sealed class LoadoutYamlTests : IDisposable
         var registry = new FileToolLoadoutRegistry([_tempDir]);
         var names = registry.GetAll().Select(l => l.Name).ToList();
 
-        Assert.Contains("a", names);
-        Assert.Contains("b", names);
+        Assert.Contains("a", names, StringComparer.Ordinal);
+        Assert.Contains("b", names, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Tools/ToolLoadoutTests.cs
+++ b/tests/JD.AI.Tests/Tools/ToolLoadoutTests.cs
@@ -169,8 +169,8 @@ public sealed class ToolLoadoutTests
             .AddDiscoverable("kube*")
             .Build();
 
-        Assert.Contains("docker*", loadout.DiscoverablePatterns);
-        Assert.Contains("kube*", loadout.DiscoverablePatterns);
+        Assert.Contains("docker*", loadout.DiscoverablePatterns, StringComparer.Ordinal);
+        Assert.Contains("kube*", loadout.DiscoverablePatterns, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public sealed class ToolLoadoutTests
         Assert.Equal("minimal", loadout.ParentLoadoutName);
         Assert.Contains("think", loadout.DefaultPlugins);
         Assert.Contains(ToolCategory.Git, loadout.IncludedCategories);
-        Assert.Contains("docker*", loadout.DiscoverablePatterns);
+        Assert.Contains("docker*", loadout.DiscoverablePatterns, StringComparer.Ordinal);
         Assert.Contains("tailscale", loadout.DisabledPlugins);
     }
 

--- a/tests/JD.AI.Tests/Tracing/TraceContextTests.cs
+++ b/tests/JD.AI.Tests/Tracing/TraceContextTests.cs
@@ -38,7 +38,7 @@ public sealed class TraceContextTests
         var childSpan = TraceContext.StartChildSpan();
         var childCtx = TraceContext.CurrentContext;
 
-        Assert.NotEqual(originalSpan, childSpan);
+        Assert.NotEqual(originalSpan, childSpan, StringComparer.Ordinal);
         Assert.NotSame(ctx, childCtx);
         Assert.Equal(childSpan, childCtx.SpanId);
         Assert.Equal(originalSpan, childCtx.ParentSpanId);

--- a/tests/JD.AI.Tests/Workflows/Distributed/InMemoryDispatcherTests.cs
+++ b/tests/JD.AI.Tests/Workflows/Distributed/InMemoryDispatcherTests.cs
@@ -332,6 +332,7 @@ public sealed class InMemoryWorkerServiceTests
             .Returns(ci =>
             {
                 var item = ci.Arg<WorkflowWorkItem>();
+                item.Should().NotBeNull();
                 processed.Add(item.WorkflowName);
                 return Task.FromResult(WorkItemResult.Success);
             });

--- a/tests/JD.AI.Tests/Workflows/WorkflowConflictDetectorTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowConflictDetectorTests.cs
@@ -162,7 +162,8 @@ public sealed class WorkflowConflictDetectorTests
 
         Assert.NotEqual(
             WorkflowConflictDetector.ComputeHash(wf1),
-            WorkflowConflictDetector.ComputeHash(wf2));
+            WorkflowConflictDetector.ComputeHash(wf2),
+            StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Workflows/WorkflowCoverageExpansionTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowCoverageExpansionTests.cs
@@ -168,7 +168,7 @@ public sealed class WorkflowVersioningTests
     public void TryParse_WithPreReleaseAndBuild()
     {
         Assert.True(WorkflowSemVersion.TryParse("2.1.0-beta.2+sha.abc", out var v));
-        Assert.Contains("beta", v.PreRelease);
+        Assert.Contains("beta", v.PreRelease, StringComparer.Ordinal);
         Assert.Equal("sha.abc", v.BuildMetadata);
     }
 

--- a/tests/JD.AI.Tests/Workflows/WorkflowGeneratorTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowGeneratorTests.cs
@@ -41,7 +41,7 @@ public sealed class WorkflowGeneratorTests
     {
         var wf = _generator.Generate("Run the test suite");
 
-        Assert.Contains("testing", wf.Tags);
+        Assert.Contains("testing", wf.Tags, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public sealed class WorkflowGeneratorTests
     {
         var wf = _generator.Generate("Review the PR changes");
 
-        Assert.Contains("code-review", wf.Tags);
+        Assert.Contains("code-review", wf.Tags, StringComparer.Ordinal);
     }
 
     [Fact]
@@ -210,8 +210,8 @@ public sealed class WorkflowGeneratorTests
 
         var composite = _generator.Compose("ci-cd", [wf1, wf2]);
 
-        Assert.Contains("testing", composite.Tags);
-        Assert.Contains("deployment", composite.Tags);
+        Assert.Contains("testing", composite.Tags, StringComparer.Ordinal);
+        Assert.Contains("deployment", composite.Tags, StringComparer.Ordinal);
     }
 
     [Fact]

--- a/tests/JD.AI.Tests/Workflows/WorkflowOrchestratorTests.cs
+++ b/tests/JD.AI.Tests/Workflows/WorkflowOrchestratorTests.cs
@@ -315,7 +315,7 @@ public sealed class WorkflowOrchestratorTests
 
         await observer.Received(1).IngestRunAsync(
             definition,
-            Arg.Is<WorkflowBridgeResult>(r => r.Success),
+            Arg.Is<WorkflowBridgeResult>(r => r!.Success),
             Arg.Any<CancellationToken>());
     }
 
@@ -349,7 +349,7 @@ public sealed class WorkflowOrchestratorTests
 
         await observer.Received(1).IngestRunAsync(
             definition,
-            Arg.Is<WorkflowBridgeResult>(r => !r.Success),
+            Arg.Is<WorkflowBridgeResult>(r => !r!.Success),
             Arg.Any<CancellationToken>());
     }
 
@@ -383,7 +383,7 @@ public sealed class WorkflowOrchestratorTests
         result.Outcome.Should().Be(WorkflowOutcome.ExecutionFailed);
         await observer.Received(1).IngestRunAsync(
             definition,
-            Arg.Is<WorkflowBridgeResult>(r => !r.Success),
+            Arg.Is<WorkflowBridgeResult>(r => !r!.Success),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary

This PR bundles the same 16 NuGet package bumps as #568 (Meziantou.Analyzer, NSubstitute, bunit, AWSSDK.SecretsManager, StackExchange.Redis, JD.SemanticKernel.* connectors, etc.) plus the fixes required for the resulting build breakage, so it can merge standalone and unblock #568 to rebase cleanly.

### Root cause 1 — MA0002 (80 sites, 32 files)
`Meziantou.Analyzer` 3.0.12x → 3.0.138 enforces MA0002: string-comparison APIs (`Assert.Contains`, `Assert.NotEqual`, `OrderDescending`, etc. over `IEnumerable<string>`) must specify an explicit `IEqualityComparer<string>`/`IComparer<string>`. Fixed by adding `StringComparer.Ordinal` at each flagged call site — this is behavior-preserving since it matches .NET's default ordinal semantics for `Contains`/equality; the one exception is `CheckpointingSteps.cs`'s `cpDirs.OrderDescending()`, where the *previous* default was culture-sensitive ordering (via `string.CompareTo`), so switching to `StringComparer.Ordinal` is technically a (safe, deterministic) semantic change, called out here for visibility.

### Root cause 2 — CS8602 / CS8604 (42 + 1 sites, 15 files) — CONFIRMED NSubstitute 6.0.0
`NSubstitute` 5.3.0 → 6.0.0 added nullable reference annotations to `Arg.Is<T>`/`Arg.Any<T>` predicate parameters and `CallInfo.Arg<T>()`, so lambda parameters and captured mock arguments that were implicitly non-null before are now `T?`, surfacing real (if practically unreachable) CS8602/CS8604 warnings that CI's `TreatWarningsAsErrors` (set only when `CI=true`, matching GitHub Actions) promotes to build errors. Verified directly: e.g. `Arg.Is<Type>(t => t.IsGenericType ...)` and `callInfo.Arg<SubagentConfig>().Name` — both APIs from NSubstitute, both newly nullable.

Fix approach, in order of preference per site:
- **Multi-statement callback lambdas** (`.Returns(callInfo => { ... })`) — added `Assert.NotNull(config)` (xUnit) or `x.Should().NotBeNull()` (FluentAssertions, matching each file's existing style) immediately after capturing the mock argument, before use. ~15 sites.
- **Single-expression predicate lambdas** (`Arg.Is<T>(x => x.Foo == ...)`) — used the null-forgiving operator `x!` on first use, since restructuring a matcher predicate into a block body just to assert would be invasive and semantically odd (an assert throwing during argument-matching, rather than at the normal test-failure point). ~28 sites.

One CS8604 site (`MultiTurnExecutorTests.cs:324`, `new ChatHistory(history)` where `history = callInfo.Arg<ChatHistory>()`) is the same root cause manifesting as a different diagnostic code; fixed identically with `history.Should().NotBeNull()`. Confirmed via a baseline build of `main` (pre-bump) with `CI=true`: zero MA0002/CS8602/CS8604 anywhere — all of this is 100% attributable to the bump.

### Verification
- `dotnet build -c Release` (with `CI=true`, matching GitHub Actions' default env, which is what actually turns these into build-breaking errors): **0 warnings, 0 errors**.
- `dotnet test -c Release`: all suites pass except two **pre-existing, unrelated** flaky/environmental failures, confirmed present on the unmodified bump branch *before* this fix (i.e., not introduced by it):
  - `JD.AI.Tests.Workflows.MlNetIntentClassifierTests` (~10-11 of many parameterized cases, count varies run-to-run) — ML.NET intent-classifier confidence-threshold flakiness, unrelated to any file touched here.
  - `JD.AI.E2E.Tests.SessionScenarioTests.GetAuditEvents_ReturnsOk` — requires external service state.

### Files touched
47 test files only (no production/`src` code touched) — see diff for the full list. No refactoring, formatting, or unrelated cleanup; every change is either `, StringComparer.Ordinal` / `, StringComparer.Ordinal)` added to an existing call, or a null-forgiving `!` / `Assert.NotNull` / `.Should().NotBeNull()` guard added immediately before a now-nullable-annotated NSubstitute value is dereferenced.

Unblocks #568 — once this merges, #568 can rebase cleanly onto a green `main`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>